### PR TITLE
chore: Use correct package name in coverage

### DIFF
--- a/.github/workflows/get_coverage.yml
+++ b/.github/workflows/get_coverage.yml
@@ -35,7 +35,7 @@ jobs:
           pytest \
             --skip-endtoend \
             --cov-report=term-missing:skip-covered \
-            --cov=tesseract --cov=tesseract_runtime \
+            --cov=tesseract_core \
           | tee pytest-coverage.txt
 
       - name: Upload coverage reports to Codecov


### PR DESCRIPTION
<!--
Please use a PR title that conforms to *conventional commits*: "<commit_type>: Describe your change"; for example: "fix: prevent race condition". Some other commit types are: fix, feat, ci, doc, refactor...
For a full list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

#### Relevant issue or PR
n/a

#### Description of changes
Fixes codecov.

#### Testing done
none, let's hope this works

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Dion Häfner <dion.haefner@simulation.science>
