### PR TITLE
feat: pass env variables through `tesseract run` and `tesseract serve`

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -114,7 +114,7 @@ jobs:
             --skip-endtoend \
             --cov-report=term-missing:skip-covered \
             --cov-report=xml:coverage.xml \
-            --cov=tesseract_core
+            --cov=tesseract_core \
             --cov-branch
 
       - name: Run test suite (Windows)
@@ -126,7 +126,7 @@ jobs:
             --skip-endtoend \
             --cov-report=term-missing:skip-covered \
             --cov-report=xml:coverage.xml \
-            --cov=tesseract_core
+            --cov=tesseract_core \
             --cov-branch
 
       - name: Upload coverage reports to Codecov
@@ -281,7 +281,7 @@ jobs:
           if [ "${{ matrix.unit-tesseract }}" == "base" ]; then
             uv run --no-sync pytest \
               --always-run-endtoend \
-              --cov-branch
+              --cov-branch \
               --cov-report=term-missing:skip-covered \
               --cov-report=xml:coverage.xml \
               --cov=tesseract_core \
@@ -290,7 +290,7 @@ jobs:
           else
             uv run --no-sync pytest \
               --always-run-endtoend \
-              --cov-branch
+              --cov-branch \
               --cov-report=term-missing:skip-covered \
               --cov-report=xml:coverage.xml \
               --cov=tesseract_core \

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -115,6 +115,7 @@ jobs:
             --cov-report=term-missing:skip-covered \
             --cov-report=xml:coverage.xml \
             --cov=tesseract_core
+            --cov-branch
 
       - name: Run test suite (Windows)
         if: runner.os == 'Windows'
@@ -126,6 +127,7 @@ jobs:
             --cov-report=term-missing:skip-covered \
             --cov-report=xml:coverage.xml \
             --cov=tesseract_core
+            --cov-branch
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.4.3
@@ -279,6 +281,7 @@ jobs:
           if [ "${{ matrix.unit-tesseract }}" == "base" ]; then
             uv run --no-sync pytest \
               --always-run-endtoend \
+              --cov-branch
               --cov-report=term-missing:skip-covered \
               --cov-report=xml:coverage.xml \
               --cov=tesseract_core \
@@ -287,6 +290,7 @@ jobs:
           else
             uv run --no-sync pytest \
               --always-run-endtoend \
+              --cov-branch
               --cov-report=term-missing:skip-covered \
               --cov-report=xml:coverage.xml \
               --cov=tesseract_core \

--- a/docs/content/using-tesseracts/advanced.md
+++ b/docs/content/using-tesseracts/advanced.md
@@ -16,10 +16,10 @@ target path:
 $ tesseract run vectoradd apply --output-path /tmp/output @inputs.json
 ```
 
-## Passing environment variables
+## Passing environment variables to Tesseract containers
 
-Through the optional `--env` argument, you can pass environment variables to tesseracts.
-This works both for serving a tesseract and running a single execution:
+Through the optional `--env` argument, you can pass environment variables to Tesseracts.
+This works both for serving a Tesseract and running a single execution:
 
 ```bash
 $ tesseract serve --env=MY_ENV_VARIABLE="some value" helloworld

