### PR TITLE
chore: Ensure breaking changes don't bump major versions

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -80,4 +80,4 @@ sort_commits = "oldest"
 
 [bump]
 features_always_bump_minor = true
-breaking_always_bump_major = true
+breaking_always_bump_major = false


### PR DESCRIPTION
Major version releases are only to be triggered manually.