### PR TITLE
fix: move private pip imports into relevant func scope

### DIFF
--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -159,6 +159,8 @@ def parse_requirements(
     All CLI options that may be part of the given requiremets file are included in
     the remote dependencies.
     """
+    # pip internals monkeypatch some typing behavior at import time, so we delay
+    # these imports as much as possible to avoid conflicts.
     from pip._internal.network.session import PipSession
     from pip._internal.req.req_file import (
         RequirementsFileParser,


### PR DESCRIPTION
<!--
Please use a PR title that conforms to *conventional commits*: "<commit_type>: Describe your change"; for example: "fix: prevent race condition". Some other commit types are: fix, feat, ci, doc, refactor...
For a full list of commit types visit https://www.conventionalcommits.org/en/v1.0.0/
-->

#### Relevant issue or PR

[Related to Tesseract Streamlit #33](https://github.com/pasteurlabs/tesseract-streamlit/pull/33).

#### Description of changes

Private namespace imports from pip were causing errors on import with Streamlit's testing module. These imports have now been moved to occur during type checking, or within the function body where they are needed. This ought to prevent errors at import time, preventing the issue.

#### Testing done
<!-- Describe how the changes were tested; e.g., "CI passes", "Tested manually in stagingrepo#123", screenshots of a terminal session that verify the changes, or any other evidence of testing the changes. -->
