### PR TITLE
fix: add volume statements to dockerfile to ensure logs / metrics / data are always written to a volume

### DIFF
--- a/tesseract_core/sdk/templates/Dockerfile.base
+++ b/tesseract_core/sdk/templates/Dockerfile.base
@@ -95,6 +95,7 @@ RUN chmod 777 {{ target_path }}
 RUN mkdir -p /tesseract/input_data /tesseract/output_data && \
     chmod 755 /tesseract/input_data && \
     chmod 777 /tesseract/output_data
+VOLUME ["/tesseract/input_data", "/tesseract/output_data"]
 
 USER 1000:1000
 


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
Without this, logs / metrics / artifacts are written to the container filesystem if `--output-path` is not passed. This causes data to accumulate over time with no straightforward way to read it. By adding `VOLUME` to the Dockerfile we make sure there is always a Docker volume to write to, even if not specifically requested.

#### Testing done
none