### PR TITLE
feat: Add output to serve pipeline

### DIFF
--- a/tesseract_core/runtime/cli.py
+++ b/tesseract_core/runtime/cli.py
@@ -360,7 +360,8 @@ def _create_user_defined_cli_command(
                 type=click.STRING,
                 help=(
                     "Output path to write the result to, such as local directory or S3 URI "
-                    "(may be anything supported by fsspec). [default: write to stdout]"
+                    "(may be anything supported by fsspec). Use STDOUT to write to stdout."
+                    "[default: ./tesseract_output]"
                 ),
                 default=None,
             ),

--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -536,7 +536,16 @@ def serve(
                 "Input path to read input files from, such as local directory or S3 URI "
                 "(may be anything supported by fsspec)."
             ),
-            hidden=True,
+        ),
+    ] = None,
+    output_path: Annotated[
+        str | None,
+        typer.Option(
+            "--output-path",
+            help=(
+                "Output path to write output files to, such as local directory or S3 URI "
+                "(may be anything supported by fsspec)."
+            ),
         ),
     ] = None,
 ) -> None:
@@ -600,6 +609,7 @@ def serve(
             service_names_list,
             user,
             input_path=input_path,
+            output_path=output_path,
         )
     except RuntimeError as ex:
         raise UserError(

--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -544,7 +544,8 @@ def serve(
             "--output-path",
             help=(
                 "Output path to write output files to, such as local directory or S3 URI "
-                "(may be anything supported by fsspec)."
+                "(may be anything supported by fsspec). Use STDOUT to write to stdout."
+                "[default: ./tesseract_output]"
             ),
         ),
     ] = None,

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -968,7 +968,7 @@ def run_tesseract(
         user = f"{os.getuid()}:{os.getgid()}" if os.name != "nt" else None
 
     # Default output path behavior if not specified
-    if "--output-path" not in args:
+    if "--output-path" not in args and "-o" not in args:
         args.append("--output-path")
         output_path = str(Path(os.getcwd()) / "tesseract_output")
         args.append(output_path)

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -619,7 +619,8 @@ def serve(
         # Make a directory in cwd called /tesseract_output
         output_path.mkdir(exist_ok=True)
         logger.info(
-            "`--output-path` not specified. Writing output to current directory `tesseract_output`..."
+            "`--output-path` not specified. Writing output to current directory: %s",
+            output_path,
         )
 
     if environment is None:
@@ -966,8 +967,12 @@ def run_tesseract(
     # Default output path behavior if not specified
     if "--output-path" not in args:
         cmd.append("--output-path")
-        cmd.append(str(Path(os.getcwd()) / "tesseract_output"))
-        logger.info("`--output-path` not specified, writing to current directory.")
+        output_path = str(Path(os.getcwd()) / "tesseract_output")
+        cmd.append(output_path)
+        logger.info(
+            "`--output-path` not specified, writing to current directory: %s",
+            output_path,
+        )
 
     for arg in args:
         if arg.startswith("-"):

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -630,7 +630,10 @@ def serve(
         volumes = []
     if "://" not in str(output_path):
         # Process output path separately in docker compose template
-        output_path = Path(output_path).resolve()
+        if "STDOUT" in str(output_path):
+            output_path = None
+        else:
+            output_path = Path(output_path).resolve()
 
     if input_path:
         environment["TESSERACT_INPUT_PATH"] = "/tesseract/input_data"
@@ -982,6 +985,11 @@ def run_tesseract(
 
         # Mount local output directories into Docker container as a volume
         if current_cmd in output_args and "://" not in arg:
+            if "STDOUT" in arg:
+                # Pop out the last arg (--output-path) in cmd
+                cmd.pop()
+                continue
+
             if arg.startswith("@"):
                 raise ValueError(
                     f"Output path {arg} cannot start with '@' (used only for input files)"

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -817,10 +817,15 @@ def _create_docker_compose_template(
 
     for i, image_id in enumerate(image_ids):
         # Write each Tesseract's output to a separate output directory
-        temp_parsed_volumes = parsed_volumes.copy()
-        source = f"{output_path}/{service_names[i]}"
-        Path(source).mkdir(exist_ok=True)
-        temp_parsed_volumes[source] = {"bind": "/tesseract/output_data", "mode": "rw"}
+        temp_parsed_volumes = parsed_volumes
+        if output_path != "None":
+            temp_parsed_volumes = parsed_volumes.copy()
+            source = f"{output_path}/{service_names[i]}"
+            Path(source).mkdir(exist_ok=True)
+            temp_parsed_volumes[source] = {
+                "bind": "/tesseract/output_data",
+                "mode": "rw",
+            }
         service = {
             "name": service_names[i],
             "user": user,

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -966,9 +966,9 @@ def run_tesseract(
 
     # Default output path behavior if not specified
     if "--output-path" not in args:
-        cmd.append("--output-path")
+        args.append("--output-path")
         output_path = str(Path(os.getcwd()) / "tesseract_output")
-        cmd.append(output_path)
+        args.append(output_path)
         logger.info(
             "`--output-path` not specified, writing to current directory: %s",
             output_path,

--- a/tests/endtoend_tests/test_endtoend.py
+++ b/tests/endtoend_tests/test_endtoend.py
@@ -614,6 +614,8 @@ def test_tesseract_serve_multiple_outputs(
     if default_output_path:
         output_args = []
         output_dir = Path(os.getcwd()) / "tesseract_output"
+        output_dir.mkdir(exist_ok=True)
+        output_dir.chmod(0o777)
     else:
         output_args = ["--output-path", str(tmp_path)]
         output_dir = tmp_path

--- a/tests/endtoend_tests/test_endtoend.py
+++ b/tests/endtoend_tests/test_endtoend.py
@@ -596,7 +596,7 @@ def test_tesseract_serve_volume_permissions(
         assert (tmp_path / "bar").exists()
 
 
-@pytest.mark.parametrize("default_output_path", [False])
+@pytest.mark.parametrize("default_output_path", [True, False])
 def test_tesseract_serve_multiple_outputs(
     built_image_name,
     docker_client,

--- a/tests/endtoend_tests/test_endtoend.py
+++ b/tests/endtoend_tests/test_endtoend.py
@@ -7,7 +7,6 @@ import json
 import os
 import subprocess
 from pathlib import Path
-from shutil import rmtree
 
 import pytest
 import requests
@@ -596,7 +595,6 @@ def test_tesseract_serve_volume_permissions(
         assert (tmp_path / "bar").exists()
 
 
-@pytest.mark.parametrize("default_output_path", [True, False])
 def test_tesseract_serve_multiple_outputs(
     built_image_name,
     docker_client,
@@ -611,15 +609,9 @@ def test_tesseract_serve_multiple_outputs(
     cli_runner = CliRunner(mix_stderr=False)
     project_id = None
 
-    if default_output_path:
-        output_args = []
-        output_dir = Path(os.getcwd()) / "tesseract_output"
-        output_dir.mkdir(exist_ok=True)
-        output_dir.chmod(0o777)
-    else:
-        output_args = ["--output-path", str(tmp_path)]
-        output_dir = tmp_path
-        tmp_path.chmod(0o777)
+    output_args = ["--output-path", str(tmp_path)]
+    output_dir = tmp_path
+    tmp_path.chmod(0o777)
 
     run_res = cli_runner.invoke(
         app,
@@ -665,10 +657,6 @@ def test_tesseract_serve_multiple_outputs(
     assert (output_dir / "tess-1" / "test_0.txt").exists()
     assert (output_dir / "tess-2" / "test_1.txt").exists()
     assert (output_dir / "tess-3" / "test_2.txt").exists()
-
-    if default_output_path:
-        # Remove the tesseract_output directory
-        rmtree(output_dir)
 
 
 def test_tesseract_serve_interop(built_image_name, docker_client, docker_cleanup):

--- a/tests/endtoend_tests/test_endtoend.py
+++ b/tests/endtoend_tests/test_endtoend.py
@@ -211,6 +211,8 @@ def test_tesseract_run_stdout(built_image_name):
                 "run",
                 built_image_name,
                 command,
+                "--output-path",
+                "STDOUT",
             ],
             catch_exceptions=False,
         )
@@ -532,6 +534,8 @@ def test_tesseract_serve_volume_permissions(
             "--volume",
             f"{volume_to_bind}:{dest}:rw",
             *(("--user", user) if user else []),
+            "--output-path",
+            "STDOUT",
             built_image_name,
             *(("--no-compose",) if no_compose else [built_image_name]),
         ],

--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -860,6 +860,7 @@ def test_unit_tesseract_endtoend(
     from tesseract_core.sdk.cli import app
 
     cli_runner = CliRunner(mix_stderr=False)
+    tmpdir.chmod(0o777)
 
     # Stage 1: Build
     img_name = build_tesseract(
@@ -878,6 +879,8 @@ def test_unit_tesseract_endtoend(
             "run",
             img_name,
             "input-schema",
+            "--output-path",
+            str(tmpdir),
         ],
         catch_exceptions=False,
     )

--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -949,6 +949,8 @@ def test_unit_tesseract_endtoend(
                     img_name,
                     cli_cmd,
                     json.dumps(request.payload),
+                    "--output-path",
+                    "STDOUT",
                 ]
             else:
                 args = [

--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -854,6 +854,7 @@ def test_unit_tesseract_endtoend(
     unit_tesseract_config,
     free_port,
     docker_cleanup,
+    tmpdir,
 ):
     """Test that unit Tesseract images can be built and used to serve REST API."""
     from tesseract_core.sdk.cli import app
@@ -907,6 +908,14 @@ def test_unit_tesseract_endtoend(
             [
                 "--output-path",
                 str(unit_tesseract_path / unit_tesseract_config.output_path),
+            ]
+        )
+    else:
+        # Override default output path behavior to prevent permission issues
+        io_args.extend(
+            [
+                "--output-path",
+                str(tmpdir),
             ]
         )
 

--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -878,9 +878,9 @@ def test_unit_tesseract_endtoend(
         [
             "run",
             img_name,
-            "input-schema",
             "--output-path",
             str(tmpdir),
+            "input-schema",
         ],
         catch_exceptions=False,
     )

--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -880,7 +880,7 @@ def test_unit_tesseract_endtoend(
             img_name,
             "input-schema",
             "--output-path",
-            str(tmpdir),
+            "STDOUT",
         ],
         catch_exceptions=False,
     )
@@ -918,7 +918,7 @@ def test_unit_tesseract_endtoend(
         io_args.extend(
             [
                 "--output-path",
-                str(tmpdir),
+                "STDOUT",
             ]
         )
 

--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -878,9 +878,9 @@ def test_unit_tesseract_endtoend(
         [
             "run",
             img_name,
+            "input-schema",
             "--output-path",
             str(tmpdir),
-            "input-schema",
         ],
         catch_exceptions=False,
     )

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -161,12 +161,12 @@ def test_run_gpu(mocked_docker):
 def test_run_tesseract_file_input(mocked_docker, tmpdir, default_output_path):
     """Test running a tesseract with file input / output."""
     if not default_output_path:
-        outdir = Path(tmpdir) / "output"
+        outdir = Path(tmpdir) / "tesseract_output"
         outdir.mkdir()
         output_args = ["--output-path", str(outdir)]
     else:
         output_args = []
-        outdir = str(Path(os.getcwd()) / "tesseract_output")
+        outdir = Path(os.getcwd()) / "tesseract_output"
 
     infile = Path(tmpdir) / "input.json"
     infile.touch()
@@ -181,9 +181,9 @@ def test_run_tesseract_file_input(mocked_docker, tmpdir, default_output_path):
     res = json.loads(res)
     assert res["command"] == [
         "apply",
+        "@/tesseract/payload.json",
         "--output-path",
         "/tesseract/output_data",
-        "@/tesseract/payload.json",
     ]
     assert res["image"] == "foobar"
     assert res["volumes"].keys() == {str(infile), str(outdir)}

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -181,9 +181,9 @@ def test_run_tesseract_file_input(mocked_docker, tmpdir, default_output_path):
     res = json.loads(res)
     assert res["command"] == [
         "apply",
-        "@/tesseract/payload.json",
         "--output-path",
         "/tesseract/output_data",
+        "@/tesseract/payload.json",
     ]
     assert res["image"] == "foobar"
     assert res["volumes"].keys() == {str(infile), str(outdir)}

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -131,9 +131,9 @@ def test_run_tesseract(mocked_docker):
     res = json.loads(res_out)
     assert res["command"] == [
         "apply",
-        '{"inputs": {"a": [1, 2, 3], "b": [4, 5, 6]}}',
         "--output-path",
         str(Path(os.getcwd()) / "tesseract_output"),
+        '{"inputs": {"a": [1, 2, 3], "b": [4, 5, 6]}}',
     ]
     assert res["image"] == "foobar"
 
@@ -157,9 +157,7 @@ def test_run_gpu(mocked_docker):
     assert res["device_requests"] == ["all"]
 
 
-pytest.mark.parametrize("default_output_path", [True, False])
-
-
+@pytest.mark.parametrize("default_output_path", [True, False])
 def test_run_tesseract_file_input(mocked_docker, tmpdir, default_output_path):
     """Test running a tesseract with file input / output."""
     if not default_output_path:

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -131,9 +131,9 @@ def test_run_tesseract(mocked_docker):
     res = json.loads(res_out)
     assert res["command"] == [
         "apply",
-        "--output-path",
-        str(Path(os.getcwd()) / "tesseract_output"),
         '{"inputs": {"a": [1, 2, 3], "b": [4, 5, 6]}}',
+        "--output-path",
+        "/tesseract/output_data",
     ]
     assert res["image"] == "foobar"
 

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -133,7 +133,7 @@ def test_run_tesseract(mocked_docker):
         "apply",
         '{"inputs": {"a": [1, 2, 3], "b": [4, 5, 6]}}',
         "--output-path",
-        Path(os.getcwd()) / "tesseract_output",
+        str(Path(os.getcwd()) / "tesseract_output"),
     ]
     assert res["image"] == "foobar"
 
@@ -168,7 +168,7 @@ def test_run_tesseract_file_input(mocked_docker, tmpdir, default_output_path):
         output_args = ["--output-path", str(outdir)]
     else:
         output_args = []
-        outdir = "."
+        outdir = str(Path(os.getcwd()) / "tesseract_output")
 
     infile = Path(tmpdir) / "input.json"
     infile.touch()


### PR DESCRIPTION
#### Description of changes
- Added `output-path` to serve pipeline
```
# Default creates output directory in current directory under service names (image-id if not specified)
$ tesseract serve helloworld vectoradd --service-names "helloworld,vectoradd"
$ ls tesseract_output
helloworld/           vectoradd/
$ tesseract serve helloworld vectoradd --output-path "/foo" --service-names "helloworld,vectoradd"
```
- Added default `output-path` to `tesseract run` 
- Added option to pass in `STDOUT` as an `output-path` 

#### Testing done
Unit Testing
