### PR TITLE
fix: meshstats `abstract_eval`

### DIFF
--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -584,7 +584,7 @@ TEST_CASES = {
                         }
                     },
                 },
-                output_contains_pattern='"shape":[5,3],"dtype":"float32"',
+                output_contains_pattern='"shape":[3],"dtype":"float32"',
             ),
             SampleRequest(
                 endpoint="jacobian",

--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -543,6 +543,49 @@ TEST_CASES = {
                 ),
             ),
             SampleRequest(
+                endpoint="abstract_eval",
+                payload={
+                    "inputs": {
+                        "mesh": {
+                            "n_points": 5,
+                            "n_cells": 8,
+                            "points": {
+                                "shape": [5, 3],
+                                "dtype": "float32",
+                            },
+                            "num_points_per_cell": {
+                                "shape": [2],
+                                "dtype": "int32",
+                            },
+                            "cell_connectivity": {
+                                "shape": [8],
+                                "dtype": "int32",
+                            },
+                            "cell_data": {
+                                "temperature": {
+                                    "shape": [2, 2],
+                                    "dtype": "float32",
+                                },
+                                "pressure": {
+                                    "shape": [2, 2],
+                                    "dtype": "float32",
+                                },
+                            },
+                            "point_data": {
+                                "displacement": {
+                                    "shape": [5, 3],
+                                    "dtype": "float32",
+                                },
+                                "velocity": {
+                                    "shape": [5, 3],
+                                    "dtype": "float32",
+                                },
+                            },
+                        }
+                    },
+                },
+            ),
+            SampleRequest(
                 endpoint="jacobian",
                 payload={
                     "jac_inputs": ["mesh.points"],

--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -584,6 +584,7 @@ TEST_CASES = {
                         }
                     },
                 },
+                output_contains_pattern='"shape":[5,3],"dtype":"float32"',
             ),
             SampleRequest(
                 endpoint="jacobian",


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
Noticed that meshstats `abstract_eval` is wrong (crashes), so I fixed it + added a test.

#### Testing done
CI, new test

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Dion Häfner <dion.haefner@simulation.science>
