### PR TITLE
fix: Pydantic 2.11.0 compatibility (hotfix)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ jinja2==3.1.6
 typer==0.15.2
 rich==13.9.4
 pyyaml==6.0.1
-pydantic==2.10.6
+pydantic==2.11.0
 numpy==2.2.4
 requests==2.32.3
 pip

--- a/tesseract_core/runtime/meta/pyproject.toml
+++ b/tesseract_core/runtime/meta/pyproject.toml
@@ -3,16 +3,16 @@ name = "tesseract_runtime"
 version = "0.1.0"
 requires-python = ">=3.9"
 dependencies = [
-    "pydantic>=2.10",
-    "fastapi>=0.115",
-    "requests>=2.32",
-    "uvicorn>=0.34",
-    "click>=8.1",
-    "typer>=0.15",
-    "fsspec[http,s3]>=2024.12",
-    "msgpack>=1.1",
-    "pybase64>=1.4",
-    "numpy>=1.26",
+    "pydantic>=2.10,<=2.11.0",
+    "fastapi>=0.115,<=0.115.12",
+    "requests>=2.32,<=2.32.3",
+    "uvicorn>=0.34,<=0.34.0",
+    "click>=8.1,<=8.1.8",
+    "typer>=0.15,<=0.15.2",
+    "fsspec[http,s3]>=2024.12,<=2025.3.0",
+    "msgpack>=1.1,<=1.1.0",
+    "pybase64>=1.4,<=1.4.1",
+    "numpy>=1.26,<=2.2.4",
 ]
 
 [project.scripts]

--- a/tesseract_core/runtime/meta/requirements.txt
+++ b/tesseract_core/runtime/meta/requirements.txt
@@ -1,4 +1,4 @@
-pydantic==2.10.6
+pydantic==2.11.0
 fastapi==0.115.12
 requests==2.32.3
 uvicorn==0.34.0

--- a/tesseract_core/runtime/schema_generation.py
+++ b/tesseract_core/runtime/schema_generation.py
@@ -271,13 +271,13 @@ def create_apply_schema(
         InputSchema,
         lambda x, _: x,
         model_prefix="Apply_",
-        model_kwargs={"model_config": ConfigDict(extra="forbid")},
+        model_kwargs={"model_config": (ConfigDict, ConfigDict(extra="forbid"))},
     )
     OutputSchema = apply_function_to_model_tree(
         OutputSchema,
         lambda x, _: x,
         model_prefix="Apply_",
-        model_kwargs={"model_config": ConfigDict(extra="forbid")},
+        model_kwargs={"model_config": (ConfigDict, ConfigDict(extra="forbid"))},
     )
 
     class ApplyInputSchema(BaseModel):
@@ -325,14 +325,14 @@ def create_abstract_eval_schema(
         InputSchema,
         replace_array_with_shapedtype,
         model_prefix="AbstractEval_",
-        model_kwargs={"model_config": ConfigDict(extra="forbid")},
+        model_kwargs={"model_config": (ConfigDict, ConfigDict(extra="forbid"))},
     )
 
     GeneratedOutputSchema = apply_function_to_model_tree(
         OutputSchema,
         replace_array_with_shapedtype,
         model_prefix="AbstractEval_",
-        model_kwargs={"model_config": ConfigDict(extra="forbid")},
+        model_kwargs={"model_config": (ConfigDict, ConfigDict(extra="forbid"))},
     )
 
     class AbstractInputSchema(BaseModel):
@@ -463,7 +463,7 @@ def create_autodiff_schema(
         InputSchema,
         lambda x, _: x,
         model_prefix=f"{ad_flavor.title()}_",
-        model_kwargs={"model_config": ConfigDict(extra="forbid")},
+        model_kwargs={"model_config": (ConfigDict, ConfigDict(extra="forbid"))},
     )
 
     def result_validator(

--- a/tesseract_core/runtime/schema_types.py
+++ b/tesseract_core/runtime/schema_types.py
@@ -170,9 +170,13 @@ class PydanticArrayAnnotation(metaclass=ArrayAnnotationType):
         Does most of the heavy lifting for validation and serialization.
         """
         # Create a Pydantic model for the encoded array, for easier validation
-        array_schema = get_array_model(
-            cls.expected_shape, cls.expected_dtype, [flag.name for flag in cls.flags]
-        ).__get_pydantic_core_schema__(_source_type, _handler)
+        array_schema = _handler(
+            get_array_model(
+                cls.expected_shape,
+                cls.expected_dtype,
+                [flag.name for flag in cls.flags],
+            )
+        )
 
         python_to_array_ = partial(
             python_to_array,


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
- Make tests pass with new pydantic.
- Upper bound all runtime dependencies.

#### Testing done
CI

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Dion Häfner <dion.haefner@simulation.science>
