### PR TITLE
feat: also allow passing an imported module to Tesseract.from_tesseract_api

### DIFF
--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -45,6 +45,28 @@ def test_Tesseract_init():
         pass
 
 
+def test_Tesseract_from_tesseract_api(dummy_tesseract_location, dummy_tesseract_module):
+    all_endpoints = [
+        "apply",
+        "jacobian",
+        "jacobian_vector_product",
+        "vector_jacobian_product",
+        "health",
+        "input_schema",
+        "output_schema",
+        "abstract_eval",
+    ]
+
+    t = Tesseract.from_tesseract_api(dummy_tesseract_location / "tesseract_api.py")
+    endpoints = t.available_endpoints
+    assert endpoints == all_endpoints
+
+    # should also work when importing the module
+    t = Tesseract.from_tesseract_api(dummy_tesseract_module)
+    endpoints = t.available_endpoints
+    assert endpoints == all_endpoints
+
+
 def test_Tesseract_from_image(mock_serving, mock_clients):
     # Object is built and has the correct attributes set
     t = Tesseract.from_image("sometesseract:0.2.3", volumes=["/my/files"], gpus=["all"])


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
Also allow passing an imported module to `Tesseract.from_tesseract_api`. For example, this allows users to monkeypatch or construct modules at runtime without having to write them to a file.

#### Testing done
new test on CI

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Dion Häfner <dion.haefner@simulation.science>
