### PR TITLE
Add --input-dir and tesseract-input/ mount point

### DIFF
--- a/tesseract_core/runtime/cli.py
+++ b/tesseract_core/runtime/cli.py
@@ -482,6 +482,7 @@ def main() -> None:
                 file=sys.stderr,
             )
             sys.exit(1)
+
         cli = _add_user_commands_to_cli(tesseract_runtime, out_stream=orig_stdout)
         cli(auto_envvar_prefix="TESSERACT_RUNTIME")
 

--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -835,6 +835,13 @@ def run_container(
             help=("User to run the Tesseract as e.g. '1000' or '1000:1000' (uid:gid)."),
         ),
     ] = None,
+    input_path: Annotated[
+        str,
+        typer.Option(
+            "--input-path",
+            help="Path to the input file.",
+        ),
+    ] = None,
 ) -> None:
     """Execute a command in a Tesseract.
 
@@ -878,7 +885,13 @@ def run_container(
 
     try:
         result_out, result_err = engine.run_tesseract(
-            tesseract_image, cmd, args, volumes=volume, gpus=gpus, user=user
+            tesseract_image,
+            cmd,
+            args,
+            volumes=volume,
+            gpus=gpus,
+            user=user,
+            input_path=input_path,
         )
 
     except ImageNotFound as e:

--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -828,6 +828,13 @@ def run_container(
             ),
         ),
     ] = None,
+    user: Annotated[
+        str | None,
+        typer.Option(
+            "--user",
+            help=("User to run the Tesseract as e.g. '1000' or '1000:1000' (uid:gid)."),
+        ),
+    ] = None,
 ) -> None:
     """Execute a command in a Tesseract.
 
@@ -871,7 +878,7 @@ def run_container(
 
     try:
         result_out, result_err = engine.run_tesseract(
-            tesseract_image, cmd, args, volumes=volume, gpus=gpus
+            tesseract_image, cmd, args, volumes=volume, gpus=gpus, user=user
         )
 
     except ImageNotFound as e:

--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -835,11 +835,11 @@ def run_container(
             help=("User to run the Tesseract as e.g. '1000' or '1000:1000' (uid:gid)."),
         ),
     ] = None,
-    input_path: Annotated[
-        str,
+    input_dir: Annotated[
+        str | None,
         typer.Option(
-            "--input-path",
-            help="Path to the input file.",
+            "--input-dir",
+            help="Path to the directory where input files are stored to be mounted on to the Tesseract.",
         ),
     ] = None,
 ) -> None:
@@ -891,7 +891,7 @@ def run_container(
             volumes=volume,
             gpus=gpus,
             user=user,
-            input_path=input_path,
+            input_dir=input_dir,
         )
 
     except ImageNotFound as e:

--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -498,6 +498,15 @@ def serve(
             ),
         ),
     ] = None,
