### PR TITLE
fix: use fixed uid/gid 5000:5000 for all tesseracts

### DIFF
--- a/tesseract_core/sdk/templates/Dockerfile.base
+++ b/tesseract_core/sdk/templates/Dockerfile.base
@@ -54,7 +54,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 {% endif %}
 
 # Drop to a non-root user
-RUN useradd --create-home -s /bin/bash tesseractor
+RUN groupadd -g 5000 tesseractor && \
+    useradd -u 5000 -g 5000 --create-home -s /bin/bash tesseractor
 WORKDIR /tesseract
 RUN chown tesseractor:tesseractor /tesseract
 USER tesseractor


### PR DESCRIPTION
#### Relevant issue or PR
Fixes #101 

#### Description of changes
☝️ 

#### Testing done
CI

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Dion Häfner <dion.haefner@simulation.science>
