### PR TITLE
fix: Add FileNotFoundError to docker info

### DIFF
--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -114,9 +114,7 @@ def needs_docker(func: Callable) -> Callable:
                 "Could not reach Docker daemon, check if it is running."
             ) from ex
         except FileNotFoundError as ex:
-            raise UserError(
-                "Docker daemon is not running, check if it is installed."
-            ) from ex
+            raise UserError("Docker not found, check if it is installed.") from ex
         return func(*args, **kwargs)
 
     return wrapper_needs_docker

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -113,6 +113,10 @@ def needs_docker(func: Callable) -> Callable:
             raise UserError(
                 "Could not reach Docker daemon, check if it is running."
             ) from ex
+        except FileNotFoundError as ex:
+            raise UserError(
+                "Docker daemon is not running, check if it is installed."
+            ) from ex
         return func(*args, **kwargs)
 
     return wrapper_needs_docker


### PR DESCRIPTION
#### Relevant issue or PR
#157 

#### Description of changes
Added FileNotFound exception to `needs_docker` wrapper

#### Testing done
Completely uninstalled docker and triggered the FileNotFoundError / no docker command error.

Reinstalled package with change and now we get this error instead.

```
(tesseract) 柯 ~/work/tesseract-core » tesseract build examples/empty
 [-] Docker daemon is not running, check if it is installed.
 [x] Aborting
 ```