### PR TITLE
feat: Add `abstract_eval` method to `tesseract_core.Tesseract`

### DIFF
--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -147,6 +147,18 @@ class Tesseract:
         payload = {"inputs": inputs}
         return self._run_tesseract("apply", payload)
 
+    def abstract_eval(self, inputs: dict) -> dict:
+        """Run abstract eval endpoint.
+
+        Args:
+            inputs: a dictionary with the (abstract) inputs.
+
+        Returns:
+            dictionary with the results.
+        """
+        payload = {"inputs": inputs}
+        return self._run_tesseract("abstract_eval", payload)
+
     def jacobian(
         self, inputs: dict, jac_inputs: list[str], jac_outputs: list[str]
     ) -> dict:


### PR DESCRIPTION
#### Relevant issue or PR
There was no way to query `abstract_eval` with  `tesseract_core.Tesseract`; this fixes it

#### Description of changes
Added a method to `tesseract_core.Tesseract`.

#### Testing done
Tested locally against `vectoradd_jax` with the following script

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Alessandro Angioi <alessandro.angioi@simulation.science>
