### PR TITLE
fix: remove zip(strict=True) for py39 support

### DIFF
--- a/tesseract_core/runtime/schema_types.py
+++ b/tesseract_core/runtime/schema_types.py
@@ -85,7 +85,7 @@ class ShapeDType(BaseModel):
                 shape = shapedtype.shape
                 if expected_shape is Ellipsis:
                     return shapedtype
-                for actual, expected in zip(shape, expected_shape, strict=True):
+                for actual, expected in zip(shape, expected_shape):
                     if expected is not None and actual != expected:
                         raise ValueError(
                             f"Expected shape: {expected_shape}. Found: {shape}."

--- a/tesseract_core/runtime/tree_transforms.py
+++ b/tesseract_core/runtime/tree_transforms.py
@@ -143,7 +143,7 @@ def filter_func(
 
     def filtered_func(*args: Any) -> dict:
         if input_paths:
-            new_inputs = dict(zip(input_paths, args, strict=True))
+            new_inputs = dict(zip(input_paths, args))
         else:
             if len(args) != 1:
                 raise ValueError("Expected a single dictionary argument")


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
Ran into some issues when experimenting with Python 3.9 envs due to `zip(..., strict=True)` being a Python 3.10+ feature. Removed all instances from the runtime.

#### Testing done
not covered by tests, but given that Py39 is EOL in October that seems OK.