### PR TITLE
fix: Issue #74

### DIFF
--- a/examples/vectoradd_jax/tesseract_api.py
+++ b/examples/vectoradd_jax/tesseract_api.py
@@ -92,7 +92,7 @@ def abstract_eval(abstract_inputs):
     jaxified_inputs = jax.tree.map(
         lambda x: jax.ShapeDtypeStruct(**x),
         abstract_inputs.model_dump(),
-        is_leaf=lambda x: (x.keys() == {"shape", "dtype"}),
+        is_leaf=lambda x: type(x) is dict and (x.keys() == {"shape", "dtype"}),
     )
     jax_shapes = jax.eval_shape(apply_jit, jaxified_inputs)
     return jax.tree.map(

--- a/examples/vectoradd_jax/tesseract_api.py
+++ b/examples/vectoradd_jax/tesseract_api.py
@@ -89,14 +89,29 @@ def apply(inputs: InputSchema) -> OutputSchema:
 
 def abstract_eval(abstract_inputs):
     """Calculate output shape of apply from the shape of its inputs."""
+    is_shapedtye_dict = lambda x: type(x) is dict and (x.keys() == {"shape", "dtype"})
+    is_shapedtye_struct = lambda x: isinstance(x, jax.ShapeDtypeStruct)
+
     jaxified_inputs = jax.tree.map(
-        lambda x: jax.ShapeDtypeStruct(**x),
+        lambda x: jax.ShapeDtypeStruct(**x) if is_shapedtye_dict(x) else x,
         abstract_inputs.model_dump(),
-        is_leaf=lambda x: type(x) is dict and (x.keys() == {"shape", "dtype"}),
+        is_leaf=is_shapedtye_dict,
     )
-    jax_shapes = jax.eval_shape(apply_jit, jaxified_inputs)
+    dynamic_inputs, static_inputs = eqx.partition(
+        jaxified_inputs, filter_spec=is_shapedtye_struct
+    )
+
+    def wrapped_apply(dynamic_inputs):
+        inputs = eqx.combine(static_inputs, dynamic_inputs)
+        return apply_jit(inputs)
+
+    jax_shapes = jax.eval_shape(wrapped_apply, dynamic_inputs)
     return jax.tree.map(
-        lambda sd: {"shape": sd.shape, "dtype": str(sd.dtype)}, jax_shapes
+        lambda x: {"shape": x.shape, "dtype": str(x.dtype)}
+        if is_shapedtye_struct(x)
+        else x,
+        jax_shapes,
+        is_leaf=is_shapedtye_struct,
     )
 
 

--- a/tesseract_core/sdk/templates/jax/tesseract_api.py
+++ b/tesseract_core/sdk/templates/jax/tesseract_api.py
@@ -107,14 +107,29 @@ def vector_jacobian_product(
 
 def abstract_eval(abstract_inputs):
     """Calculate output shape of apply from the shape of its inputs."""
+    is_shapedtye_dict = lambda x: type(x) is dict and (x.keys() == {"shape", "dtype"})
+    is_shapedtye_struct = lambda x: isinstance(x, jax.ShapeDtypeStruct)
+
     jaxified_inputs = jax.tree.map(
-        lambda x: jax.ShapeDtypeStruct(**x),
+        lambda x: jax.ShapeDtypeStruct(**x) if is_shapedtye_dict(x) else x,
         abstract_inputs.model_dump(),
-        is_leaf=lambda x: type(x) is dict and (x.keys() == {"shape", "dtype"}),
+        is_leaf=is_shapedtye_dict,
     )
-    jax_shapes = jax.eval_shape(apply_jit, jaxified_inputs)
+    dynamic_inputs, static_inputs = eqx.partition(
+        jaxified_inputs, filter_spec=is_shapedtye_struct
+    )
+
+    def wrapped_apply(dynamic_inputs):
+        inputs = eqx.combine(static_inputs, dynamic_inputs)
+        return apply_jit(inputs)
+
+    jax_shapes = jax.eval_shape(wrapped_apply, dynamic_inputs)
     return jax.tree.map(
-        lambda sd: {"shape": sd.shape, "dtype": str(sd.dtype)}, jax_shapes
+        lambda x: (
+            {"shape": x.shape, "dtype": str(x.dtype)} if is_shapedtye_struct(x) else x
+        ),
+        jax_shapes,
+        is_leaf=is_shapedtye_struct,
     )
 
 

--- a/tesseract_core/sdk/templates/jax/tesseract_api.py
+++ b/tesseract_core/sdk/templates/jax/tesseract_api.py
@@ -110,7 +110,7 @@ def abstract_eval(abstract_inputs):
     jaxified_inputs = jax.tree.map(
         lambda x: jax.ShapeDtypeStruct(**x),
         abstract_inputs.model_dump(),
-        is_leaf=lambda x: (x.keys() == {"shape", "dtype"}),
+        is_leaf=lambda x: type(x) is dict and (x.keys() == {"shape", "dtype"}),
     )
     jax_shapes = jax.eval_shape(apply_jit, jaxified_inputs)
     return jax.tree.map(

--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -203,6 +203,21 @@ TEST_CASES = {
                 output_contains_array=np.array([7.0, 11.0, 15.0], dtype="float32"),
             ),
             SampleRequest(
+                endpoint="abstract_eval",
+                payload={
+                    "inputs": {
+                        "a": {
+                            "v": {"shape": [3], "dtype": "float32"},
+                            "s": {"shape": [], "dtype": "float32"},
+                        },
+                        "b": {
+                            "v": {"shape": [3], "dtype": "float32"},
+                            "s": {"shape": [], "dtype": "float32"},
+                        },
+                    }
+                },
+            ),
+            SampleRequest(
                 endpoint="apply",
                 payload={"inputs": {}},
                 expected_status_code=422,


### PR DESCRIPTION
#### Relevant issue or PR
Fix #74 

#### Description of changes
Check that x in is_leaf(x) is a dict before calling methods like .keys()

#### Testing done
Local checks, added e2e test

#### License

- [ x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [ x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Alessandro Angioi <alessandro.angioi@simulation.science>