--- a/docs/content/using-tesseracts/advanced.md
+++ b/docs/content/using-tesseracts/advanced.md
@@ -16,6 +16,16 @@ target path:
 $ tesseract run vectoradd apply --output-path /tmp/output @inputs.json
 ```
 
+## Passing environment variables
+
+Through the optional `--env` argument, you can pass environment variables to tesseracts.
+This works both for serving a tesseract and running a single execution:
+
+```bash
+$ tesseract serve --env=MY_ENV_VARIABLE="some value" helloworld
+$ tesseract run --env=MY_ENV_VARIABLE="some value" helloworld apply '{"inputs": {"name": "Osborne"}}'
+```
+
 ## Using GPUs
 
 To leverage GPU support in your Tesseract environment, you can specify which NVIDIA GPU(s) to make available

--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -893,7 +893,6 @@ def run_container(
 
     if environment is not None:
         try:
-            print("env: ", environment)
             environment = {
                 item.split("=", maxsplit=1)[0]: item.split("=", maxsplit=1)[1]
                 for item in environment

--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -939,7 +939,7 @@ def run_container(
             volumes=volume,
             gpus=gpus,
             environment=environment,
-            user=user
+            user=user,
         )
 
     except ImageNotFound as e:

--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -507,6 +507,7 @@ class Containers:
         command: list_[str],
         volumes: dict | None = None,
         device_requests: list_[int | str] | None = None,
+        environment: dict[str, str] | None = None,
         detach: bool = False,
         remove: bool = False,
         ports: dict | None = None,
@@ -559,6 +560,12 @@ class Containers:
         if device_requests:
             gpus_str = ",".join(device_requests)
             optional_args.extend(["--gpus", f'"device={gpus_str}"'])
+
+        if environment:
+            env_args = []
+            for env_var, value in environment.items():
+                env_args.extend(["-e", f"{env_var}={value}"])
+            optional_args.extend(env_args)
 
         # Remove and detached cannot both be set to true
         if remove and detach:

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -751,7 +751,10 @@ def _create_docker_compose_template(
             "port": f"{ports[i]}:8000",
             "volumes": volumes,
             "gpus": gpu_settings,
-            "environment": {"TESSERACT_DEBUG": "1" if debug else "0", **environment},
+            "environment": {
+                "TESSERACT_DEBUG": "1" if debug else "0",
+                **(environment or {}),
+            },
             "num_workers": num_workers,
             "debugpy_port": debugpy_ports[i] if debug else None,
         }

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -543,6 +543,7 @@ def serve(
     host_ip: str = "127.0.0.1",
     ports: list[str] | None = None,
     volumes: list[str] | None = None,
+    environment: dict[str, str] | None = None,
     gpus: list[str] | None = None,
     debug: bool = False,
     num_workers: int = 1,
@@ -558,6 +559,7 @@ def serve(
         host_ip: IP address to bind the Tesseracts to.
         ports: port or port range to serve each Tesseract on.
         volumes: list of paths to mount in the Tesseract container.
+        environment: dictionary of environment variables to pass to the Tesseract.
         gpus: IDs of host Nvidia GPUs to make available to the Tesseracts.
         debug: Enable debug mode. This will propagate full tracebacks to the client
             and start a debugpy server in the Tesseract.
@@ -667,6 +669,7 @@ def serve(
         service_names,
         ports,
         volumes,
+        environment,
         gpus,
         num_workers,
         debug=debug,
@@ -692,6 +695,7 @@ def _create_docker_compose_template(
     service_names: list[str] | None = None,
     ports: list[str] | None = None,
     volumes: list[str] | None = None,
+    environment: dict[str, str] | None = None,
     gpus: list[str] | None = None,
     num_workers: int = 1,
     debug: bool = False,
@@ -747,9 +751,7 @@ def _create_docker_compose_template(
             "port": f"{ports[i]}:8000",
             "volumes": volumes,
             "gpus": gpu_settings,
-            "environment": {
-                "TESSERACT_DEBUG": "1" if debug else "0",
-            },
+            "environment": {"TESSERACT_DEBUG": "1" if debug else "0", **environment},
             "num_workers": num_workers,
             "debugpy_port": debugpy_ports[i] if debug else None,
         }
@@ -816,6 +818,7 @@ def run_tesseract(
     volumes: list[str] | None = None,
     gpus: list[int | str] | None = None,
     ports: dict[str, str] | None = None,
+    environment: dict[str, str] | None = None,
 ) -> tuple[str, str]:
     """Start a Tesseract and execute a given command.
 
@@ -827,6 +830,8 @@ def run_tesseract(
         gpus: list of GPUs, as indices or names, to passthrough the container.
         ports: dictionary of ports to bind to the host. Key is the host port,
             value is the container port.
+        environment: list of environment variables to set in the container,
+            in Docker format: key=value.
 
     Returns:
         Tuple with the stdout and stderr of the Tesseract.
@@ -891,6 +896,7 @@ def run_tesseract(
         command=cmd,
         volumes=parsed_volumes,
         device_requests=gpus,
+        environment=environment,
         ports=ports,
         detach=False,
         remove=True,

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -26,6 +26,7 @@ class SpawnConfig:
 
     image: str
     volumes: list[str] | None
+    environment: dict[str, str] | None
     gpus: list[str] | None
     num_workers: int
     debug: bool
@@ -84,6 +85,7 @@ class Tesseract:
         image: str,
         *,
         volumes: list[str] | None = None,
+        environment: dict[str, str] | None = None,
         gpus: list[str] | None = None,
         num_workers: int = 1,
         no_compose: bool = False,
@@ -104,6 +106,7 @@ class Tesseract:
         Args:
             image: The Docker image to use.
             volumes: List of volumes to mount, e.g. ["/path/on/host:/path/in/container"].
+            environment: dictionary of environment variables to pass to the Tesseract.
             gpus: List of GPUs to use, e.g. ["0", "1"]. (default: no GPUs)
             num_workers: Number of worker processes to use. This determines how
                 many requests can be handled in parallel. Higher values
@@ -117,6 +120,7 @@ class Tesseract:
         obj._spawn_config = SpawnConfig(
             image=image,
             volumes=volumes,
+            environment=environment,
             gpus=gpus,
             num_workers=num_workers,
             debug=True,
@@ -223,6 +227,7 @@ class Tesseract:
             self._spawn_config.image,
             port=port,
             volumes=self._spawn_config.volumes,
+            environment=self._spawn_config.environment,
             gpus=self._spawn_config.gpus,
             num_workers=self._spawn_config.num_workers,
             debug=self._spawn_config.debug,
@@ -265,6 +270,7 @@ class Tesseract:
         port: str | None = None,
         host_ip: str = "127.0.0.1",
         volumes: list[str] | None = None,
+        environment: dict[str, str] | None = None,
         gpus: list[str] | None = None,
         debug: bool = False,
         num_workers: int = 1,
@@ -279,6 +285,7 @@ class Tesseract:
             [image],
             ports=ports,
             volumes=volumes,
+            environment=environment,
             gpus=gpus,
             debug=debug,
             num_workers=num_workers,

--- a/tests/dummy_tesseract/tesseract_api.py
+++ b/tests/dummy_tesseract/tesseract_api.py
@@ -1,6 +1,8 @@
 # Copyright 2025 Pasteur Labs. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 import numpy as np
 from pydantic import BaseModel, Field
 
@@ -40,6 +42,10 @@ def apply(inputs: InputSchema) -> OutputSchema:
     if inputs.normalize:
         norm = np.linalg.norm(result, ord=2)
         result /= norm
+
+    env_var = os.getenv("TEST_ENV_VAR")
+    if env_var:
+        print(f"TEST_ENV_VAR: {env_var}")
 
     return OutputSchema(result=result)
 

--- a/tests/dummy_tesseract/tesseract_api.py
+++ b/tests/dummy_tesseract/tesseract_api.py
@@ -1,8 +1,6 @@
 # Copyright 2025 Pasteur Labs. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-
 import numpy as np
 from pydantic import BaseModel, Field
 
@@ -42,10 +40,6 @@ def apply(inputs: InputSchema) -> OutputSchema:
     if inputs.normalize:
         norm = np.linalg.norm(result, ord=2)
         result /= norm
-
-    env_var = os.getenv("TEST_ENV_VAR")
-    if env_var:
-        print(f"TEST_ENV_VAR: {env_var}")
 
     return OutputSchema(result=result)
 

--- a/tests/endtoend_tests/test_endtoend.py
+++ b/tests/endtoend_tests/test_endtoend.py
@@ -5,6 +5,7 @@
 
 import json
 import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -126,6 +127,85 @@ def test_build_generate_only(dummy_tesseract_location, skip_checks):
             assert 'RUN ["tesseract-runtime", "check"]' not in docker_file_contents
         else:
             assert 'RUN ["tesseract-runtime", "check"]' in docker_file_contents
+
+
+def test_env_passthrough_run(
+    docker_cleanup, docker_client, dummy_image_name, dummy_tesseract_location
+):
+    """Ensure we can pass environment variables to tesseracts when running."""
+    image_name = build_tesseract(
+        docker_client,
+        dummy_tesseract_location,
+        dummy_image_name,
+    )
+    assert image_exists(docker_client, image_name)
+    docker_cleanup["images"].append(image_name)
+
+    result = subprocess.run(
+        [
+            "tesseract",
+            "run",
+            "--env=TEST_ENV_VAR=foo",
+            dummy_image_name,
+            "apply",
+            '{"inputs": {"a": [1, 2, 3], "b": [4, 5, 6]}}',
+        ],
+        capture_output=True,
+        cwd=dummy_tesseract_location,
+    )
+    assert result.returncode == 0, result.stderr.decode()
+    assert "TEST_ENV_VAR: foo" in result.stderr.decode()
+
+
+def test_env_passthrough_serve(
+    docker_cleanup, docker_client, dummy_image_name, dummy_tesseract_location
+):
+    """Ensure we can pass environment variables to tesseracts when serving."""
+    image_name = build_tesseract(
+        docker_client,
+        dummy_tesseract_location,
+        dummy_image_name,
+    )
+    assert image_exists(docker_client, image_name)
+    docker_cleanup["images"].append(image_name)
+
+    cli_runner = CliRunner(mix_stderr=False)
+    run_res = subprocess.run(
+        [
+            "tesseract",
+            "serve",
+            image_name,
+            "--env=TEST_ENV_VAR=foo",
+        ],
+        capture_output=True,
+        cwd=dummy_tesseract_location,
+        text=True,
+    )
+    assert run_res.returncode == 0, run_res.stderr
+    assert run_res.stdout
+
+    project_meta = json.loads(run_res.stdout)
+    project_id = project_meta["project_id"]
+    tesseract_id = project_meta["containers"][0]["name"]
+
+    # Send apply request to the served Tesseract
+    res = requests.post(
+        f"http://{project_meta['containers'][0]['ip']}:{project_meta['containers'][0]['port']}/apply",
+        json={"inputs": {"a": [1, 2, 3], "b": [4, 5, 6]}},
+    )
+    assert res.status_code == 200, res.text
+
+    # Check docker logs for the environment variable
+    logs = docker_client.containers.get(tesseract_id).logs().decode("utf-8")
+    assert "TEST_ENV_VAR: foo" in logs
+
+    # Teardown the project
+    run_res = cli_runner.invoke(
+        app,
+        ["teardown", project_id],
+        catch_exceptions=False,
+    )
+    assert run_res.exit_code == 0, run_res.stderr
 
 
 def test_tesseract_list(built_image_name):

--- a/tests/endtoend_tests/test_endtoend.py
+++ b/tests/endtoend_tests/test_endtoend.py
@@ -160,13 +160,10 @@ def test_env_passthrough_serve(
     project_id = project_meta["project_id"]
     tesseract_id = project_meta["containers"][0]["name"]
 
-    try:
-        container = docker_client.containers.get(tesseract_id)
-        exit_code, output = container.exec_run(["sh", "-c", "echo $TEST_ENV_VAR"])
-        assert exit_code == 0, f"Command failed with exit code {exit_code}"
-        assert "foo" in output.decode("utf-8"), f"Output was: {output.decode('utf-8')}"
-    except ContainerError as e:
-        pytest.fail(f"Failed to execute command in container: {e}")
+    container = docker_client.containers.get(tesseract_id)
+    exit_code, output = container.exec_run(["sh", "-c", "echo $TEST_ENV_VAR"])
+    assert exit_code == 0, f"Command failed with exit code {exit_code}"
+    assert "foo" in output.decode("utf-8"), f"Output was: {output.decode('utf-8')}"
 
     # Teardown the project
     run_res = cli_runner.invoke(

--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -116,6 +116,7 @@ def test_serve_lifecycle(mock_serving, mock_clients):
         ["sometesseract:0.2.3"],
         ports=None,
         volumes=None,
+        environment=None,
         gpus=None,
         debug=True,
         num_workers=1,


### PR DESCRIPTION
#### Relevant issue or PR

@johnbcoughlin extracted this from #229 . It's needed right away and requires less discussion, so makes sense to merge separately.

#### Description of changes
We allow passing user-defined env variables to docker (and docker-compose) on `tesseract run` and `tesseract serve`.

Example:

```
tesseract run --env=MLFLOW_TRACKING_URI="http://localhost:5001" helloworld apply '...'
```

Immediately relevant use case: Connecting tesseracts to user-hosted MLflow servers.

#### Testing done
Tested manually.