### PR TITLE
fix: "docker buildx build requires exactly 1 argument" error when using `tesseract build --forward-ssh-agent`

### DIFF
--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -155,6 +155,10 @@ class Images:
         """
         docker = _get_executable("docker")
         extra_args = get_config().docker_build_args
+
+        if ssh is not None:
+            extra_args = ("--ssh", ssh, *extra_args)
+
         build_cmd = [
             *docker,
             "buildx",
@@ -168,9 +172,6 @@ class Images:
             "--",
             str(path),
         ]
-
-        if ssh is not None:
-            build_cmd.extend(["--ssh", ssh])
 
         return build_cmd
 


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
Wrong order of arguments, we passed `docker build -- <contextdir> --ssh ...` but it should be `docker build --ssh ... -- <contextdir>`.

#### Testing done
none yet
