### PR TITLE
feat: Support input/output files by introducing FileReference Pydantic annotation

### DIFF
--- a/examples/helloworld/tesseract_api.py
+++ b/examples/helloworld/tesseract_api.py
@@ -3,15 +3,30 @@
 
 from pydantic import BaseModel, Field
 
+from tesseract_core.runtime import FileReference
+
 
 class InputSchema(BaseModel):
     name: str = Field(description="Name of the person you want to greet.")
+    input_file: FileReference = Field(description="A file that can be used as input.")
 
 
 class OutputSchema(BaseModel):
     greeting: str = Field(description="A greeting!")
+    output_file: FileReference = Field(description="We'll dump some output here.")
 
 
 def apply(inputs: InputSchema) -> OutputSchema:
     """Greet a person whose name is given as input."""
-    return OutputSchema(greeting=f"Hello {inputs.name}!")
+    # read the file to demonstrate usage of FileReference
+    with inputs.input_file.open() as f:
+        file_content = f.read()
+        print(f"File content: {file_content}")
+    # Create output file "test_out.txt"
+    output_file = inputs.input_file.with_name("test_out.txt")
+    with output_file.open("w") as f:
+        f.write("This is some output content.")
+    return OutputSchema(
+        greeting=f"Hello {inputs.name}! Read file: '{inputs.input_file}' with content '{file_content}'",
+        output_file=output_file,
+    )

--- a/tesseract_core/runtime/__init__.py
+++ b/tesseract_core/runtime/__init__.py
@@ -33,6 +33,7 @@ except ModuleNotFoundError as e:
 from .schema_types import (
     Array,
     Differentiable,
+    FileReference,
     Float16,
     Float32,
     Float64,
@@ -50,6 +51,7 @@ from .schema_types import (
 __all__ = [
     "Array",
     "Differentiable",
+    "FileReference",
     "Float16",
     "Float32",
     "Float64",


### PR DESCRIPTION
#### Relevant issue or PR
N/A

#### Description of changes
We'd like to support (binary) input/output files in tesseracts. This PR adds a `FileReference` Pydantic annotation.

Its validation step ensures the file exists and is a path relative to correct directory. The latter is crucial since it ensures that files are actually accessible, AND ensures we won't leak internals of the container/host.

Usage (based on hello world tesseract):

```
class InputSchema(BaseModel):
    name: str = Field(description="Name of the person you want to greet.")
    input_file: FileReference = Field(description="A file that can be used as input.")

[...]

def apply(inputs: InputSchema) -> OutputSchema:
    with inputs.input_file.open() as f:
        file_content = f.read()
        print(f"File content: {file_content}")
    [...]
```

```
curl -d '{"inputs": {"name": "Osborne", "input_file": "../helloworld/test.txt"}}' -H "Content-Type: application/json" http://127.0.0.1:8080/apply
```

The tesseract will resolve this to simply "test.txt" and verify the file exists.

#### TODO
- [ ] Remove example code in helloworld
- [ ] add dedicated example + docs for input/output files
- [ ] Automatically move output files to (upcoming) `--output-path`, and ensure paths are relative to `--input-path` and `--output-path`. Depends on @angela-ko 's upcoming changes.

#### Testing done
Local testing for variations of file paths.