### PR TITLE
fix: use random api port if network is "host"

### DIFF
--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -699,12 +699,13 @@ def _get_tesseract_env_vals(
 def _get_tesseract_network_meta(container: Container) -> dict:
     """Retrieve network addresses from container."""
     network_meta = {}
-    networks = container.attrs["NetworkSettings"].get("Networks", {})
-    for network_name, network_info in networks.items():
-        network_meta[network_name] = {
-            "ip": f"{network_info['IPAddress']}",
-            "port": 8000,
-        }
+    docker_network_ips = container.docker_network_ips
+    if docker_network_ips:
+        for network_name, ip in docker_network_ips.items():
+            network_meta[network_name] = {
+                "ip": ip,
+                "port": container.api_port,
+            }
     return network_meta
 
 

--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -328,9 +328,26 @@ class Container:
         if self.attrs.get("NetworkSettings", None):
             ports = self.attrs["NetworkSettings"].get("Ports", None)
             if ports:
-                api_port_key = "8000/tcp"
+                api_port_key = f"{self.api_port}/tcp"
                 if ports[api_port_key]:
                     return ports[api_port_key][0].get("HostPort")
+        return None
+
+    @property
+    def api_port(self) -> str | None:
+        """Gets the api port of the container."""
+        return self.attrs["Config"]["Cmd"][2]
+
+    @property
+    def docker_network_ips(self) -> str | None:
+        """Gets the host port of the container."""
+        if self.attrs.get("NetworkSettings", None):
+            networks = self.attrs["NetworkSettings"].get("Networks", None)
+            if networks:
+                network_ips = {}
+                for network_name, network_info in networks.items():
+                    network_ips[network_name] = f"{network_info['IPAddress']}"
+                return network_ips
         return None
 
     @property
@@ -350,7 +367,7 @@ class Container:
         if self.attrs.get("NetworkSettings", None):
             ports = self.attrs["NetworkSettings"].get("Ports", None)
             if ports:
-                api_port_key = "8000/tcp"
+                api_port_key = f"{self.api_port}/tcp"
                 if ports[api_port_key]:
                     return ports[api_port_key][0].get("HostIp")
         return None

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -564,12 +564,6 @@ def serve(
     if output_format:
         environment["TESSERACT_OUTPUT_FORMAT"] = output_format
 
-    args = []
-    container_api_port = "8000"
-    container_debugpy_port = "5678"
-
-    args.extend(["--port", container_api_port])
-
     if not port:
         port = str(get_free_port())
     else:
@@ -577,6 +571,12 @@ def serve(
         if "-" in port:
             port_start, port_end = port.split("-")
             port = str(get_free_port(within_range=(int(port_start), int(port_end))))
+
+    args = []
+    container_api_port = "8000" if not network or network != "host" else port
+    container_debugpy_port = "5678"
+
+    args.extend(["--port", container_api_port])
 
     if num_workers > 1:
         args.extend(["--num-workers", str(num_workers)])


### PR DESCRIPTION
#### Description of changes
- change `engine.serve` to use a random api port for unicorn if `network==host`
- change `sdk.docker_client` and `sdk.cli` to not use hardcoded api port

#### Testing done
- Tested serving locally
