### PR TITLE
feat: add network args to from_image

### DIFF
--- a/examples/_multi-tesseract/multi_helloworld/README.md
+++ b/examples/_multi-tesseract/multi_helloworld/README.md
@@ -9,6 +9,14 @@ $ tesseract build ./examples/helloworld
 $ tesseract build ./examples/_multi-tesseract/multi-helloworld
 ```
 
+### Create Network
+
+Next, we create a network by running:
+
+```bash
+$ docker network create my_network
+```
+
 ## Python SDK Instructions
 
 This example can be executed using the Tesseract Python SDK or CLI. To run the example using the Python SDK, simply execute the Python script:
@@ -20,26 +28,15 @@ $ python run_example.py
 
 ## CLI Instructions
 
-### 1. Create Network (optional)
-
-We can create a network by running:
-
-```bash
-$ docker network create my_network
-```
-
-If you choose not to create a network, you can omit the `--network` argument in the following commands. The Tesseracts will be automatically connected to a network named `bridge`.
-
-
-### 2. Serve `helloworld` Tesseract
+### Serve `helloworld` Tesseract
 
 To serve the Tesseract, run:
 
 ```bash
-$ tesseract serve "helloworld:latest" --network my_network
+$ tesseract serve "helloworld:latest" --network my_network --network-alias helloworld
 ```
 
-This command will print relevant container metadata to `stdout`. Importantly, the container metadata tells us the Tesseract's IP address for each network it is connected to. In our case, the helloworld Tesseract is connected to `my_network` (or `bridge` if no network was created) and is reachable at `172.19.0.2:8000`.
+This command will print relevant container metadata to `stdout`. Importantly, the container metadata tells us the Tesseract's IP address for each network it is connected to. In our case, the helloworld Tesseract is connected to `my_network` and is reachable at `172.19.0.2:8000`. The `network-alias` argument allows us to create more human-readable addresses, in this example `--network-alias helloworld` also makes the Tesseract available at `http://helloworld:8000`.
 
 ```
  [i] Serving Tesseract at http://127.0.0.1:53385
@@ -52,15 +49,15 @@ This command will print relevant container metadata to `stdout`. Importantly, th
 {"project_id": "recursing_kirch", "containers": [{"name": "recursing_kirch", "port": "53385", "ip": "127.0.0.1", "networks": {"my_network": {"ip": "172.19.0.2", "port": 8000}}}]}%
 ```
 
-### 3. Run `multi-helloworld` Tesseract
+### Run `multi-helloworld` Tesseract
 
 With the helloworld Tesseract served, we can now run the multi-helloworld Tesseract:
 
 ```bash
-$ tesseract run "multi-helloworld:latest" apply '{"inputs": {"helloworld_tesseract_url": "172.19.0.2:8000" , "name": "YOU"}}' --network my_network
+$ tesseract run "multi-helloworld:latest" apply '{"inputs": {"helloworld_tesseract_url": "http://helloworld:8000" , "name": "YOU"}}' --network my_network
 ```
 
-### 4. Teardown
+### Teardown
 
 Finally, we tear down the helloworld tesseract using the container name from the metadata returned by the serve command (or by running `tesseract ps`):
 

--- a/examples/_multi-tesseract/multi_helloworld/run_example.py
+++ b/examples/_multi-tesseract/multi_helloworld/run_example.py
@@ -1,15 +1,11 @@
-import tesseract_core.sdk.docker_client as docker_client
 from tesseract_core import Tesseract
 
-with Tesseract.from_image("multi-helloworld:latest") as multi_helloworld_tess:
-    with Tesseract.from_image("helloworld:latest") as helloworld_tess:
-        helloworld_container = docker_client.Containers.get(
-            helloworld_tess._serve_context["container_name"]
-        )
-        helloworld_url = f"{helloworld_container.attrs['NetworkSettings']['Networks']['bridge']['IPAddress']}:8000"
-        payload = {
-            "name": "YOU",
-            "helloworld_tesseract_url": helloworld_url,
-        }
+with Tesseract.from_image(
+    "multi-helloworld:latest", network="my_network", network_alias="multi-helloworld"
+) as multi_helloworld_tess:
+    with Tesseract.from_image(
+        "helloworld:latest", network="my_network", network_alias="helloworld"
+    ) as helloworld_tess:
+        payload = {"name": "YOU", "helloworld_tesseract_url": "http://helloworld:8000"}
         result = multi_helloworld_tess.apply(inputs=payload)
         print(result["greeting"])

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -32,6 +32,8 @@ class SpawnConfig:
     environment: dict[str, str] | None
     gpus: list[str] | None
     num_workers: int