+    user: Annotated[
+        str | None,
+        typer.Option(
+            "--user",
+            help=(
+                "User to run the Tesseracts as e.g. '1000' or '1000:1000' (uid:gid)."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Serve one or more Tesseract images.
 
@@ -543,6 +552,7 @@ def serve(
             num_workers,
             no_compose,
             service_names_list,
+            user,
         )
     except RuntimeError as ex:
         raise UserError(

--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -835,7 +835,7 @@ class Volumes:
         docker = _get_executable("docker")
         try:
             _ = subprocess.run(
-                [*docker, "volume", "create", "--name", name],
+                [*docker, "volume", "create", name],
                 check=True,
                 capture_output=True,
                 text=True,

--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -506,13 +506,13 @@ class Containers:
         image: str,
         command: list_[str],
         volumes: dict | None = None,
-        user: str | None = None,
         device_requests: list_[int | str] | None = None,
         detach: bool = False,
         remove: bool = False,
         ports: dict | None = None,
         stdout: bool = True,
         stderr: bool = False,
+        user: str | None = None,
     ) -> Container | tuple[bytes, bytes] | bytes:
         """Run a command in a container from an image.
 

--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -506,6 +506,7 @@ class Containers:
         image: str,
         command: list_[str],
         volumes: dict | None = None,
+        user: str | None = None,
         device_requests: list_[int | str] | None = None,
         detach: bool = False,
         remove: bool = False,
@@ -519,6 +520,7 @@ class Containers:
             image: The image name or id to run the command in.
             command: The command to run in the container.
             volumes: A dict of volumes to mount in the container.
+            user: String of user information to run command as in the format "uid:(optional)gid".
             device_requests: A list of device requests for the container.
             detach: If True, run the container in detached mode. Detach must be set to
                     True if we wish to retrieve the container id of the running container,
@@ -555,6 +557,9 @@ class Containers:
                     f"{host_path}:{volume_info['bind']}:{volume_info['mode']}"
                 )
             optional_args.extend(volume_args)
+
+        if user:
+            optional_args.extend(["-u", user])
 
         if device_requests:
             gpus_str = ",".join(device_requests)
@@ -774,6 +779,116 @@ class Compose:
         return project_container_map
 
 
+@dataclass
+class Volume:
+    """Volume class to wrap Docker volumes."""
+
+    name: str
+    attrs: dict
+
+    @classmethod
+    def from_dict(cls, json_dict: dict) -> "Volume":
+        """Create an Image object from a json dictionary.
+
+        Params:
+            json_dict: The json dictionary to create the object from.
+
+        Returns:
+            The created volume object.
+        """
+        return cls(
+            name=json_dict.get("Name", None),
+            attrs=json_dict,
+        )
+
+    def remove(self, force: bool = False) -> None:
+        """Remove a Docker volume.
+
+        Params:
+            force: If True, force the removal of the volume.
+        """
+        docker = _get_executable("docker")
+        try:
+            _ = subprocess.run(
+                [*docker, "volume", "rm", "--force" if force else "", self.name],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as ex:
+            raise NotFound(f"Error removing volume {self.name}: {ex}") from ex
+
+
+class Volumes:
+    """Volume class to wrap Docker volumes."""
+
+    @staticmethod
+    def create(name: str) -> Volume:
+        """Create a Docker volume.
+
+        Params:
+            name: The name of the volume to create.
+
+        Returns:
+            The created volume object.
+        """
+        docker = _get_executable("docker")
+        try:
+            _ = subprocess.run(
+                [*docker, "volume", "create", "--name", name],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return Volumes.get(name)
+        except subprocess.CalledProcessError as ex:
+            raise NotFound(f"Error creating volume {name}: {ex}") from ex
+
+    @staticmethod
+    def get(name: str) -> Volume:
+        """Get a Docker volume.
+
+        Params:
+            name: The name of the volume to get.
+
+        Returns:
+            The volume object.
+        """
+        docker = _get_executable("docker")
+        try:
+            result = subprocess.run(
+                [*docker, "volume", "inspect", name],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            json_dict = json.loads(result.stdout)
+        except subprocess.CalledProcessError as ex:
+            raise NotFound(f"Volume {name} not found: {ex}") from ex
+        if not json_dict:
+            raise NotFound(f"Volume {name} not found.")
+        return Volume.from_dict(json_dict[0])
+
+    @staticmethod
+    def list() -> list[str]:
+        """List all Docker volumes.
+
+        Returns:
+            List of volume names.
+        """
+        docker = _get_executable("docker")
+        try:
+            result = subprocess.run(
+                [*docker, "volume", "ls", "-q"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as ex:
+            raise APIError(f"Error listing volumes: {ex}") from ex
+        return result.stdout.strip().split("\n")
+
+
 class DockerException(Exception):
     """Base class for Docker CLI exceptions."""
 
@@ -847,6 +962,7 @@ class CLIDockerClient:
         self.containers = Containers()
         self.images = Images()
         self.compose = Compose()
+        self.volumes = Volumes()
 
     @staticmethod
     def info() -> tuple:

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -843,6 +843,7 @@ def run_tesseract(
     gpus: list[int | str] | None = None,
     ports: dict[str, str] | None = None,
     user: str | None = None,
+    input_path: str | None = None,
 ) -> tuple[str, str]:
     """Start a Tesseract and execute a given command.
 
@@ -865,6 +866,8 @@ def run_tesseract(
     cmd = [command]
     current_cmd = None
 
+    if input_path:
+        volumes.append(f"{input_path}:/tesseract_input")
     if volumes is None:
         parsed_volumes = {}
     else:

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -763,22 +763,23 @@ def _create_docker_compose_template(
         services.append(service)
 
     docker_volumes = {}  # Dictionary of volume names mapped to whether or not they already exist
-    for volume in volumes:
-        source = volume.split(":")[0]
-        # Check if source exists to determine if specified volume is a docker volume
-        if not Path(source).exists():
-            # Check if volume exists
-            if not docker_client.volumes.get(source):
-                if "/" not in source:
-                    docker_volumes[source] = False
+    if volumes:
+        for volume in volumes:
+            source = volume.split(":")[0]
+            # Check if source exists to determine if specified volume is a docker volume
+            if not Path(source).exists():
+                # Check if volume exists
+                if not docker_client.volumes.get(source):
+                    if "/" not in source:
+                        docker_volumes[source] = False
+                    else:
+                        raise ValueError(
+                            f"Volume/Path {source} does not already exist, "
+                            "and new volume cannot be created due to '/' in name."
+                        )
                 else:
-                    raise ValueError(
-                        f"Volume/Path {source} does not already exist, "
-                        "and new volume cannot be created due to '/' in name."
-                    )
-            else:
-                # Docker volume is external
-                docker_volumes[source] = True
+                    # Docker volume is external
+                    docker_volumes[source] = True
 
     template = ENV.get_template("docker-compose.yml")
     return template.render(services=services, docker_volumes=docker_volumes)

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -843,7 +843,7 @@ def run_tesseract(
     gpus: list[int | str] | None = None,
     ports: dict[str, str] | None = None,
     user: str | None = None,
-    input_path: str | None = None,
+    input_dir: str | None = None,
 ) -> tuple[str, str]:
     """Start a Tesseract and execute a given command.
 
@@ -856,6 +856,7 @@ def run_tesseract(
         ports: dictionary of ports to bind to the host. Key is the host port,
             value is the container port.
         user: user to run the Tesseract as, e.g. '1000' or '1000:1000' (uid:gid).
+        input_dir: Path to the directory where input files are stored to be mounted on to the Tesseract.
 
     Returns:
         Tuple with the stdout and stderr of the Tesseract.
@@ -866,9 +867,11 @@ def run_tesseract(
     cmd = [command]
     current_cmd = None
 
-    if input_path:
-        volumes.append(f"{input_path}:/tesseract_input")
-    if volumes is None:
+    if input_dir:
+        if volumes is None:
+            volumes = []
+        volumes.append(f"{input_dir}:/tesseract_input")
+    if not volumes:
         parsed_volumes = {}
     else:
         parsed_volumes = _parse_volumes(volumes)

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -566,7 +566,7 @@ def serve(
         num_workers: number of workers to use for serving the Tesseracts.
         no_compose: if True, do not use Docker Compose to serve the Tesseracts.
         service_names: list of service names under which to expose each Tesseract container on the shared network.
-        user: user to run the Tesseracts as.
+        user: user to run the Tesseracts as, e.g. '1000' or '1000:1000' (uid:gid).
 
     Returns:
         A string representing the Tesseract project ID.
@@ -841,6 +841,7 @@ def run_tesseract(
     volumes: list[str] | None = None,
     gpus: list[int | str] | None = None,
     ports: dict[str, str] | None = None,
+    user: str | None = None,
 ) -> tuple[str, str]:
     """Start a Tesseract and execute a given command.
 
@@ -852,6 +853,7 @@ def run_tesseract(
         gpus: list of GPUs, as indices or names, to passthrough the container.
         ports: dictionary of ports to bind to the host. Key is the host port,
             value is the container port.
+        user: user to run the Tesseract as, e.g. '1000' or '1000:1000' (uid:gid).
 
     Returns:
         Tuple with the stdout and stderr of the Tesseract.
@@ -920,6 +922,7 @@ def run_tesseract(
         detach=False,
         remove=True,
         stderr=True,
+        user=user,
     )
     stdout = stdout.decode("utf-8")
     stderr = stderr.decode("utf-8")

--- a/tesseract_core/sdk/templates/docker-compose.yml
+++ b/tesseract_core/sdk/templates/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     image: {{ service.image }}
     restart: unless-stopped
     command: ["serve", "--host", "0.0.0.0", "--num-workers", "{{ service.num_workers }}"]
+    {%- if service.user %}
+    user: "{{ service.user }}"
+    {%- endif %}
     ports:
       - {{ service.port }}
     {% if service.environment.TESSERACT_DEBUG == "1" %}
@@ -38,6 +41,16 @@ services:
             {{ service.gpus }}
     {% endif %}
 {% endfor %}
+
+{%- if docker_volumes %}
+volumes:
+{%- for name, external in docker_volumes.items() %}
+  {{ name }}:
+    {%- if external %}
+    external: true
+    {% endif %}
+{% endfor %}
+{% endif %}
 
 networks:
   multi-tesseract-network:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,6 +207,20 @@ def docker_client():
     return docker_client_module.CLIDockerClient()
 
 
+@pytest.fixture
+def docker_volume(docker_client):
+    # Create the Docker volume
+    volume = docker_client.volumes.create(name="docker_client_test_volume")
+    try:
+        yield volume
+    finally:
+        try:
+            volume.remove()
+        except Exception:
+            # already removed
+            pass
+
+
 @pytest.fixture(scope="module")
 def docker_cleanup_module(docker_client, request):
     """Clean up all tesseracts created by the tests after the module exits."""

--- a/tests/endtoend_tests/test_docker_client.py
+++ b/tests/endtoend_tests/test_docker_client.py
@@ -48,21 +48,6 @@ def docker_client_built_image_name(
             pass
 
 
-@pytest.fixture(scope="module")
-def docker_volume(docker_client):
-    # Create the Docker volume
-    volume = docker_client.volumes.create(name="docker_client_test_volume")
-    try:
-        yield volume
-    finally:
-        pass
-        # try:
-        #     volume.remove()
-        # except NotFound:
-        #     # already removed
-        #     pass
-
-
 def test_get_image(docker_client, docker_client_built_image_name, docker_py_client):
     """Test image retrieval."""
 
@@ -414,7 +399,7 @@ def test_compose_error(docker_client, tmp_path, docker_client_built_image_name):
     assert "Failed to start Tesseract container" in str(e.value)
 
 
-def test_volume_permissions(
+def test_volume_uid_permissions(
     docker_client, docker_client_built_image_name, docker_volume, docker_cleanup
 ):
     # Set up root only directory

--- a/tests/endtoend_tests/test_docker_client.py
+++ b/tests/endtoend_tests/test_docker_client.py
@@ -439,7 +439,7 @@ def test_volume_permissions(
     assert "Permission denied" in str(e)
 
     # Try to write to the folder as UID 1000
-    write_cmd = "echo hello > /bar/hello_1000.txt"
+    write_cmd = "echo hello > /bar/hello_1000.txt && cat /bar/hello_1000.txt"
     with pytest.raises(ContainerError) as e:
         _ = run_tesseract_with_volume(write_cmd, user="1000:1000")
     assert "Permission denied" in str(e)
@@ -453,7 +453,6 @@ def test_volume_permissions(
     assert stdout == b"hello\n"
 
     # Try to write to the folder as UID 1000 again
-    write_cmd = "echo hello > /bar/hello_1000.tx && cat /bar/hello_1000.txt"
     stdout = run_tesseract_with_volume(write_cmd, user="1000:1000")
     assert stdout == b"hello\n"
 

--- a/tests/endtoend_tests/test_docker_client.py
+++ b/tests/endtoend_tests/test_docker_client.py
@@ -464,12 +464,12 @@ def test_volume_permissions(
         docker_volume.name: {"bind": "/from", "mode": "rw"},
         volume_777.name: {"bind": "/to", "mode": "rw"},
     }
-    cmd = "chmod 700 /from && cp /from/hello.txt /to/hello_777.txt && cat /to/hello_777.txt"
+    cmd = "chmod 700 /from && cp /from/hello.txt /to/hello.txt && cat /to/hello.txt"
     stdout = run_tesseract_with_volume(cmd, volume=volume_args)
     assert stdout == b"hello\n"
 
     # Try to access files as UID1000
-    cmd = "cat /to/hello_777.txt"
+    cmd = "cat /to/hello.txt"
     stdout = run_tesseract_with_volume(cmd, user="1000:1000", volume=volume_args)
     assert stdout == b"hello\n"
 
@@ -478,3 +478,9 @@ def test_volume_permissions(
             "cat /from/hello_777.txt", user="1000:1000", volume=volume_args
         )
     assert "Permission denied" in str(e)
+
+    cmd = (
+        "adduser -D testuser && chmod 777 /from && su - testuser && cat /from/hello.txt"
+    )
+    stdout = run_tesseract_with_volume(cmd, volume=volume_args)
+    assert stdout == b"hello\n"

--- a/tests/endtoend_tests/test_docker_client.py
+++ b/tests/endtoend_tests/test_docker_client.py
@@ -410,8 +410,8 @@ def test_volume_uid_permissions(
             docker_client_built_image_name,
             [cmd],
             remove=True,
-            user=user,
             volumes=volume,
+            user=user,
         )
 
     cmd = "mkdir -p /bar && echo hello > /bar/hello.txt && chmod 700 /bar"

--- a/tests/endtoend_tests/test_docker_client.py
+++ b/tests/endtoend_tests/test_docker_client.py
@@ -14,6 +14,7 @@ from common import image_exists
 
 from tesseract_core.sdk.docker_client import (
     APIError,
+    ContainerError,
     ImageNotFound,
     build_docker_image,
 )
@@ -45,6 +46,21 @@ def docker_client_built_image_name(
         except ImageNotFound:
             # already removed
             pass
+
+
+@pytest.fixture(scope="module")
+def docker_volume(docker_client):
+    # Create the Docker volume
+    volume = docker_client.volumes.create(name="docker_client_test_volume")
+    try:
+        yield volume
+    finally:
+        pass
+        # try:
+        #     volume.remove()
+        # except NotFound:
+        #     # already removed
+        #     pass
 
 
 def test_get_image(docker_client, docker_client_built_image_name, docker_py_client):
@@ -396,3 +412,69 @@ def test_compose_error(docker_client, tmp_path, docker_client_built_image_name):
         docker_client.compose.up(str(compose_file), "docker_client_compose_test")
     # Check that the container's logs were printed to stderr
     assert "Failed to start Tesseract container" in str(e.value)
+
+
+def test_volume_permissions(
+    docker_client, docker_client_built_image_name, docker_volume, docker_cleanup
+):
+    # Set up root only directory
+    def run_tesseract_with_volume(cmd: str, user: str = "root:root", volume: str = ""):
+        if not volume:
+            volume = {docker_volume.name: {"bind": "/bar", "mode": "rw"}}
+        return docker_client.containers.run(
+            docker_client_built_image_name,
+            [cmd],
+            remove=True,
+            user=user,
+            volumes=volume,
+        )
+
+    cmd = "mkdir -p /bar && echo hello > /bar/hello.txt && chmod 700 /bar"
+    _ = run_tesseract_with_volume(cmd)
+
+    # Try to read the file as UID 1000
+    read_cmd = "cat /bar/hello.txt"
+    with pytest.raises(ContainerError) as e:
+        _ = run_tesseract_with_volume(read_cmd, user="1000:1000")
+    assert "Permission denied" in str(e)
+
+    # Try to write to the folder as UID 1000
+    write_cmd = "echo hello > /bar/hello_1000.txt"
+    with pytest.raises(ContainerError) as e:
+        _ = run_tesseract_with_volume(write_cmd, user="1000:1000")
+    assert "Permission denied" in str(e)
+
+    # Grant permission to the file
+    cmd = "chmod 777 /bar"
+    _ = run_tesseract_with_volume(cmd)
+
+    # Try to read the file as UID 1000 again
+    stdout = run_tesseract_with_volume(read_cmd, user="1000:1000")
+    assert stdout == b"hello\n"
+
+    # Try to write to the folder as UID 1000 again
+    write_cmd = "echo hello > /bar/hello_1000.tx && cat /bar/hello_1000.txt"
+    stdout = run_tesseract_with_volume(write_cmd, user="1000:1000")
+    assert stdout == b"hello\n"
+
+    # Try to copy a file from a volume with permissions 700 to a volume with permission 777
+    volume_777 = docker_client.volumes.create(name="docker_client_test_volume_777")
+    docker_cleanup["volumes"].append(volume_777)
+    volume_args = {
+        docker_volume.name: {"bind": "/from", "mode": "rw"},
+        volume_777.name: {"bind": "/to", "mode": "rw"},
+    }
+    cmd = "chmod 700 /from && cp /from/hello.txt /to/hello_777.txt && cat /to/hello_777.txt"
+    stdout = run_tesseract_with_volume(cmd, volume=volume_args)
+    assert stdout == b"hello\n"
+
+    # Try to access files as UID1000
+    cmd = "cat /to/hello_777.txt"
+    stdout = run_tesseract_with_volume(cmd, user="1000:1000", volume=volume_args)
+    assert stdout == b"hello\n"
+
+    with pytest.raises(ContainerError) as e:
+        run_tesseract_with_volume(
+            "cat /from/hello_777.txt", user="1000:1000", volume=volume_args
+        )
+    assert "Permission denied" in str(e)

--- a/tests/endtoend_tests/test_endtoend.py
+++ b/tests/endtoend_tests/test_endtoend.py
@@ -610,7 +610,8 @@ def test_serve_nonstandard_host_ip(
         requests.get(f"http://localhost:{project_container.host_port}/health")
 
 
-def test_tesseract_cli_options_parsing(built_image_name, tmpdir):
+@pytest.mark.parametrize("use_input_dir", [True, False])
+def test_tesseract_cli_options_parsing(built_image_name, tmpdir, use_input_dir):
     cli_runner = CliRunner(mix_stderr=False)
 
     tmpdir.chmod(0o0707)
@@ -624,12 +625,18 @@ def test_tesseract_cli_options_parsing(built_image_name, tmpdir):
         ["apply", "-o", str(tmpdir), f"@{example_inputs}", "-f", "json+binref"],
     )
 
+    if use_input_dir:
+        additional_options = ["--input-dir", str(example_inputs.parent)]
+    else:
+        additional_options = []
+
     for args in test_commands:
         run_res = cli_runner.invoke(
             app,
             [
                 "run",
                 built_image_name,
+                *additional_options,
                 *args,
             ],
             catch_exceptions=False,

--- a/tests/endtoend_tests/test_endtoend.py
+++ b/tests/endtoend_tests/test_endtoend.py
@@ -4,6 +4,7 @@
 """End-to-end tests for Tesseract workflows."""
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -494,7 +495,9 @@ def test_tesseract_serve_docker_volume(
         tesseract0 = docker_client.containers.get(tesseract0_id)
         tesseract1_id = project_meta["containers"][1]["name"]
         tesseract1 = docker_client.containers.get(tesseract1_id)
-        if user == "root":
+        # Podman does UID remapping by default to avoid permission issues
+        docker_host = os.environ.get("DOCKER_HOST", "")
+        if user == "root" or "podman" in docker_host:
             volume_read_write()
         else:
             with pytest.raises(ContainerError) as e:

--- a/tests/endtoend_tests/test_endtoend.py
+++ b/tests/endtoend_tests/test_endtoend.py
@@ -401,7 +401,7 @@ def test_tesseract_serve_with_volumes(built_image_name, tmp_path, docker_client)
         [
             "serve",
             "--volume",
-            f"tmp_path:{dest}",
+            f"{tmp_path}:{dest}",
             built_image_name,
             built_image_name,
         ],

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -191,6 +191,20 @@ def test_run_tesseract_file_input(mocked_docker, tmpdir):
         "bind": "/path/in/container",
     }
 
+    # Test the same but with --input_dir
+    res, _ = engine.run_tesseract(
+        "foobar",
+        "apply",
+        [f"@{infile}", "--output-path", str(outdir)],
+        input_dir=tmpdir,
+    )
+    res = json.loads(res)
+    assert res["volumes"].keys() == {str(infile), str(outdir), str(tmpdir)}
+    assert res["volumes"][str(tmpdir)] == {
+        "mode": "ro",
+        "bind": "/tesseract-input",
+    }
+
 
 def test_serve_tesseracts_invalid_input_args(mocked_docker):
     """Test input validation logic for multi-tesseract serve."""


### PR DESCRIPTION
#### Description of changes
- Added `--input-dir` to tesseract run cli commands. 
- If `--input-dir` is specified, instead of a json payload, we would be expecting a relative path to the --input-dir and this would be located under `/tesseract-input`

I debated between putting this flag in runtime vs sdk, but I decided to go with sdk since runtime shouldn't need to know anything about the paths of stuff that lives outside of it (the container). This might make the argument a bit confusing since `--input-dir` would need to be before `apply`, e.g. `tesseract run --input-dir helloworld apply inputs.json`. 

I also swapped to the name `input-dir` instead of `path` since there already exists flags for runtime names `input-paths` and `output-paths`, and since we are expecting a directory, this makes a bit more sense? 

#### Testing done
Unit testing


- [ ] Additional Testing to be done
- [ ] More checking of `--input-dir` path vs `json_payload`

