### PR TITLE
chore: Switch out private registry for public pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,8 @@ on:
       - published
 
 jobs:
-  release:
-    name: "Release"
+  build:
+    name: "Build distribution"
     runs-on: '${{ matrix.os }}'
     strategy:
       matrix:
@@ -20,6 +20,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,33 +35,37 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install Build & Upload Packages
-        run: pip install twine build
-
-      - name: Azure Login
-        uses: azure/login@v2
-        with:
-          # https://github.com/azure/login/tree/v2/?tab=readme-ov-file#creds
-          creds: |
-            {
-              "clientId": "${{ secrets.PL_INTERNAL_TOOLS_AZ_CLIENT_ID }}",
-              "clientSecret": "${{ secrets.PL_INTERNAL_TOOLS_AZ_CLIENT_SECRET }}",
-              "subscriptionId": "${{ vars.PL_INTERNAL_TOOLS_AZ_CLIENT_SUB_ID }}",
-              "tenantId": "${{ secrets.PL_INTERNAL_TOOLS_AZ_TENANT_ID }}"
-            }
+      - name: Install Build
+        run: pip install build
 
       - name: Build Package
         run: python -m build
 
-      - name: Get Publish Token
-        run: |
-          PUBLISH_TOKEN=$(az account get-access-token --query accessToken -o tsv)
-          echo "PUBLISH_TOKEN=$PUBLISH_TOKEN" >> $GITHUB_ENV
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
 
-      - name: Upload
-        run: |
-          twine upload dist/* \
-            -u token_user \
-            -p $PUBLISH_TOKEN \
-            --skip-existing \
-            --repository-url ${{vars.PL_INTERNAL_PYPI_PUSH_URL}}
+  publish:
+    name: "Publish distribution"
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tesseract-core
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Dion Häfner <dion.haefner@simulation.science>
