### PR TITLE
fix: Test that LogPipe implementations do not diverge

### DIFF
--- a/tests/endtoend_tests/test_tesseract_sdk.py
+++ b/tests/endtoend_tests/test_tesseract_sdk.py
@@ -208,3 +208,13 @@ def test_signature_consistency():
             f"Default value mismatch for parameter '{key}': "
             f"{from_image_sig[key].default} != {serve_sig[key].default}"
         )
+
+
+def test_logpipe_consistency():
+    """Test that the source code of the two duplicate LogPipe implementations is identical."""
+    from tesseract_core.runtime.logs import LogPipe as RuntimeLogPipe
+    from tesseract_core.sdk.logs import LogPipe as SDKLogPipe
+
+    runtime_source = inspect.getsource(RuntimeLogPipe)
+    sdk_source = inspect.getsource(SDKLogPipe)
+    assert runtime_source == sdk_source


### PR DESCRIPTION
#### Description of changes
Adds an automated test of the invariant asked for in the comments on `LogPipe`:
```
# NOTE: This is duplicated in `tesseract_core/sdk/logs.py`.
# Make sure to propagate changes to both files.
```
