### PR TITLE
refactor: transpose folder structure

### DIFF
--- a/tesseract_core/runtime/cli.py
+++ b/tesseract_core/runtime/cli.py
@@ -40,6 +40,7 @@ from tesseract_core.runtime.file_interactions import (
 from tesseract_core.runtime.finite_differences import (
     check_gradients as check_gradients_,
 )
+from tesseract_core.runtime.mpa import start_run
 from tesseract_core.runtime.serve import create_rest_api
 from tesseract_core.runtime.serve import serve as serve_
 
@@ -427,7 +428,9 @@ def _create_user_defined_cli_command(
         if output_path:
             Path(output_path).mkdir(parents=True, exist_ok=True)
 
-        result = user_function(**user_function_args)
+        with start_run(base_dir=output_path):
+            result = user_function(**user_function_args)
+
         result = output_to_bytes(result, output_format, output_path)
 
         # write raw bytes to out_stream.buffer to support binary data (which may e.g. be piped)

--- a/tesseract_core/runtime/core.py
+++ b/tesseract_core/runtime/core.py
@@ -12,8 +12,6 @@ from typing import Any, TextIO, Union
 
 from pydantic import BaseModel
 
-from tesseract_core.runtime.experimental import start_run
-
 from .config import get_config
 from .schema_generation import (
     create_abstract_eval_schema,
@@ -154,8 +152,7 @@ def create_endpoints(api_module: ModuleType) -> list[Callable]:
     @assemble_docstring(api_module.apply)
     def apply(payload: ApplyInputSchema) -> ApplyOutputSchema:
         """Apply the Tesseract to the input data."""
-        with start_run():
-            out = api_module.apply(payload.inputs)
+        out = api_module.apply(payload.inputs)
         if isinstance(out, api_module.OutputSchema):
             out = out.model_dump()
         return ApplyOutputSchema.model_validate(out)
@@ -173,8 +170,7 @@ def create_endpoints(api_module: ModuleType) -> list[Callable]:
 
             Differentiates ``jac_outputs`` with respect to ``jac_inputs``, at the point ``inputs``.
             """
-            with start_run():
-                out = api_module.jacobian(**dict(payload))
+            out = api_module.jacobian(**dict(payload))
             return JacobianOutputSchema.model_validate(
                 out,
                 context={
@@ -197,8 +193,7 @@ def create_endpoints(api_module: ModuleType) -> list[Callable]:
             Evaluates the Jacobian vector product between the Jacobian given by ``jvp_outputs``
             with respect to ``jvp_inputs`` at the point ``inputs`` and the given tangent vector.
             """
-            with start_run():
-                out = api_module.jacobian_vector_product(**dict(payload))
+            out = api_module.jacobian_vector_product(**dict(payload))
             return JVPOutputSchema.model_validate(
                 out, context={"output_keys": payload.jvp_outputs}
             )
@@ -217,8 +212,7 @@ def create_endpoints(api_module: ModuleType) -> list[Callable]:
             Computes the vector Jacobian product between the Jacobian given by ``vjp_outputs``
             with respect to ``vjp_inputs`` at the point ``inputs`` and the given cotangent vector.
             """
-            with start_run():
-                out = api_module.vector_jacobian_product(**dict(payload))
+            out = api_module.vector_jacobian_product(**dict(payload))
             return VJPOutputSchema.model_validate(
                 out, context={"input_keys": payload.vjp_inputs}
             )

--- a/tesseract_core/runtime/core.py
+++ b/tesseract_core/runtime/core.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from io import TextIOBase
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Optional, TextIO, Union
+from typing import Any, TextIO, Union
 
 from pydantic import BaseModel
 
@@ -152,11 +152,9 @@ def create_endpoints(api_module: ModuleType) -> list[Callable]:
     )
 
     @assemble_docstring(api_module.apply)
-    def apply(
-        payload: ApplyInputSchema, job_id: Optional[str] = None
-    ) -> ApplyOutputSchema:
+    def apply(payload: ApplyInputSchema) -> ApplyOutputSchema:
         """Apply the Tesseract to the input data."""
-        with start_run(job_id):
+        with start_run():
             out = api_module.apply(payload.inputs)
         if isinstance(out, api_module.OutputSchema):
             out = out.model_dump()
@@ -170,14 +168,12 @@ def create_endpoints(api_module: ModuleType) -> list[Callable]:
         )
 
         @assemble_docstring(api_module.jacobian)
-        def jacobian(
-            payload: JacobianInputSchema, job_id: Optional[str] = None
-        ) -> JacobianOutputSchema:
+        def jacobian(payload: JacobianInputSchema) -> JacobianOutputSchema:
             """Computes the Jacobian of the Tesseract.
 
             Differentiates ``jac_outputs`` with respect to ``jac_inputs``, at the point ``inputs``.
             """
-            with start_run(job_id):
+            with start_run():
                 out = api_module.jacobian(**dict(payload))
             return JacobianOutputSchema.model_validate(
                 out,
@@ -195,15 +191,13 @@ def create_endpoints(api_module: ModuleType) -> list[Callable]:
         )
 
         @assemble_docstring(api_module.jacobian_vector_product)
-        def jacobian_vector_product(
-            payload: JVPInputSchema, job_id: Optional[str] = None
-        ) -> JVPOutputSchema:
+        def jacobian_vector_product(payload: JVPInputSchema) -> JVPOutputSchema:
             """Compute the Jacobian vector product of the Tesseract at the input data.
 
             Evaluates the Jacobian vector product between the Jacobian given by ``jvp_outputs``
             with respect to ``jvp_inputs`` at the point ``inputs`` and the given tangent vector.
             """
-            with start_run(job_id):
+            with start_run():
                 out = api_module.jacobian_vector_product(**dict(payload))
             return JVPOutputSchema.model_validate(
                 out, context={"output_keys": payload.jvp_outputs}
@@ -217,15 +211,13 @@ def create_endpoints(api_module: ModuleType) -> list[Callable]:
         )
 
         @assemble_docstring(api_module.vector_jacobian_product)
-        def vector_jacobian_product(
-            payload: VJPInputSchema, job_id: Optional[str] = None
-        ) -> VJPOutputSchema:
+        def vector_jacobian_product(payload: VJPInputSchema) -> VJPOutputSchema:
             """Compute the Jacobian vector product of the Tesseract at the input data.
 
             Computes the vector Jacobian product between the Jacobian given by ``vjp_outputs``
             with respect to ``vjp_inputs`` at the point ``inputs`` and the given cotangent vector.
             """
-            with start_run(job_id):
+            with start_run():
                 out = api_module.vector_jacobian_product(**dict(payload))
             return VJPOutputSchema.model_validate(
                 out, context={"input_keys": payload.vjp_inputs}

--- a/tesseract_core/runtime/experimental.py
+++ b/tesseract_core/runtime/experimental.py
@@ -26,7 +26,6 @@ from tesseract_core.runtime.mpa import (
     log_artifact,
     log_metric,
     log_parameter,
-    start_run,
 )
 from tesseract_core.runtime.schema_types import safe_issubclass
 
@@ -238,5 +237,4 @@ __all__ = [
     "log_artifact",
     "log_metric",
     "log_parameter",
-    "start_run",
 ]

--- a/tesseract_core/runtime/file_interactions.py
+++ b/tesseract_core/runtime/file_interactions.py
@@ -15,7 +15,10 @@ SUPPORTED_FORMATS = get_args(supported_format_type)
 
 
 def output_to_bytes(
-    obj: Any, format: supported_format_type, base_dir: Optional[Union[str, Path]] = None
+    obj: Any,
+    format: supported_format_type,
+    base_dir: Optional[Union[str, Path]] = None,
+    binref_dir: Optional[Union[str, Path]] = None,
 ) -> bytes:
     """Encode endpoint output to bytes in the given format.
 
@@ -33,7 +36,11 @@ def output_to_bytes(
     elif format == "json+binref":
         return ObjSchema.dump_json(
             obj,
-            context={"array_encoding": "binref", "base_dir": base_dir},
+            context={
+                "array_encoding": "binref",
+                "base_dir": base_dir,
+                "binref_dir": binref_dir,
+            },
             exclude_unset=True,
         )
 

--- a/tesseract_core/runtime/mpa.py
+++ b/tesseract_core/runtime/mpa.py
@@ -8,7 +8,6 @@ import json
 import os
 import shutil
 import sys
-import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Generator
 from contextlib import ExitStack, contextmanager
@@ -27,20 +26,9 @@ from tesseract_core.runtime.logs import LogPipe
 class BaseBackend(ABC):
     """Base class for MPA backends."""
 
-    def __init__(self, job_id: Optional[str] = None) -> None:
-        if job_id is None:
-            job_id = str(uuid.uuid4())
-        self.job_id = job_id
-        self.log_dir = os.getenv("LOG_DIR")
-        if not self.log_dir:
-            self.log_dir = Path(get_config().output_path) / "logs"
-        else:
-            self.log_dir = Path(self.log_dir)
-        self.log_dir.mkdir(exist_ok=True)
-
-        # Create a unique run directory
-        self.run_dir = self.log_dir / f"run_{job_id}"
-        self.run_dir.mkdir(exist_ok=True)
+    def __init__(self) -> None:
+        self.log_dir = Path(get_config().output_path) / "logs"
+        self.log_dir.mkdir(parents=True, exist_ok=True)
 
     @abstractmethod
     def log_parameter(self, key: str, value: Any) -> None:
@@ -71,12 +59,12 @@ class BaseBackend(ABC):
 class FileBackend(BaseBackend):
     """MPA backend that writes to local files."""
 
-    def __init__(self, job_id: Optional[str] = None) -> None:
-        super().__init__(job_id)
+    def __init__(self) -> None:
+        super().__init__()
         # Initialize log files
-        self.params_file = self.run_dir / "parameters.json"
-        self.metrics_file = self.run_dir / "metrics.csv"
-        self.artifacts_dir = self.run_dir / "artifacts"
+        self.params_file = self.log_dir / "parameters.json"
+        self.metrics_file = self.log_dir / "metrics.csv"
+        self.artifacts_dir = self.log_dir / "artifacts"
         self.artifacts_dir.mkdir(exist_ok=True)
 
         # Initialize parameters dict and metrics list
@@ -136,8 +124,8 @@ class FileBackend(BaseBackend):
 class MLflowBackend(BaseBackend):
     """MPA backend that writes to an MLflow tracking server."""
 
-    def __init__(self, job_id: Optional[str] = None) -> None:
-        super().__init__(job_id)
+    def __init__(self) -> None:
+        super().__init__()
         try:
             os.environ["GIT_PYTHON_REFRESH"] = (
                 "quiet"  # Suppress potential MLflow git warnings
@@ -187,20 +175,20 @@ class MLflowBackend(BaseBackend):
 
     def start_run(self) -> None:
         """Start a new MLflow run."""
-        self.mlflow.start_run(run_name=f"run_{self.job_id}")
+        self.mlflow.start_run()
 
     def end_run(self) -> None:
         """End the current MLflow run."""
         self.mlflow.end_run()
 
 
-def _create_backend(job_id: Optional[str] = None) -> BaseBackend:
+def _create_backend() -> BaseBackend:
     """Create the appropriate backend based on environment."""
     config = get_config()
     if config.mlflow_tracking_uri:
-        return MLflowBackend(job_id)
+        return MLflowBackend()
     else:
-        return FileBackend(job_id)
+        return FileBackend()
 
 
 # Context variable for the current backend instance
@@ -267,13 +255,13 @@ def redirect_stdio(logfile: Union[str, Path]) -> Generator[None, None, None]:
 
 
 @contextmanager
-def start_run(job_id: Optional[str] = None) -> Generator[None, None, None]:
+def start_run() -> Generator[None, None, None]:
     """Context manager for starting and ending a run."""
-    backend = _create_backend(job_id)
+    backend = _create_backend()
     token = _current_backend.set(backend)
     backend.start_run()
 
-    logfile = backend.run_dir / "tesseract.log"
+    logfile = backend.log_dir / "tesseract.log"
 
     try:
         with redirect_stdio(logfile):

--- a/tesseract_core/runtime/serve.py
+++ b/tesseract_core/runtime/serve.py
@@ -63,12 +63,12 @@ def create_rest_api(api_module: ModuleType) -> FastAPI:
 
         @wraps(endpoint_func)
         async def wrapper(
-            *args: Any, accept: str, job_id: Optional[str], **kwargs: Any
+            *args: Any, accept: str, run_id: Optional[str], **kwargs: Any
         ):
-            if job_id is None:
-                job_id = str(uuid.uuid4())
+            if run_id is None:
+                run_id = str(uuid.uuid4())
             output_path = get_config().output_path
-            rundir_name = f"run_{job_id}"
+            rundir_name = f"run_{run_id}"
             rundir = join_paths(output_path, rundir_name)
             with start_run(base_dir=rundir):
                 result = endpoint_func(*args, **kwargs)
@@ -90,8 +90,8 @@ def create_rest_api(api_module: ModuleType) -> FastAPI:
                 default=Header(default=None),
                 annotation=Union[str, None],
             )
-            job_id = inspect.Parameter(
-                "job_id",
+            run_id = inspect.Parameter(
+                "run_id",
                 inspect.Parameter.POSITIONAL_OR_KEYWORD,
                 default=None,
                 annotation=Annotated[Optional[str], Query(include_in_schema=False)],
@@ -99,7 +99,7 @@ def create_rest_api(api_module: ModuleType) -> FastAPI:
             # Other header parameters common to computational endpoints
             # could be defined and appended here as well.
             new_params = original_sig.parameters.copy()
-            new_params.update({"accept": accept, "job_id": job_id})
+            new_params.update({"accept": accept, "run_id": run_id})
             # Update the signature of the wrapper
             new_sig = original_sig.replace(parameters=list(new_params.values()))
             wrapper.__signature__ = new_sig

--- a/tesseract_core/runtime/serve.py
+++ b/tesseract_core/runtime/serve.py
@@ -13,14 +13,16 @@ from pydantic import BaseModel
 
 from .config import get_config
 from .core import create_endpoints
-from .file_interactions import SUPPORTED_FORMATS, output_to_bytes
+from .file_interactions import SUPPORTED_FORMATS, join_paths, output_to_bytes
 from .mpa import start_run
 
 # Endpoints that should use GET instead of POST
 GET_ENDPOINTS = {"health"}
 
 
-def create_response(model: BaseModel, accept: str, base_dir: Optional[str]) -> Response:
+def create_response(
+    model: BaseModel, accept: str, base_dir: Optional[str], binref_dir: Optional[str]
+) -> Response:
     """Create a response of the format specified by the Accept header."""
     config = get_config()
 
@@ -32,7 +34,9 @@ def create_response(model: BaseModel, accept: str, base_dir: Optional[str]) -> R
     if base_dir is None:
         base_dir = config.output_path
 
-    content = output_to_bytes(model, output_format, base_dir=base_dir)
+    content = output_to_bytes(
+        model, output_format, base_dir=base_dir, binref_dir=binref_dir
+    )
     return Response(status_code=200, content=content, media_type=accept)
 
 
@@ -63,10 +67,14 @@ def create_rest_api(api_module: ModuleType) -> FastAPI:
         ):
             if job_id is None:
                 job_id = str(uuid.uuid4())
-            output_path = f"{get_config().output_path}/run_{job_id}"
-            with start_run(base_dir=output_path):
+            output_path = get_config().output_path
+            rundir_name = f"run_{job_id}"
+            rundir = join_paths(output_path, rundir_name)
+            with start_run(base_dir=rundir):
                 result = endpoint_func(*args, **kwargs)
-            return create_response(result, accept, base_dir=output_path)
+            return create_response(
+                result, accept, base_dir=output_path, binref_dir=rundir_name
+            )
 
         if endpoint_func.__name__ not in endpoints_to_wrap:
             return endpoint_func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -295,6 +295,7 @@ def _docker_cleanup(docker_client, request):
                 _ = subprocess.run(
                     [*docker_cmd, "network", "rm", network, "--force"],
                     check=True,
+                    capture_output=True,
                 )
             except Exception as e:
                 failures.append(f"Failed to remove network {network}: {pprint_exc(e)}")

--- a/tests/endtoend_tests/test_endtoend.py
+++ b/tests/endtoend_tests/test_endtoend.py
@@ -597,8 +597,18 @@ def test_io_path_interactions(
         binref_file = output_dir / binref_path
         assert binref_file.exists(), f"Expected binref file {binref_file} to exist"
 
+    # Ensure logs are written to the output directory
     if method == "serve":
-        # also try overriding the output format via Accept header
+        run_dirs = list(output_dir.glob("run_*/"))
+        assert len(run_dirs) == 1, f"Expected one run directory, found: {run_dirs}"
+        output_dir = run_dirs[0]
+
+    log_dir = output_dir / "logs"
+    assert log_dir.exists(), f"Expected log directory {log_dir} to exist"
+    assert (log_dir / "tesseract.log").exists(), "Expected tesseract.log to exist"
+
+    # Also try overriding the output format via Accept header
+    if method == "serve":
         req = requests.post(
             f"http://localhost:{serve_meta['containers'][0]['port']}/apply",
             json=example_inputs,
@@ -608,16 +618,6 @@ def test_io_path_interactions(
         result = req.json()
         assert "result" in result
         assert result["result"]["data"]["encoding"] == "base64"
-
-    # Ensure logs are written to the output directory
-    log_dir = output_dir / "logs"
-    assert log_dir.exists(), f"Expected log directory {log_dir} to exist"
-
-    run_dirs = list(log_dir.glob("run_*/"))
-    assert len(run_dirs) == 1, f"Expected one run directory, found: {run_dirs}"
-
-    run_dir = run_dirs[0]
-    assert (run_dir / "tesseract.log").exists(), "Expected tesseract.log to exist"
 
 
 def test_tesseract_serve_interop(

--- a/tests/endtoend_tests/test_endtoend.py
+++ b/tests/endtoend_tests/test_endtoend.py
@@ -864,15 +864,15 @@ def test_logging_tesseract_serve(
     docker_cleanup["containers"].append(container_name)
     container = docker_client.containers.get(container_name)
 
-    job_id = str(uuid.uuid4())
+    run_id = str(uuid.uuid4())
     res = requests.post(
         f"http://{container.host_ip}:{container.host_port}/apply",
-        params={"job_id": job_id},
+        params={"run_id": run_id},
         json={"inputs": {}},
     )
     assert res.status_code == 200, res.text
 
-    log_file = Path(tmpdir) / f"run_{job_id}/logs/tesseract.log"
+    log_file = Path(tmpdir) / f"run_{run_id}/logs/tesseract.log"
     assert log_file.exists()
 
     with open(log_file) as f:

--- a/tests/runtime_tests/test_mpa.py
+++ b/tests/runtime_tests/test_mpa.py
@@ -10,7 +10,7 @@ import pytest
 
 from tesseract_core.runtime import mpa
 from tesseract_core.runtime.config import update_config
-from tesseract_core.runtime.experimental import (
+from tesseract_core.runtime.mpa import (
     log_artifact,
     log_metric,
     log_parameter,
@@ -52,14 +52,14 @@ def test_nested_runs():
 
 def test_file_backend_default():
     """Test that FileBackend is used by default."""
-    backend = mpa._create_backend()
+    backend = mpa._create_backend(None)
     assert isinstance(backend, mpa.FileBackend)
 
 
 def test_file_backend_empty_mlflow_uri():
     """Test that FileBackend is used when mlflow_tracking_uri is empty."""
     update_config(mlflow_tracking_uri="")
-    backend = mpa._create_backend()
+    backend = mpa._create_backend(None)
     assert isinstance(backend, mpa.FileBackend)
 
 
@@ -137,7 +137,7 @@ def test_mlflow_backend_creation(tmpdir):
     pytest.importorskip("mlflow")  # Skip if MLflow is not installed
     mlflow_dir = tmpdir / "mlflow_backend_test"
     update_config(mlflow_tracking_uri=f"file://{mlflow_dir}")
-    backend = mpa._create_backend()
+    backend = mpa._create_backend(None)
     assert isinstance(backend, mpa.MLflowBackend)
 
 

--- a/tests/runtime_tests/test_mpa.py
+++ b/tests/runtime_tests/test_mpa.py
@@ -5,8 +5,6 @@
 
 import csv
 import json
-import os
-import uuid
 
 import pytest
 
@@ -63,32 +61,6 @@ def test_file_backend_empty_mlflow_uri():
     update_config(mlflow_tracking_uri="")
     backend = mpa._create_backend()
     assert isinstance(backend, mpa.FileBackend)
-
-
-def test_custom_log_directory(tmpdir):
-    """Test that FileBackend respects LOG_DIR environment variable."""
-    custom_dir = tmpdir / "custom_logs"
-    os.environ["LOG_DIR"] = str(custom_dir)
-
-    backend = mpa.FileBackend()
-    assert backend.log_dir == custom_dir
-    assert backend.log_dir.exists()
-
-
-def test_uses_job_id_log_directory(tmpdir):
-    job_id = str(uuid.uuid4())
-    backend = mpa.FileBackend(job_id)
-    assert backend.run_dir.name == f"run_{job_id}"
-
-
-def test_unique_run_directories():
-    """Test that each FileBackend instance creates unique run directories."""
-    backend1 = mpa.FileBackend()
-    backend2 = mpa.FileBackend()
-
-    assert backend1.run_dir != backend2.run_dir
-    assert backend1.run_dir.exists()
-    assert backend2.run_dir.exists()
 
 
 def test_log_parameter_content():

--- a/tests/runtime_tests/test_mpa.py
+++ b/tests/runtime_tests/test_mpa.py
@@ -63,6 +63,12 @@ def test_file_backend_empty_mlflow_uri():
     assert isinstance(backend, mpa.FileBackend)
 
 
+def test_uses_custom_base_directory(tmpdir):
+    outdir = tmpdir / "mpa_test"
+    backend = mpa.FileBackend(base_dir=str(outdir))
+    assert backend.log_dir == outdir / "logs"
+
+
 def test_log_parameter_content():
     """Test parameter logging creates correct JSON content."""
     backend = mpa.FileBackend()

--- a/tests/runtime_tests/test_serve.py
+++ b/tests/runtime_tests/test_serve.py
@@ -129,7 +129,7 @@ def test_create_rest_api_apply_endpoint(http_client, dummy_tesseract_module, for
         "/apply",
         json={"inputs": model_to_json(test_inputs)},
         headers={"Accept": f"application/{format}"},
-        params={"job_id": "test_job"},
+        params={"run_id": "test_job"},
     )
 
     assert response.status_code == 200, response.text
@@ -199,8 +199,8 @@ def test_get_openapi_schema(http_client):
     assert response.status_code == 200, response.text
     assert response.json()["info"]["title"] == "Tesseract"
     assert response.json()["paths"]
-    # The job_id query parameter is intended to be hidden
-    assert "job_id" not in response.json()
+    # The run_id query parameter is intended to be hidden
+    assert "run_id" not in response.json()
 
 
 @pytest.mark.skipif(

--- a/tests/runtime_tests/test_serve.py
+++ b/tests/runtime_tests/test_serve.py
@@ -129,11 +129,14 @@ def test_create_rest_api_apply_endpoint(http_client, dummy_tesseract_module, for
         "/apply",
         json={"inputs": model_to_json(test_inputs)},
         headers={"Accept": f"application/{format}"},
+        params={"job_id": "test_job"},
     )
 
     assert response.status_code == 200, response.text
 
-    result = array_from_json(response.json()["result"], Path(get_config().output_path))
+    result = array_from_json(
+        response.json()["result"], Path(get_config().output_path) / "run_test_job"
+    )
     assert np.array_equal(result, np.array([3.5, 6.0, 8.5]))
 
 

--- a/tests/runtime_tests/test_serve.py
+++ b/tests/runtime_tests/test_serve.py
@@ -134,9 +134,7 @@ def test_create_rest_api_apply_endpoint(http_client, dummy_tesseract_module, for
 
     assert response.status_code == 200, response.text
 
-    result = array_from_json(
-        response.json()["result"], Path(get_config().output_path) / "run_test_job"
-    )
+    result = array_from_json(response.json()["result"], Path(get_config().output_path))
     assert np.array_equal(result, np.array([3.5, 6.0, 8.5]))
 
 


### PR DESCRIPTION
#### Relevant issue or PR
n/a

#### Description of changes
This adopts a new folder structure for outputs.

**Using `tesseract run`:**

```bash
$ tesseract run metrics apply '{"inputs": {}}' --output-path /tmp/t_run --output-file out.json
This is a message from the apply function.

$ tree /tmp/t_run
/tmp/t_run
├── logs
│   ├── artifacts
│   │   └── artifact.txt
│   ├── metrics.csv
│   ├── parameters.json
│   └── tesseract.log
├── out.json
└── <optional .bin files when using binref>

# also works with local MLFlow logging
$ tesseract run metrics apply '{"inputs": {}}' --output-path /tmp/ml_run --output-file out.json --output-format json+binref --env TESSERACT_MLFLOW_TRACKING_URI=/tesseract/output_data/mlruns
This is a message from the apply function.

$ tree /tmp/ml_run
/tmp/ml_run
├── logs
│   └── tesseract.log
├── mlruns
│   └── 0
│       ├── b27ad9c511f241569678d44159f0cc8a
│       │   ├── artifacts
│       │   │   └── artifact.txt
│       │   ├── meta.yaml
│       │   ├── metrics
│       │   │   └── squared_step
│       │   ├── params
│       │   │   └── example_param
│       │   └── tags
│       │       └── mlflow.runName
│       └── meta.yaml
└── out.json
```

**When using `tesseract serve`:**

```bash
$ tesseract serve metrics --output-path /tmp/t_serve
 [i] Waiting for Tesseract to start...
 [i] Serving Tesseract at http://127.0.0.1:51130
 [i] View Tesseract: http://127.0.0.1:51130/docs
 [i] Container ID: c6504a816610d76730bfb5c50e7e6191e9c333d5e32c8ad7e37894dd26c6e7da
 [i] Name: sleepy_heyrovsky
 [i] Entrypoint: ['tesseract-runtime']
 [i] View Tesseract: http://127.0.0.1:51130/docs
 [i] Tesseract container name, use it with 'tesseract teardown' command: sleepy_heyrovsky
{"container_name": "sleepy_heyrovsky", "containers": {"name": "sleepy_heyrovsky", "port": "51130", "ip": "127.0.0.1", "networks": {"bridge": {"ip": "172.17.0.2", "port": 8000}}}}⏎ 

$ curl -H "Content-Type: application/json" -X POST -d '{"inputs": {}}' http://localhost:51130/apply
{}⏎                                                                             

$ curl -H "Content-Type: application/json" -X POST -d '{"inputs": {}}' http://localhost:51130/apply
{}⏎         

$ curl -H "Content-Type: application/json" -X POST -d '{"inputs": {}}' http://localhost:51130/apply
{}⏎ 

curl -H "Content-Type: application/json" -X POST -d '{"inputs": {}}' "http://localhost:51130/apply?run_id=asdf"
{}⏎        

$ tree /tmp/t_serve
/tmp/t_serve
├── run_63db274e-d21f-4f38-bcbe-0e3a49f2b8b6
│   └── logs
│       ├── artifacts
│       │   └── artifact.txt
│       ├── metrics.csv
│       ├── parameters.json
│       └── tesseract.log
├── run_8f801533-ea08-4749-a81c-30b0b24d0e08
│   └── logs
│       ├── artifacts
│       │   └── artifact.txt
│       ├── metrics.csv
│       ├── parameters.json
│       └── tesseract.log
├── run_asdf
│   └── logs
│       ├── artifacts
│       │   └── artifact.txt
│       ├── metrics.csv
│       ├── parameters.json
│       └── tesseract.log
└── run_cefd71be-4c43-439d-baae-c2c1be59de40
    └── logs
        ├── artifacts
        │   └── artifact.txt
        ├── metrics.csv
        ├── parameters.json
        └── tesseract.log
```

**But wait, there's more:**

Also removes setting MLFlow run IDs through the job ID. We may bring this back in the future, but for now I think it's prudent to make sure that the file-based logging works as intended, while we make the MLFlow backend more useful when people actually start using it.

#### Testing done
CI, manual (see session above)