### PR TITLE
chore: Bump changelog for v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - Jax template now uses equinox `filter_jit` to allow non-array inputs (#56)
 - Added pip as dependency (#58)
-- Issue #74 (#75)
+- Buggy `is_leaf` check in the `abstract_eval` of jax recipe and vectoradd_jax (#75)
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.8.0] - 2025-03-13
+## [0.7.3] - 2025-03-13
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8.0] - 2025-03-13
+
+### Features
+
+- Raise proper error (`ValidationError`) for invalid inputs (#67)
+- Add `abstract_eval` method to `tesseract_core.Tesseract` (#76)
+
+### Bug Fixes
+
+- Jax template now uses equinox `filter_jit` to allow non-array inputs (#56)
+- Added pip as dependency (#58)
+- Issue #74 (#75)
+
+### Documentation
+
+- Updated comments in jax recipe and docs on Differentiable flag (#65)
+
 ## [0.7.2] - 2025-02-27
 
 ### Bug Fixes


### PR DESCRIPTION
#### Relevant issue or PR
Bump changelog in preparation of a release

#### Description of changes
`git cliff --output CHANGELOG.md --bump` + small manual edit

#### Testing done
👁️ + 👁️  + 👓 

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Alessandro Angioi <alessandro.angioi@simulation.science>
