### PR TITLE
feat: Add network argument to `tesseract serve`

### DIFF
--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -454,6 +454,16 @@ def serve(
             callback=_validate_port,
         ),
     ] = None,
+    network: Annotated[
+        str | None,
+        typer.Option(
+            "--network",
+            help="Network to use for the Tesseract container, analogous to Docker's --network option. "
+            "For example, 'host' uses the host system's network. Alternatively, you can create a custom "
+            "network with `docker network create <network-name>` and use it here.",
+            show_default=False,
+        ),
+    ] = None,
     host_ip: Annotated[
         str,
         typer.Option(
@@ -591,6 +601,7 @@ def serve(
             image_names,
             host_ip,
             ports,
+            network,
             volume,
             environment,
             gpus,

--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -706,6 +706,19 @@ def _find_tesseract_project(
     return tesseract.name
 
 
+def _get_tesseract_network_meta(container: Container) -> dict:
+    """Retrieve network addresses from container."""
+    network_meta = {}
+    networks = container.attrs["NetworkSettings"]["Networks"]
+    for network_name, network_info in networks.items():
+        network_meta[network_name] = {
+            "ip": f"{network_info['IPAddress']}",
+            "port": 8000,
+        }
+
+    return network_meta
+
+
 @app.command("apidoc")
 @engine.needs_docker
 def apidoc(
@@ -759,8 +772,14 @@ def _display_project_meta(project_id: str) -> list:
         host_port = container.host_port
         host_ip = container.host_ip
         logger.info(f"View Tesseract: http://{host_ip}:{host_port}/docs")
+        network_meta = _get_tesseract_network_meta(container)
         container_ports.append(
-            {"name": container.name, "port": host_port, "ip": host_ip}
+            {
+                "name": container.name,
+                "port": host_port,
+                "ip": host_ip,
+                "networks": network_meta,
+            }
         )
         if container.host_debugpy_port:
             logger.info(

--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -709,13 +709,12 @@ def _find_tesseract_project(
 def _get_tesseract_network_meta(container: Container) -> dict:
     """Retrieve network addresses from container."""
     network_meta = {}
-    networks = container.attrs["NetworkSettings"]["Networks"]
+    networks = container.attrs["NetworkSettings"].get("Networks", {})
     for network_name, network_info in networks.items():
         network_meta[network_name] = {
             "ip": f"{network_info['IPAddress']}",
             "port": 8000,
         }
-
     return network_meta
 
 

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -569,7 +569,7 @@ def serve(
         images: a list of Tesseract image IDs as strings.
         host_ip: IP address to bind the Tesseracts to.
         ports: port or port range to serve each Tesseract on.
-        network: network to which the Tesseract will be attached to.
+        network: name of the network the Tesseract will be attached to.
         volumes: list of paths to mount in the Tesseract container.
         environment: dictionary of environment variables to pass to the Tesseract.
         gpus: IDs of host Nvidia GPUs to make available to the Tesseracts.

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -550,6 +550,7 @@ def serve(
     images: list[str],
     host_ip: str = "127.0.0.1",
     ports: list[str] | None = None,
+    network: str | None = None,
     volumes: list[str] | None = None,
     environment: dict[str, str] | None = None,
     gpus: list[str] | None = None,
@@ -568,6 +569,7 @@ def serve(
         images: a list of Tesseract image IDs as strings.
         host_ip: IP address to bind the Tesseracts to.
         ports: port or port range to serve each Tesseract on.
+        network: network to which the Tesseract will be attached to.
         volumes: list of paths to mount in the Tesseract container.
         environment: dictionary of environment variables to pass to the Tesseract.
         gpus: IDs of host Nvidia GPUs to make available to the Tesseracts.
@@ -674,6 +676,7 @@ def serve(
             command=["serve", *args],
             device_requests=gpus,
             ports=port_mappings,
+            network=network,
             detach=True,
             volumes=parsed_volumes,
             user=user,


### PR DESCRIPTION
#### Relevant issue or PR
The `network` argument was implemented in `tesseract run` but not `tesseract serve`

#### Description of changes
Added `network` arg and piped it to docker
