### PR TITLE
feat: Raise proper error (`ValidationError`) for invalid inputs

### DIFF
--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -317,7 +317,10 @@ class HTTPClient:
         response = requests.request(method=method, url=url, json=encoded_payload)
         data = response.json()
 
-        if response.status_code == requests.codes.unprocessable_entity and "detail" in data:
+        if (
+            response.status_code == requests.codes.unprocessable_entity
+            and "detail" in data
+        ):
             errors = [
                 InitErrorDetails(
                     type=e["type"],

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -317,7 +317,7 @@ class HTTPClient:
         response = requests.request(method=method, url=url, json=encoded_payload)
         data = response.json()
 
-        if response.status_code == 422 and "detail" in data:
+        if response.status_code == requests.codes.unprocessable_entity and "detail" in data:
             errors = [
                 InitErrorDetails(
                     type=e["type"],

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -11,6 +11,8 @@ from urllib.parse import urlparse, urlunparse
 
 import numpy as np
 import requests
+from pydantic import ValidationError
+from pydantic_core import ErrorDetails
 
 from . import engine
 
@@ -313,7 +315,20 @@ class HTTPClient:
             encoded_payload = None
 
         response = requests.request(method=method, url=url, json=encoded_payload)
-        response.raise_for_status()
+
+        if response.status_code == 422 and "detail" in response.json():
+            errors = [
+                ErrorDetails(
+                    type=e["type"],
+                    loc=tuple(e["loc"]),
+                    msg=e["msg"],
+                    input=e.get("input"),
+                )
+                for e in response.json()["detail"]
+            ]
+            raise ValidationError.from_exception_data(f"endpoint {endpoint}", errors)
+        else:
+            response.raise_for_status()
 
         data = response.json()
 


### PR DESCRIPTION
#### Relevant issue or PR

Close #19 

#### Description of changes
If HTTPClient gets a 422 response (validation error), its context is parsed and reraised as a pydantic ValidationError

#### Testing done
Added a unit test + tested locally on vectoradd with
```python
from tesseract_core import Tesseract
import numpy as np

a = np.array([1.0, 2.0, 3.0])
b = np.array([1.0, 2.0, 3.0])

with Tesseract.from_image("vectoradd") as t:
    t.apply({"whoops": "whatever"})
```

#### License

- [ x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [ x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Alessandro Angioi <alessandro.angioi@simulation.science>
