### PR TITLE
fix: fixed typos in jax recipe

### DIFF
--- a/tesseract_core/sdk/templates/jax/tesseract_api.py
+++ b/tesseract_core/sdk/templates/jax/tesseract_api.py
@@ -107,16 +107,16 @@ def vector_jacobian_product(
 
 def abstract_eval(abstract_inputs):
     """Calculate output shape of apply from the shape of its inputs."""
-    is_shapedtye_dict = lambda x: type(x) is dict and (x.keys() == {"shape", "dtype"})
-    is_shapedtye_struct = lambda x: isinstance(x, jax.ShapeDtypeStruct)
+    is_shapedtype_dict = lambda x: type(x) is dict and (x.keys() == {"shape", "dtype"})
+    is_shapedtype_struct = lambda x: isinstance(x, jax.ShapeDtypeStruct)
 
     jaxified_inputs = jax.tree.map(
-        lambda x: jax.ShapeDtypeStruct(**x) if is_shapedtye_dict(x) else x,
+        lambda x: jax.ShapeDtypeStruct(**x) if is_shapedtype_dict(x) else x,
         abstract_inputs.model_dump(),
-        is_leaf=is_shapedtye_dict,
+        is_leaf=is_shapedtype_dict,
     )
     dynamic_inputs, static_inputs = eqx.partition(
-        jaxified_inputs, filter_spec=is_shapedtye_struct
+        jaxified_inputs, firter_spec=is_shapedtype_struct
     )
 
     def wrapped_apply(dynamic_inputs):
@@ -126,10 +126,10 @@ def abstract_eval(abstract_inputs):
     jax_shapes = jax.eval_shape(wrapped_apply, dynamic_inputs)
     return jax.tree.map(
         lambda x: (
-            {"shape": x.shape, "dtype": str(x.dtype)} if is_shapedtye_struct(x) else x
+            {"shape": x.shape, "dtype": str(x.dtype)} if is_shapedtype_struct(x) else x
         ),
         jax_shapes,
-        is_leaf=is_shapedtye_struct,
+        is_leaf=is_shapedtype_struct,
     )
 
 

--- a/tesseract_core/sdk/templates/jax/tesseract_api.py
+++ b/tesseract_core/sdk/templates/jax/tesseract_api.py
@@ -22,7 +22,7 @@ from tesseract_core.runtime.tree_transforms import filter_func, flatten_with_pat
 # inputs/outputs as static. As Tesseract scalar objects (e.g. Float32) are
 # essentially just wrappers around numpy 0D arrays, they will be considered to
 # be dynamic and will be traced by JAX.
-# If you want to treat numerical values as scalar you will need to use
+# If you want to treat scalar numerical values as static you will need to use
 # built-in Python types (e.g. float, int) instead of Float32.
 
 

--- a/tesseract_core/sdk/templates/jax/tesseract_api.py
+++ b/tesseract_core/sdk/templates/jax/tesseract_api.py
@@ -116,7 +116,7 @@ def abstract_eval(abstract_inputs):
         is_leaf=is_shapedtype_dict,
     )
     dynamic_inputs, static_inputs = eqx.partition(
-        jaxified_inputs, firter_spec=is_shapedtype_struct
+        jaxified_inputs, filter_spec=is_shapedtype_struct
     )
 
     def wrapped_apply(dynamic_inputs):


### PR DESCRIPTION
#### Relevant issue or PR
N/A

#### Description of changes
Fixed typos in jax recipe

#### Testing done
Manual: Initializing Tesseract with jax recipe generates running code without typos

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Heiko Zimmermann heiko.zimmermann@simulation.science
