### PR TITLE
fix: OpenAPI schema failure for differentiable arrays with unknown shape

### DIFF
--- a/tesseract_core/runtime/schema_generation.py
+++ b/tesseract_core/runtime/schema_generation.py
@@ -231,12 +231,12 @@ def _serialize_diffable_arrays(
     for pathtuple, value in obj.items():
         shape = value.__metadata__[0].expected_shape
         dtype = value.__metadata__[0].expected_dtype
+
         # Ensure shape is JSON serializable
-        shape = (
-            tuple(None if dim is None else dim for dim in shape)
-            if isinstance(shape, tuple)
-            else shape
-        )
+        if shape is Ellipsis:
+            json_shape = None
+        else:
+            json_shape = tuple(shape)
 
         # Replace sentinel values with indexing syntax
         str_parts = []
@@ -249,7 +249,7 @@ def _serialize_diffable_arrays(
                 str_parts.append(part)
 
         serialized[".".join(str_parts)] = {
-            "shape": shape,
+            "shape": json_shape,
             "dtype": dtype,
         }
 

--- a/tesseract_core/runtime/schema_generation.py
+++ b/tesseract_core/runtime/schema_generation.py
@@ -234,9 +234,9 @@ def _serialize_diffable_arrays(
 
         # Ensure shape is JSON serializable
         if shape is Ellipsis:
-            json_shape = None
+            shape = None
         else:
-            json_shape = tuple(shape)
+            shape = tuple(shape)
 
         # Replace sentinel values with indexing syntax
         str_parts = []
@@ -249,7 +249,7 @@ def _serialize_diffable_arrays(
                 str_parts.append(part)
 
         serialized[".".join(str_parts)] = {
-            "shape": json_shape,
+            "shape": shape,
             "dtype": dtype,
         }
 

--- a/tests/runtime_tests/test_schema_generation.py
+++ b/tests/runtime_tests/test_schema_generation.py
@@ -1,6 +1,7 @@
 # Copyright 2025 Pasteur Labs. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 from collections.abc import Iterable
 from copy import deepcopy
 from typing import Annotated, Optional
@@ -664,3 +665,26 @@ def test_fancy_pydantic_model(endpoint):
                     "jac_outputs": ["myarray"],
                 }
             )
+
+
+@pytest.mark.parametrize(
+    "endpoint", ["apply", "abstract_eval", "jacobian", "jvp", "vjp"]
+)
+def test_json_schema(endpoint):
+    if endpoint == "apply":
+        InputSchema, OutputSchema = create_apply_schema(NestedModel, NestedModel)
+    elif endpoint == "abstract_eval":
+        InputSchema, OutputSchema = create_abstract_eval_schema(
+            NestedModel, NestedModel
+        )
+    else:
+        InputSchema, OutputSchema = create_autodiff_schema(
+            NestedModel, NestedModel, endpoint
+        )
+
+    schema_inputs = InputSchema.model_json_schema()
+    schema_outputs = OutputSchema.model_json_schema()
+
+    # Test that the JSON schema is valid JSON
+    json.dumps(schema_inputs)
+    json.dumps(schema_outputs)


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
Before this PR, requesting the OpenAPI schema of a Tesseract that uses a differentiable array of unknown rank would trigger a serialization error:

```python
class InputSchema(BaseModel):
    myarray: Differentiable[Array[..., Float32]]
```

```bash
$ tesseract-runtime input-schema
...
pydantic_core._pydantic_core.PydanticSerializationError: Unable to serialize unknown type: <class 'ellipsis'>
```

The problem is that `...` was inserted as shape into the new `differentiable_arrays` property of the schema, which works as long as the schema isn't serialized to JSON (which we didn't test for).

#### Testing done
CI, old and new tests

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Dion Häfner <dion.haefner@simulation.science>
