### PR TITLE
fix: Fix Tesseract SDK decoding and error handling

### DIFF
--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -355,9 +355,10 @@ def _decode_array(encoded_arr: dict):
             data = base64.b64decode(encoded_arr["data"]["buffer"])
             arr = np.frombuffer(data, dtype=encoded_arr["dtype"])
         else:
-            arr = np.array(encoded_arr["data"]["buffer"])
+            arr = np.array(encoded_arr["data"]["buffer"], dtype=encoded_arr["dtype"])
+            arr = arr.reshape(encoded_arr["shape"])
     else:
-        arr = encoded_arr
+        raise ValueError("Encoded array does not contain 'data' key. Cannot decode.")
     return arr
 
 
@@ -410,6 +411,7 @@ class HTTPClient:
                         type=e["type"],
                         loc=tuple(e["loc"]),
                         input=e.get("input"),
+                        ctx=e.get("ctx", {}),
                     )
                     for e in data["detail"]
                 ]

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -356,9 +356,9 @@ def _decode_array(encoded_arr: dict):
             arr = np.frombuffer(data, dtype=encoded_arr["dtype"])
         else:
             arr = np.array(encoded_arr["data"]["buffer"], dtype=encoded_arr["dtype"])
-            arr = arr.reshape(encoded_arr["shape"])
     else:
         raise ValueError("Encoded array does not contain 'data' key. Cannot decode.")
+    arr = arr.reshape(encoded_arr["shape"])
     return arr
 
 

--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -176,21 +176,21 @@ def test_encode_array(b64, expected_data):
                 "dtype": "float32",
                 "data": {"buffer": [1.0, 2.0, 3.0], "encoding": "raw"},
             },
-            [1.0, 2.0, 3.0],
+            np.array([1.0, 2.0, 3.0], dtype="float32"),
         ),
         (
             {
-                "shape": (3,),
+                "shape": (1, 3),
                 "dtype": "float32",
                 "data": {"buffer": "AACAPwAAAEAAAEBA", "encoding": "base64"},
             },
-            [1.0, 2.0, 3.0],
+            np.array([[1.0, 2.0, 3.0]], dtype="float32"),
         ),
     ],
 )
 def test_decode_array(encoded, expected):
     decoded = _decode_array(encoded)
-    assert np.all(decoded == expected)
+    np.testing.assert_array_equal(decoded, expected, strict=True)
 
 
 def test_tree_map():


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
- Ensure returned arrays have the correct shape and dtype.
- Fix an internal error when triggering certain validation errors that rely on a context object.

#### Testing done
manual

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Dion Häfner <dion.haefner@simulation.science>
