### PR TITLE
feat: [WIP] fix blockers for podman compatibility

### DIFF
--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -293,12 +293,12 @@ def build_image(
         remote_dependencies = []
         local_dependencies = []
 
+    local_requirements_path = build_dir / "local_requirements"
+    Path.mkdir(local_requirements_path)
     if local_dependencies:
-        local_requirements_path = build_dir / "local_requirements"
-        Path.mkdir(local_requirements_path)
         for dependency in local_dependencies:
             src = Path(src_dir) / dependency
-            dest = build_dir / "local_requirements" / src.name
+            dest = local_requirements_path / src.name
             if src.is_file():
                 copy(src, dest)
             else:

--- a/tesseract_core/sdk/templates/Dockerfile.base
+++ b/tesseract_core/sdk/templates/Dockerfile.base
@@ -57,8 +57,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN groupadd -g 1000 tesseractor && \
     useradd -u 1000 -g 1000 --create-home -s /bin/bash tesseractor
 WORKDIR /tesseract
-RUN chown tesseractor:tesseractor /tesseract
-USER tesseractor
 
 # Set environment variables
 ENV TESSERACT_NAME="{{ config.name }}" \
@@ -69,6 +67,9 @@ ENV TESSERACT_NAME="{{ config.name }}" \
 # Copy only necessary files
 COPY --from=build_stage /python-env /python-env
 COPY "{{ tesseract_source_directory }}/tesseract_api.py" ${TESSERACT_API_PATH}
+
+RUN chown -R tesseractor:tesseractor /tesseract
+USER tesseractor
 
 ENV PATH="/python-env/bin:$PATH"
 


### PR DESCRIPTION
<!--
Please use a PR title that conforms to *conventional commits*: "<commit_type>: Describe your change"; for example: "fix: prevent race condition". Some other commit types are: fix, feat, ci, doc, refactor...
For a full list of commit types visit https://www.conventionalcommits.org/en/v1.0.0-beta.2/
-->

#### Relevant issue or PR
On the path to resolving #8.

We can merge this if the changes are considered unoffensive, or we can wait until #33 lands to verify that the changes in here fix an error when building and running with podman.

#### Description of changes
- Create the `local_requirements` directory even in the case where there are none; in this case it will be empty. This is required because `podman` errors on the `COPY local_requirements* ./local_requirements` line if the directory doesn't exist.
- Run `chown -R` after copying `tesseract_api.py` into `/tesseract`. This fixes a permissions error on that file when built by `podman`.
- ... possibly more to come ...

#### Testing done
These changes were arrived at during the process of figuring out what's necessary to build and run a tesseract on the [NERSC perlmutter](https://docs.nersc.gov/systems/perlmutter/architecture/) HPC cluster.

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Jack Coughlin <jack.coughlin@simulation.science>
