### PR TITLE
doc: dependencies and user privileges

### DIFF
--- a/docs/content/introduction/installation.md
+++ b/docs/content/introduction/installation.md
@@ -1,5 +1,15 @@
 # Installation
 
+## Dependencies
+
+Tesseract Core depends on Docker.
+If you are on macOS, installing Docker Desktop includes several plugins for extended functionality needed by Tesseract Core.
+If you are on Linux and / or prefer to work via CLIs, you will need to install these plugin packages in addition to `docker`.
+These are 
+
+1. [`docker-buildx`](https://github.com/docker/buildx)
+2. [`docker-compose`](https://github.com/docker/compose)
+
 ## Basic installation
 
 ```{note}
@@ -61,6 +71,28 @@ You can always confirm what executable the command `tesseract` corresponds with
 ```bash
 $ which tesseract
 ```
+
+### User privileges
+
+If you are on Linux and not a regular Docker user, or are used to running Docker via the command line using `sudo`, you may find that `tesseract build` results in the following exception
+
+```
+$ tesseract build examples/helloworld
+RuntimeError: Could not reach Docker daemon, check if it is running. See logs for details.
+```
+
+Your natural inclination may be to run this with elevated privileges, however if you do this it's possible that your system will ignore the `tesseract` command in your virtual environment, and instead execute [Tesseract OCR](https://github.com/tesseract-ocr/tesseract)
+
+```
+$ sudo tesseract build examples/helloworld
+Error opening data file /usr/share/tessdata/eng.traineddata
+Please make sure the TESSDATA_PREFIX environment variable is set to your "tessdata" directory.
+Failed loading language 'eng'
+...
+```
+
+You can resolve this by omitting the `sudo` command, and instead adding your user to the `docker` group.
+See [Linux post-installation steps for Docker Engine > Manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user).
 
 (installation-dev)=
 ## Development installation


### PR DESCRIPTION
<!--
Please use a PR title that conforms to *conventional commits*: "<commit_type>: Describe your change"; for example: "fix: prevent race condition". Some other commit types are: fix, feat, ci, doc, refactor...
For a full list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

#### Relevant issue or PR
<!-- If the changes resolve an issue or follow some other PR, link to them here. Only link something if it is directly relevant. -->

Closes #88.

#### Description of changes
<!-- Add a high-level description of changes, focusing on the *what* and *why*. -->

- Added description of dependencies for users who installed Docker's CLI, rather than via Docker Desktop (which is only available for Windows and macOS, with limited support for some Linux distros).
- Described steps to add user to the `docker` group, to avoid Tesseract OCR gotcha when using `sudo tesseract`

#### Testing done
<!-- Describe how the changes were tested; e.g., "CI passes", "Tested manually in stagingrepo#123", screenshots of a terminal session that verify the changes, or any other evidence of testing the changes. -->

In progress.

#### License

- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [X] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Jacan Chaplais jacan.chaplais@simulation.science
