### PR TITLE
feat!: remove `--forward-ssh-agent` option

### DIFF
--- a/demo/data-assimilation-4dvar/lorenz_tesseract/tesseract_requirements.txt
+++ b/demo/data-assimilation-4dvar/lorenz_tesseract/tesseract_requirements.txt
@@ -5,6 +5,3 @@
 numpy==1.26.0
 jax[cpu]==0.5.2
 equinox
-# This may contain private dependencies via SSH URLs:
-# git+ssh://git@github.com/username/repo.git@branch
-# (use `tesseract build --forward-ssh-agent` to grant the builder access to your SSH keys)

--- a/docs/content/creating-tesseracts/advanced.md
+++ b/docs/content/creating-tesseracts/advanced.md
@@ -93,11 +93,7 @@ various circumstances:
 
 ## Building Tesseracts with private dependencies
 
-In case you have some dependencies in `tesseract_requirements.txt` for which you need to
-ssh into a server (e.g., private repositories which you specify via "git+ssh://..."),
-you can make your ssh agent available to `tesseract build` with the option
-`--forward-ssh-agent`. Alternatively you can use `pip download` to download a dependency
-to the machine that builds the Tesseract.
+In case you have some dependencies in `tesseract_requirements.txt` that are not accessible to the public (e.g., private GitHub repositories or PyPI registries), you can use `pip download`
 
 ## Customizing the build process
 

--- a/examples/cuda/tesseract_requirements.txt
+++ b/examples/cuda/tesseract_requirements.txt
@@ -3,7 +3,3 @@
 
 # Add Python requirements like this:
 # numpy==1.18.1
-
-# This may contain private dependencies via SSH URLs:
-# git+ssh://git@github.com/username/repo.git@branch
-# (use `tesseract build --forward-ssh-agent` to grant the builder access to your SSH keys)

--- a/tesseract_core/runtime/core.py
+++ b/tesseract_core/runtime/core.py
@@ -224,18 +224,6 @@ def create_endpoints(api_module: ModuleType) -> list[Callable]:
 
     endpoints.append(health)
 