+    network: str | None
+    network_alias: str | None
     debug: bool
 
 
@@ -92,6 +94,8 @@ class Tesseract:
         output_path: PathLike | None = None,
         gpus: list[str] | None = None,
         num_workers: int = 1,
+        network: str | None = None,
+        network_alias: str | None = None,
     ) -> Tesseract:
         """Create a Tesseract instance from a Docker image.
 
@@ -120,6 +124,8 @@ class Tesseract:
             num_workers: Number of worker processes to use. This determines how
                 many requests can be handled in parallel. Higher values
                 will increase throughput, but also increase resource usage.
+            network: Name of the Docker network to connect the Tesseract to.
+            network_alias: Alias for the Tesseract in the Docker network.
 
         Returns:
             A Tesseract instance.
@@ -143,6 +149,8 @@ class Tesseract:
             environment=environment,
             gpus=gpus,
             num_workers=num_workers,
+            network=network,
+            network_alias=network_alias,
             debug=True,
         )
         obj._serve_context = None
@@ -262,12 +270,16 @@ class Tesseract:
             environment=self._spawn_config.environment,
             gpus=self._spawn_config.gpus,
             num_workers=self._spawn_config.num_workers,
+            network=self._spawn_config.network,
+            network_alias=self._spawn_config.network_alias,
             debug=self._spawn_config.debug,
             host_ip=host_ip,
         )
         self._serve_context = dict(
             container_name=container_name,
             port=container.host_port,
+            network=self._spawn_config.network,
+            network_alias=self._spawn_config.network_alias,
         )
         self._lastlog = None
         self._client = HTTPClient(f"http://{host_ip}:{container.host_port}")

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -234,7 +234,7 @@ class Tesseract:
         This will stop the Tesseract server if it is running.
         """
         if self._serve_context is None:
-            # This can happen if __enter__ short-cirtuits
+            # This can happen if __enter__ short-circuits
             return
         self.teardown()
 
@@ -309,7 +309,7 @@ class Tesseract:
     @cached_property
     @requires_client
     def openapi_schema(self) -> dict:
-        """Get the OpenAPI schema of this Tessseract.
+        """Get the OpenAPI schema of this Tesseract.
 
         Returns:
             dictionary with the OpenAPI Schema.
@@ -319,7 +319,7 @@ class Tesseract:
     @cached_property
     @requires_client
     def input_schema(self) -> dict:
-        """Get the input schema of this Tessseract.
+        """Get the input schema of this Tesseract.
 
         Returns:
              dictionary with the input schema.
@@ -329,7 +329,7 @@ class Tesseract:
     @cached_property
     @requires_client
     def output_schema(self) -> dict:
-        """Get the output schema of this Tessseract.
+        """Get the output schema of this Tesseract.
 
         Returns:
              dictionary with the output schema.

--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -1135,22 +1135,18 @@ def test_multi_helloworld_endtoend(
             helloworld_tesseract_img_name,
             "--network",
             dummy_network_name,
+            "--network-alias",
+            "helloworld",
         ],
         catch_exceptions=True,
     )
     assert result.exit_code == 0, result.output
-    container_meta = json.loads(result.stdout)
-    docker_cleanup["containers"].append(container_meta["container_name"])
-    helloworld_tesseract_url = (
-        f"{container_meta['containers']['networks'][dummy_network_name]['ip']}:"
-        f"{container_meta['containers']['networks'][dummy_network_name]['port']}"
-    )
 
     payload = json.dumps(
         {
             "inputs": {
                 "name": "you",
-                "helloworld_tesseract_url": helloworld_tesseract_url,
+                "helloworld_tesseract_url": "http://helloworld:8000",
             }
         }
     )

--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -116,6 +116,8 @@ def test_serve_lifecycle(mock_serving, mock_clients):
         gpus=None,
         debug=True,
         num_workers=1,
+        network=None,
+        network_alias=None,
         host_ip="127.0.0.1",
     )
 


### PR DESCRIPTION
#### Description of changes
- Added network arguments to `from_image` method of `tesseract_core.sdk.tesseract.Tesseract`
- Updated "multi-helloworld" examples to make use of network aliases
- Fixed a couple of typos in `tesseract_core.sdk.tesseract`

#### Testing done
- Local testing of example CLI and SDK instructions
- "multi-helloworld" e2e test passes