### PR TITLE
doc: Updated comments in jax recipe and docs on Differentiable flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.9.7
+  rev: v0.9.9
   hooks:
   # Run the linter.
   - id: ruff

--- a/docs/content/creating-tesseracts/create.md
+++ b/docs/content/creating-tesseracts/create.md
@@ -239,9 +239,11 @@ Here, it will be possible in principle to differentiate `a` in the Tesseract's o
 parameter `x` and with respect to each of the components of the matrix `r` -- but not with respect to `s`.
 
 ```{warning}
-Differentiable can only be used on {py:class}`tesseract_core.runtime.Array` types, which includes aliases for
+`Differentiable` can only be used on {py:class}`tesseract_core.runtime.Array` types, which includes aliases for
 rank 0 tensors like {py:class}`Float64 <tesseract_core.runtime.Float64>`. Do not use it on
 Python base types -- things like `Differentiable[float]` will trigger errors.
+
+Additionally, `Differentiable` is currently ONLY used to determine valid inputs/outputs for differentiation. That is, passing e.g. `jac_inputs=["non_differentiable_arg"]` to the `jacobian` endpoint will raise a validation error even before the endpoint is invoked.
 ```
 
 Aside from marking the parameters with respect to which your Tesseract is differentiable, one also

--- a/docs/content/creating-tesseracts/create.md
+++ b/docs/content/creating-tesseracts/create.md
@@ -212,12 +212,10 @@ class InputSchema(BaseModel):
 
 A key feature of Tesseracts is their ability to expose endpoints for calculating various kinds of derivatives when the operation they implement is differentiable, which in turn makes it possible to combine multiple Tesseracts into automatically differentiable workflows! This is advantageous in multiple contexts: shape optimization, model calibration, and so on.
 
-In order to make your Tesseract differentiable with respect to some parameter, you need
-to mark that parameter with the {py:class}`tesseract_core.runtime.Differentiable` type annotation.
-The outputs that can be differentiated should be marked as `Differentiable` as well.
-
-In other words, all outputs marked as `Differentiable` will be considered differentiable with respect to
+Keeping with one of Tesseract's key foci being *validation*, the type annotation {py:class}`tesseract_core.runtime.Differentiable` is introduced to mark outputs that can be differentiated, and inputs that can be differentiated with respect to.
+All outputs marked as `Differentiable` will be considered differentiable with respect to
 all inputs marked as `Differentiable`.
+Attempting to differentiate (with respect to) an output/input (e.g. by passing `jac_inputs=["non_differentiable_arg"]` to the `jacobian` endpoint) will raise a validation error even before the endpoint is invoked.
 
 For example:
 
@@ -242,8 +240,6 @@ parameter `x` and with respect to each of the components of the matrix `r` -- bu
 `Differentiable` can only be used on {py:class}`tesseract_core.runtime.Array` types, which includes aliases for
 rank 0 tensors like {py:class}`Float64 <tesseract_core.runtime.Float64>`. Do not use it on
 Python base types -- things like `Differentiable[float]` will trigger errors.
-
-Additionally, `Differentiable` is currently ONLY used to determine valid inputs/outputs for differentiation. That is, passing e.g. `jac_inputs=["non_differentiable_arg"]` to the `jacobian` endpoint will raise a validation error even before the endpoint is invoked.
 ```
 
 Aside from marking the parameters with respect to which your Tesseract is differentiable, one also

--- a/tesseract_core/sdk/templates/jax/tesseract_api.py
+++ b/tesseract_core/sdk/templates/jax/tesseract_api.py
@@ -21,11 +21,8 @@ from tesseract_core.runtime.tree_transforms import filter_func, flatten_with_pat
 # Note: This template uses equinox filter_jit to automatically treat non-array
 # inputs/outputs as static. As Tesseract scalar objects (e.g. Float32) are
 # essentially just wrappers around numpy 0D arrays, they will be considered to
-# be dynamic and will be traced by JAX. This is regardless of whether they are
-# tagged as Differentiable or not (the only purpose of the Differentiable tag
-# is to determine valid values for AD endpoint arguments not named `inputs`
-# and declaring a Float32 without the Differentiable flag provided no performance
-# gain). If you want to treat numerical value(s) as scalar you will need to use
+# be dynamic and will be traced by JAX. 
+# If you want to treat numerical values as scalar you will need to use
 # primitive Python types (e.g. float, int) instead of Float32, placing them in
 # hashable containers (e.g. tuple) if necessary.
 

--- a/tesseract_core/sdk/templates/jax/tesseract_api.py
+++ b/tesseract_core/sdk/templates/jax/tesseract_api.py
@@ -18,6 +18,18 @@ from tesseract_core.runtime.tree_transforms import filter_func, flatten_with_pat
 #
 
 
+# Note: This template uses equinox filter_jit to automatically treat non-array
+# inputs/outputs as static. As Tesseract scalar objects (e.g. Float32) are
+# essentially just wrappers around numpy 0D arrays, they will be considered to
+# be dynamic and will be traced by JAX. This is regardless of whether they are
+# tagged as Differentiable or not (the only purpose of the Differentiable tag
+# is to determine valid values for AD endpoint arguments not named `inputs`
+# and declaring a Float32 without the Differentiable flag provided no performance
+# gain). If you want to treat numerical value(s) as scalar you will need to use
+# primitive Python types (e.g. float, int) instead of Float32, placing them in
+# hashable containers (e.g. tuple) if necessary.
+
+
 class InputSchema(BaseModel):
     example: Differentiable[Float32]
 

--- a/tesseract_core/sdk/templates/jax/tesseract_api.py
+++ b/tesseract_core/sdk/templates/jax/tesseract_api.py
@@ -21,7 +21,7 @@ from tesseract_core.runtime.tree_transforms import filter_func, flatten_with_pat
 # Note: This template uses equinox filter_jit to automatically treat non-array
 # inputs/outputs as static. As Tesseract scalar objects (e.g. Float32) are
 # essentially just wrappers around numpy 0D arrays, they will be considered to
-# be dynamic and will be traced by JAX. 
+# be dynamic and will be traced by JAX.
 # If you want to treat numerical values as scalar you will need to use
 # built-in Python types (e.g. float, int) instead of Float32.
 

--- a/tesseract_core/sdk/templates/jax/tesseract_api.py
+++ b/tesseract_core/sdk/templates/jax/tesseract_api.py
@@ -23,8 +23,7 @@ from tesseract_core.runtime.tree_transforms import filter_func, flatten_with_pat
 # essentially just wrappers around numpy 0D arrays, they will be considered to
 # be dynamic and will be traced by JAX. 
 # If you want to treat numerical values as scalar you will need to use
-# primitive Python types (e.g. float, int) instead of Float32, placing them in
-# hashable containers (e.g. tuple) if necessary.
+# built-in Python types (e.g. float, int) instead of Float32.
 
 
 class InputSchema(BaseModel):


### PR DESCRIPTION
#### Description of changes
Explained how to specify static numerical values in Jax recipe. Added clarifications to docs warning on Differentiable.

#### Testing done
N/A

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: [Jonathan Brodrick] <jonathan.brodrick@simulation.science>