-    def input_schema() -> dict[str, Any]:
-        """Get input schema for tesseract apply function."""
-        return ApplyInputSchema.model_json_schema()
-
-    endpoints.append(input_schema)
-
-    def output_schema() -> dict[str, Any]:
-        """Get output schema for tesseract apply function."""
-        return ApplyOutputSchema.model_json_schema()
-
-    endpoints.append(output_schema)
-
     if "abstract_eval" in supported_functions:
         AbstractEvalInputSchema, AbstractEvalOutputSchema = create_abstract_eval_schema(
             api_module.InputSchema, api_module.OutputSchema

--- a/tesseract_core/runtime/core.py
+++ b/tesseract_core/runtime/core.py
@@ -224,6 +224,18 @@ def create_endpoints(api_module: ModuleType) -> list[Callable]:
 
     endpoints.append(health)
 
+    def input_schema() -> dict[str, Any]:
+        """Get input schema for tesseract apply function."""
+        return ApplyInputSchema.model_json_schema()
+
+    endpoints.append(input_schema)
+
+    def output_schema() -> dict[str, Any]:
+        """Get output schema for tesseract apply function."""
+        return ApplyOutputSchema.model_json_schema()
+
+    endpoints.append(output_schema)
+
     if "abstract_eval" in supported_functions:
         AbstractEvalInputSchema, AbstractEvalOutputSchema = create_abstract_eval_schema(
             api_module.InputSchema, api_module.OutputSchema

--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -263,15 +263,6 @@ def build_image(
             writable=True,
         ),
     ] = None,
-    forward_ssh_agent: Annotated[
-        bool,
-        typer.Option(
-            help=(
-                "Forward the SSH agent to the Docker build environment. "
-                "Has to be provided if requirements.txt contains private dependencies."
-            ),
-        ),
-    ] = False,
     config_override: Annotated[
         list[str] | None,
         typer.Option(
@@ -321,7 +312,6 @@ def build_image(
                 src_dir,
                 tag,
                 build_dir=build_dir,
-                inject_ssh=forward_ssh_agent,
                 config_override=parsed_config_override,
                 generate_only=generate_only,
             )

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -209,7 +209,6 @@ def prepare_build_context(
     src_dir: str | Path,
     context_dir: str | Path,
     user_config: TesseractConfig,
-    use_ssh_mount: bool = False,
 ) -> Path:
     """Populate the build context for a Tesseract.
 
@@ -232,7 +231,6 @@ def prepare_build_context(
         src_dir: The source directory where the Tesseract project is located.
         context_dir: The directory where the build context will be created.
         user_config: The Tesseract configuration object.
-        use_ssh_mount: Whether to use SSH mount to install dependencies (prevents caching).
 
     Returns:
         The path to the build context directory.
@@ -250,7 +248,6 @@ def prepare_build_context(
         "tesseract_source_directory": "__tesseract_source__",
         "tesseract_runtime_location": "__tesseract_runtime__",
         "config": user_config,
-        "use_ssh_mount": use_ssh_mount,
     }
 
     logger.debug(f"Generating Dockerfile from template: {template_name}")
@@ -376,7 +373,6 @@ def build_tesseract(
     src_dir: str | Path,
     image_tag: str | None,
     build_dir: Path | None = None,
-    inject_ssh: bool = False,
     config_override: dict[tuple[str, ...], Any] | None = None,
     generate_only: bool = False,
 ) -> Image | Path:
@@ -389,7 +385,6 @@ def build_tesseract(
         image_tag: name to be used as a tag for the Tesseract image.
         build_dir: directory to be used to store the build context.
           If not provided, a temporary directory will be created.
-        inject_ssh: whether or not to forward SSH agent when building the image.
         config_override: overrides for configuration options in the Tesseract.
         generate_only: only generate the build context but do not build the image.
 
@@ -430,7 +425,9 @@ def build_tesseract(
         keep_build_dir = True
 
     context_dir = prepare_build_context(
-        src_dir, build_dir, config, use_ssh_mount=inject_ssh
+        src_dir,
+        build_dir,
+        config,
     )
 
     if generate_only:
@@ -443,7 +440,6 @@ def build_tesseract(
             path=context_dir.as_posix(),
             tags=tags,
             dockerfile=context_dir / "Dockerfile",
-            inject_ssh=inject_ssh,
             print_and_exit=generate_only,
         )
     finally:

--- a/tesseract_core/sdk/templates/Dockerfile.base
+++ b/tesseract_core/sdk/templates/Dockerfile.base
@@ -16,7 +16,6 @@ fi
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
-        ssh \
     && rm -rf /var/lib/apt/lists/*
 
 {% if config.build_config.extra_packages %}
@@ -24,11 +23,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     {{ config.build_config.extra_packages | join(" ") }} \
     && rm -rf /var/lib/apt/lists/*
-{% endif %}
-
-{% if use_ssh_mount %}
-# Set up SSH config
-RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 {% endif %}
 
 # Copy all dependencies, for both the specific Tesseract and the runtime
@@ -40,7 +34,7 @@ COPY local_requirements/ ./local_requirements
 
 # Build a python venv from python provider build scripts.
 # The build script has to create a venv at /python-env
-RUN {% if use_ssh_mount %}--mount=type=ssh{% endif %} bash {{ config.build_config.requirements._build_script }}
+RUN bash {{ config.build_config.requirements._build_script }}
 ENV PATH="/python-env/bin:$PATH"
 
 # Stage 2: Set up runtime environment

--- a/tesseract_core/sdk/templates/base/tesseract_requirements.txt
+++ b/tesseract_core/sdk/templates/base/tesseract_requirements.txt
@@ -3,7 +3,3 @@
 
 # Add Python requirements like this:
 # numpy==1.18.1
-
-# This may contain private dependencies via SSH URLs:
-# git+ssh://git@github.com/username/repo.git@branch
-# (use `tesseract build --forward-ssh-agent` to grant the builder access to your SSH keys)

--- a/tesseract_core/sdk/templates/jax/tesseract_requirements.txt
+++ b/tesseract_core/sdk/templates/jax/tesseract_requirements.txt
@@ -4,7 +4,3 @@
 # Add Python requirements like this:
 jax[cpu]
 equinox
-
-# This may contain private dependencies via SSH URLs:
-# git+ssh://git@github.com/username/repo.git@branch
-# (use `tesseract build --forward-ssh-agent` to grant the builder access to your SSH keys)

--- a/tesseract_core/sdk/templates/pytorch/tesseract_requirements.txt
+++ b/tesseract_core/sdk/templates/pytorch/tesseract_requirements.txt
@@ -4,7 +4,3 @@
 # Add Python requirements like this:
 --index-url https://download.pytorch.org/whl/cpu
 torch
-
-# This may contain private dependencies via SSH URLs:
-# git+ssh://git@github.com/username/repo.git@branch
-# (use `tesseract build --forward-ssh-agent` to grant the builder access to your SSH keys)


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
Another feature that doesn't see usage. Again, should be easy to add back – for now, it seems to crystallize that `pip download` prior to building is the more useful and less error-prone pattern.

#### Testing done
CI
