### PR TITLE
feat: improve healthcheck after serve, add restart policy

### DIFF
--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -3,7 +3,6 @@
 
 """Docker client for Tesseract usage."""
 
-# store a reference to the list type, which is shadowed by some function names below
 import json
 import logging
 import os
@@ -12,6 +11,8 @@ import shlex
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+
+# store a reference to the list type, which is shadowed by some function names below
 from typing import List as list_  # noqa: UP035
 
 from tesseract_core.sdk.config import get_config

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -608,15 +608,16 @@ def serve(
         port_mappings[f"{host_ip}:{debugpy_port}"] = container_debugpy_port
         environment["TESSERACT_DEBUG"] = "1"
 
-    logger.info(f"Serving Tesseract at http://{ping_ip}:{port}")
-    logger.info(f"View Tesseract: http://{ping_ip}:{port}/docs")
-    if debug:
-        logger.info(f"Debugpy server listening at http://{ping_ip}:{debugpy_port}")
-
     parsed_volumes = _parse_volumes(volumes) if volumes else {}
 
-    extra_args = []
+    extra_args = [
+        "--restart",
+        "unless-stopped",
+    ]
+
     if is_podman():
+        # This ensures podman behaves like Docker in terms of user namespaces
+        # and allows the container to run with the same user ID as the host.
         extra_args.extend(["--userns", "keep-id"])
 
     container = docker_client.containers.run(
@@ -631,6 +632,9 @@ def serve(
         environment=environment,
         extra_args=extra_args,
     )
+    assert isinstance(container, Container)
+
+    logger.info("Waiting for Tesseract to start...")
     # wait for server to start
     timeout = 30
     while True:
@@ -645,8 +649,32 @@ def serve(
         time.sleep(0.1)
         timeout -= 0.1
 
-        if timeout < 0:
-            raise TimeoutError("Tesseract did not start in time")
+        container_status = docker_client.containers.get(container.id).status
+
+        if timeout < 0 or container_status != "running":
+            try:
+                container_logs = container.logs(stdout=True, stderr=True)
+                logger.error(
+                    f"Tesseract container {container.name} failed to start:\n{container_logs.decode()}"
+                )
+            except APIError as ex:
+                logger.warning(
+                    f"Failed to get logs for container {container.name}: {ex}"
+                )
+            try:
+                container.stop()
+            except APIError as ex:
+                logger.warning(f"Failed to stop container {container.name}: {ex}")
+
+            if timeout < 0:
+                raise TimeoutError("Tesseract did not start in time")
+            else:
+                raise RuntimeError("Tesseract failed to start")
+
+    logger.info(f"Serving Tesseract at http://{ping_ip}:{port}")
+    logger.info(f"View Tesseract: http://{ping_ip}:{port}/docs")
+    if debug:
+        logger.info(f"Debugpy server listening at http://{ping_ip}:{debugpy_port}")
 
     return container.name, container
 


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
- Add functionality to restart containers if they exit unexpectedly (same as we did with `docker-compose`).
- Distinguish between a container failing to start and taking too long to start.
- Improve error messages.
- Call `get_config()` in every function of the Docker client instead of at import time (config may change during runtime).

#### Testing done
manual