### PR TITLE
fix: Correct error message on use of T created via from_image

### DIFF
--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -42,7 +42,8 @@ def requires_client(func: Callable) -> Callable:
     def wrapper(self: Tesseract, *args: Any, **kwargs: Any) -> Any:
         if not self._client:
             raise RuntimeError(
-                f"{self.__class__.__name__} must be used as a context manager when created via `from_image`."
+                f"When creating a {self.__class__.__name__} via `from_image`, "
+                "you must either use it as a context manager or call .serve() before use."
             )
         return func(self, *args, **kwargs)
 


### PR DESCRIPTION
#### Description of changes
We now support running Tesseracts via `from_image` without context manager, by explicitly spinning the Tesseract up on `.serve()` instead.
The error message still conveyed that context managers are the only option.

#### Testing done
Local testing