### PR TITLE
fix: apidoc CLI call used container ID in place of container object to retrieve host port

### DIFF
--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -559,7 +559,8 @@ def apidoc(
     project_id = None
     try:
         project_id = engine.serve([image_name])
-        container = docker_client.compose.list()[project_id][0]
+        container_id = docker_client.compose.list()[project_id][0]
+        container = docker_client.containers.get(container_id)
         url = f"http://localhost:{container.host_port}/docs"
         logger.info(f"Serving OpenAPI docs for Tesseract {image_name} at {url}")
         logger.info("  Press Ctrl+C to stop")


### PR DESCRIPTION
#### Relevant issue or PR

#### Description of changes
apidoc call failed due to using a container ID in place of a Container object when retrieving the doc's host port:

```
│ /usr/local/lib/python3.12/dist-packages/tesseract_core/sdk/cli.py:563 in apidoc                  │
│                                                                                                  │
│   560 │   try:                                                                                   │
│   561 │   │   project_id = engine.serve([image_name])                                            │
│   562 │   │   container = docker_client.compose.list()[project_id][0]                            │
│ ❱ 563 │   │   url = f"http://localhost:{container.host_port}/docs"                               │
│   564 │   │   logger.info(f"Serving OpenAPI docs for Tesseract {image_name} at {url}")           │
│   565 │   │   logger.info("  Press Ctrl+C to stop")                                              │
│   566 │   │   if browser:                                                                        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
AttributeError: 'str' object has no attribute 'host_port'
```
Fix: Retrieve Container object for given container ID, then use it to get the port.

#### Testing done
Tested locally.
We currently have no apidoc CLI test in place. Adding one might be a bit tricky since the apidoc call launches a webbrowser and doesn't terminate by itself...

#### License

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://pasteurlabs.github.io/tesseract/LICENSE).
- [x] I sign the Developer Certificate of Origin below by adding my name and email address to the `Signed-off-by` line.

<details>
<summary><b>Developer Certificate of Origin</b></summary>

```text
Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
```

</details>

Signed-off-by: Linus Seelinger, linus.seelinger@simulation.science