### PR TITLE
feat: Check AD derivatives via finite differences

### DIFF
--- a/deleteme/finite_differences.py
+++ b/deleteme/finite_differences.py
@@ -1,0 +1,124 @@
+# %% [markdown]
+# # Check gradients against finite-differences
+#
+# This is an exploratory notebook where I'll experiment how to check Tesseract Jacobian, JVPs and VJPs against finite difference
+# calculations.
+#
+# I'll do this in python, but the idea is to have a command in the runtime which does this check,
+# which will be called directly from the sdk cli in a similar way to what we do for serve.
+# The signature of this command will mostly be the same as vjp, jvp, and jacobian, with maybe some extra args
+# to specify epsilon and the direction of the finite differences.
+#
+# Let's start by just performing the calculation of a Jacobian, using
+# vectoradd_jax because it has a nontrivial structure of inputs and
+# outputs:
+# %%
+import numpy as np
+
+from tesseract_core import Tesseract
+
+a = np.array([1.0, 2.0, 3.0])
+b = np.array([1.0, 2.0, 3.0])
+
+x0 = {"a": {"v": a, "s": 1}, "b": {"v": b, "s": 2}}
+
+with Tesseract.from_image("vectoradd_jax") as t:
+    result = t.apply(x0)
+    jacobian = t.jacobian(
+        x0,
+        jac_inputs=["a.v", "b.s"],
+        jac_outputs=["vector_min.result", "vector_add.normed_result"],
+    )
+    jvp = t.jacobian_vector_product(
+        x0,
+        jvp_inputs=["a.v", "b.s"],
+        jvp_outputs=["vector_min.result", "vector_add.normed_result"],
+        tangent_vector={"a.v": 0.5 * a, "b.s": 1.0},
+    )
+    vjp = t.vector_jacobian_product(
+        x0,
+        vjp_inputs=["a.v", "b.s"],
+        vjp_outputs=["vector_min.result", "vector_add.normed_result"],
+        cotangent_vector={
+            "vector_min.result": 0.1 * np.ones(3),
+            "vector_add.normed_result": np.array([1.0, 0.0, 0.0]),
+        },
+    )
+result
+# %%
+jacobian
+# %%
+jvp
+# %%
+vjp
+# %% [markdown]
+# How would we implement a finite difference check for the jacobian? We could
+# keep the same signature as jacobian, and component-wise add a "small" perturbation.
+# A heuristic we could use is that for each component $x_i$, we add/subtract a perturbation of size $K x_i$,
+# with $K \sim 10^{-3}$ or so. This has some shortcomings (what if some components are zero, and so on)
+# which we could address later, but it seems to me like a good choice for a variety of reasons,
+# including the fact that it automatically takes into consideration possibly different ranges
+# for different components.
+#
+# Notice also that this does not calculate the full jacobian, but gives a result which can be
+# compared with $J x$ -- otherwise we would need to run this calculation component-wise.
+# %%
+from copy import deepcopy
+
+import tesseract_core.runtime.tree_transforms as tt
+
+
+def fd_check_jacobian(inputs, jac_inputs, jac_outputs, K=1e-3):
+    x0 = inputs
+    x0_plus_eps = deepcopy(inputs)
+    x0_minus_eps = deepcopy(inputs)
+    epsilons = []
+
+    # Here we build the perturbed inputs
+    for in_ in jac_inputs:
+        vec = tt.get_at_path(x0, in_)
+
+        eps = K * vec
+        epsilons.append(eps)
+
+        x0_plus_eps = tt.set_at_path(x0_plus_eps, {in_: vec + eps})
+        x0_minus_eps = tt.set_at_path(x0_minus_eps, {in_: vec - eps})
+
+    # TODO: of course in the runtime this would be substituted by the
+    #       actual apply and jacobian
+    with Tesseract.from_image("vectoradd_jax") as t:
+        f_x0_plus_eps = t.apply(x0_plus_eps)
+        f_x0_minus_eps = t.apply(x0_minus_eps)
+        jacobian = t.jacobian(
+            x0,
+            jac_inputs=["a.v", "b.s"],
+            jac_outputs=["vector_min.result", "vector_add.normed_result"],
+        )
+
+    # Now we compute the finite-difference derivatives
+    fd_result = deepcopy(jacobian)
+    for out in jac_outputs:
+        for in_, eps in zip(jac_inputs, epsilons):
+            contrib_plus = tt.get_at_path(f_x0_plus_eps, out)
+            contrib_minus = tt.get_at_path(f_x0_minus_eps, out)
+            derivative = (contrib_plus - contrib_minus) / (2 * eps)
+            fd_result[out][in_] = derivative
+
+    # We then compare with J x and fd_result
+    # TODO: return comparison rather than fd_result
+    return fd_result
+
+
+fd_check_jacobian(
+    x0,
+    jac_inputs=["a.v", "b.s"],
+    jac_outputs=["vector_min.result", "vector_add.normed_result"],
+)
+# %%
+with Tesseract.from_image("vectoradd_jax") as t:
+    result = t.apply(x0)
+    jacobian = t.jacobian(
+        x0,
+        jac_inputs=["a.v", "b.s"],
+        jac_outputs=["vector_min.result", "vector_add.normed_result"],
+    )

--- a/ruff.toml
+++ b/ruff.toml
@@ -10,6 +10,7 @@ extend-exclude = [
     ".venv",
     "_version.py",
     "tesseract_core/**/vendor/**/*.py",
+    "deleteme"
 ]
 
 # Also lint/format Jupyter Notebooks.


### PR DESCRIPTION
#### Relevant issue or PR
Close #18 

#### Description of changes
<!-- Add a high-level description of changes, focusing on the *what* and *why*. -->

#### Testing done
<!-- Describe how the changes were tested; e.g., "CI passes", "Tested manually in stagingrepo#123", screenshots of a terminal session that verify the changes, or any other evidence of testing the changes. -->

#### License

- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [ ] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: [YOUR NAME] <[YOUR EMAIL]>
