### PR TITLE
chore: add all-ok test step

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -236,3 +236,23 @@ jobs:
           slug: pasteurlabs/tesseract-core
           files: coverage*.xml
           fail_ci_if_error: true
+
+  all-ok:
+    needs: [tests-base, tests-e2e]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for errors
+        run: |
+          if [ "${{ needs.tests-base.result }}" != "success" ]; then
+            echo "Base tests failed"
+            exit 1
+          fi
+
+          if [ "${{ needs.tests-e2e.result }}" != "success" ]; then
+            echo "E2E tests failed"
+            exit 1
+          fi
+
+          echo "All tests passed!"


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
This allows us to mark all tests as required to merge a PR.

#### Testing done
👇 ([all-ok](https://github.com/pasteurlabs/tesseract-core/actions/runs/14900366944/job/41851192798?pr=153) ran)

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Dion Häfner <dion.haefner@simulation.science>
