### PR TITLE
fix: tesseract-runtime default io paths

### DIFF
--- a/tesseract_core/runtime/config.py
+++ b/tesseract_core/runtime/config.py
@@ -15,8 +15,8 @@ class RuntimeConfig(BaseModel):
     name: str = "Tesseract"
     version: str = "0+unknown"
     debug: bool = False
-    input_path: str = "/tesseract/input_data"
-    output_path: str = "/tesseract/output_data"
+    input_path: str = "."
+    output_path: str = "."
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 

--- a/tesseract_core/sdk/templates/Dockerfile.base
+++ b/tesseract_core/sdk/templates/Dockerfile.base
@@ -98,6 +98,9 @@ RUN mkdir -p /tesseract/input_data /tesseract/output_data && \
 
 USER 1000:1000
 
+ENV TESSERACT_INPUT_PATH="/tesseract/input_data"
+ENV TESSERACT_OUTPUT_PATH="/tesseract/output_data"
+
 # Final sanity check to ensure the runtime is installed and tesseract_api.py is valid
 {% if not config.build_config.skip_checks %}
 RUN ["tesseract-runtime", "check"]


### PR DESCRIPTION
`tesseract-runtime` should always default to local paths (assume it's running non-containerized), which we overwrite in the Dockerfile for containerized use.