### PR TITLE
Pavlo/tree transforms unit tests

### DIFF
--- a/tesseract_core/runtime/tree_transforms.py
+++ b/tesseract_core/runtime/tree_transforms.py
@@ -37,7 +37,7 @@ def get_at_path(tree: Any, path: str) -> Any:
     # Empty path means "the root of the tree"
     if not path:
         return tree
-        
+
     split_path = path.split(".")
 
     def _get_recursive(tree: Any, path: list[str]) -> Any:
@@ -89,7 +89,7 @@ def set_at_path(tree: Any, values: dict[str, Any]) -> Any:
                     setattr(tree, key, value)
                     return
                 return _set_recursive(getattr(tree, key), path, value)
-            elif isinstance(tree, Mapping):
+            elif isinstance(tree, dict):
                 # If the key is not an attribute, try to access it as a key in a dictionary
                 # This is useful for accessing keys of models that have been dumped to dictionaries
                 if not path:

--- a/tesseract_core/runtime/tree_transforms.py
+++ b/tesseract_core/runtime/tree_transforms.py
@@ -11,17 +11,17 @@ from pydantic import BaseModel
 
 def path_to_index_op(path: str) -> tuple[str, Union[int, str]]:
     """Converts a path string to a tuple of operation and index."""
-    seq_idx_re = re.match(r"\[(\d+)\]", path)
+    seq_idx_re = re.match(r"^\[(\d+)\]$", path)
     if seq_idx_re:
         return ("seq", int(seq_idx_re.group(1)))
 
-    dict_idx_re = re.match(r"\{(.+)\}", path)
+    dict_idx_re = re.match(r"^\{(.+)\}$", path)
     if dict_idx_re:
         return ("dict", dict_idx_re.group(1))
 
-    getattr_re = re.match(r"(\w+)", path)
-    if getattr_re:
-        return ("getattr", getattr_re.group(1))
+    # Use Python's built-in identifier validation for attribute names
+    if path.isidentifier():
+        return ("getattr", path)
 
     raise ValueError(f"Invalid path: {path}")
 

--- a/tesseract_core/runtime/tree_transforms.py
+++ b/tesseract_core/runtime/tree_transforms.py
@@ -4,12 +4,14 @@
 import re
 from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
-from typing import Any, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel
 
 
-def path_to_index_op(path: str) -> tuple[str, Union[int, str]]:
+def path_to_index_op(
+    path: str,
+) -> tuple[Literal["seq", "dict", "getattr"], Union[int, str]]:
     """Converts a path string to a tuple of operation and index."""
     seq_idx_re = re.match(r"^\[(\d+)\]$", path)
     if seq_idx_re:
@@ -126,7 +128,7 @@ def filter_func(
     func: Callable[[dict], dict],
     default_inputs: dict,
     output_paths: Optional[set[str]] = None,
-    input_paths: Optional[set[str]] = None,
+    input_paths: Optional[Sequence[str]] = None,
 ) -> Callable:
     """Modifies a function that operates on pytrees to operate on flat {path: value} or positional args instead.
 

--- a/tesseract_core/runtime/tree_transforms.py
+++ b/tesseract_core/runtime/tree_transforms.py
@@ -34,6 +34,10 @@ def get_at_path(tree: Any, path: str) -> Any:
     - `b.[0]` is the first element of the list `b`
     - `c.{key}` is the value of the key `key` in the dictionary `c`
     """
+    # Empty path means "the root of the tree"
+    if not path:
+        return tree
+        
     split_path = path.split(".")
 
     def _get_recursive(tree: Any, path: list[str]) -> Any:

--- a/tesseract_core/runtime/tree_transforms.py
+++ b/tesseract_core/runtime/tree_transforms.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from copy import deepcopy
 from typing import Any, Literal, Optional, Union
 
@@ -116,7 +116,7 @@ def set_at_path(tree: Any, values: dict[str, Any]) -> Any:
 
 def flatten_with_paths(
     tree: Union[Mapping, Sequence, BaseModel],
-    include_paths: set[str],
+    include_paths: Iterable[str],
 ) -> dict[str, Any]:
     """Filter and flatten a nested PyTree by extracting only the specified paths.
 
@@ -131,7 +131,7 @@ def flatten_with_paths(
 def filter_func(
     func: Callable[[dict], dict],
     default_inputs: dict,
-    output_paths: Optional[set[str]] = None,
+    output_paths: Optional[Iterable[str]] = None,
     input_paths: Optional[Sequence[str]] = None,
 ) -> Callable:
     """Modifies a function that operates on pytrees to operate on flat {path: value} or positional args instead.

--- a/tesseract_core/runtime/tree_transforms.py
+++ b/tesseract_core/runtime/tree_transforms.py
@@ -11,7 +11,11 @@ from pydantic import BaseModel
 
 def path_to_index_op(
     path: str,
-) -> tuple[Literal["seq", "dict", "getattr"], Union[int, str]]:
+) -> Union[
+    tuple[Literal["seq"], int],
+    tuple[Literal["dict"], str],
+    tuple[Literal["getattr"], str],
+]:
     """Converts a path string to a tuple of operation and index."""
     seq_idx_re = re.match(r"^\[(\d+)\]$", path)
     if seq_idx_re:

--- a/tesseract_core/runtime/tree_transforms.py
+++ b/tesseract_core/runtime/tree_transforms.py
@@ -162,6 +162,8 @@ def filter_func(
         else:
             if len(args) != 1:
                 raise ValueError("Expected a single dictionary argument")
+            if not isinstance(args[0], dict):
+                raise TypeError("Expected argument to be a dictionary")
             new_inputs = args[0]
 
         updated_inputs = set_at_path(default_inputs, new_inputs)

--- a/tests/runtime_tests/test_tree_transofrms.py
+++ b/tests/runtime_tests/test_tree_transofrms.py
@@ -586,3 +586,23 @@ class TestFilterFunc:
         # Should expect exactly one dict argument
         with pytest.raises(ValueError, match="Expected a single dictionary argument"):
             filtered_func({"root_key": "hello"}, {"extra": "arg"})
+
+    @pytest.mark.parametrize(
+        "invalid_arg",
+        [
+            "not_a_dict",
+            ["not", "a", "dict"],
+            42,
+            None,
+            object(),
+        ],
+    )
+    def test_filter_func_dict_input_wrong_type(
+        self, sample_tree, sample_func, invalid_arg
+    ):
+        """Test that filter_func raises error when argument is not a dictionary."""
+        filtered_func = filter_func(sample_func, sample_tree)
+
+        # Should expect a dictionary argument
+        with pytest.raises(TypeError, match="Expected argument to be a dictionary"):
+            filtered_func(invalid_arg)

--- a/tests/runtime_tests/test_tree_transofrms.py
+++ b/tests/runtime_tests/test_tree_transofrms.py
@@ -1,0 +1,70 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from tesseract_core.runtime.tree_transforms import path_to_index_op
+
+
+class TestPathToIndexOp:
+    """Test cases for path_to_index_op function."""
+
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            # Basic sequence indexing
+            ("[0]", ("seq", 0)),
+            ("[123]", ("seq", 123)),
+            # Basic dictionary indexing
+            ("{key}", ("dict", "key")),
+            ("{bar_baz}", ("dict", "bar_baz")),
+            # Dictionary indexing with special characters
+            ("{key with spaces}", ("dict", "key with spaces")),
+            ("{key-with-dashes}", ("dict", "key-with-dashes")),
+            ("{key.with.dots}", ("dict", "key.with.dots")),
+            ("{123}", ("dict", "123")),
+            ("{a123}", ("dict", "a123")),
+            ("{ }", ("dict", " ")),
+            # Basic attribute access
+            ("attr", ("getattr", "attr")),
+            # Attribute access with underscores and numbers
+            ("attr123", ("getattr", "attr123")),
+            ("attr_123", ("getattr", "attr_123")),
+            ("_private", ("getattr", "_private")),
+            # Unicode letters are correct in attribute names
+            ("café", ("getattr", "café")),
+            ("фыя", ("getattr", "фыя")),
+            # All Unicode characters are correct in dictionary keys
+            ("{café}", ("dict", "café")),
+            ("{🔑key}", ("dict", "🔑key")),
+        ],
+    )
+    def test_valid_paths(self, path, expected):
+        """Test valid path patterns return expected results."""
+        assert path_to_index_op(path) == expected
+
+    @pytest.mark.parametrize(
+        "invalid_path",
+        [
+            "",
+            "[]",
+            "{}",
+            "[pi]",
+            "[1.5]",
+            "[-1]",
+            # Invalid attribute names
+            "attr-with-dashes",
+            "attr with spaces",
+            "123startswithadigit",
+            "attr!",
+            "🚀rocket",
+            "done✅",
+            "-starts-with-dash",
+            " starts-with-space",
+            "!starts-with-symbol",
+        ],
+    )
+    def test_invalid_paths(self, invalid_path):
+        """Test invalid path patterns raise ValueError."""
+        with pytest.raises(ValueError, match="Invalid path"):
+            path_to_index_op(invalid_path)

--- a/tests/runtime_tests/test_tree_transofrms.py
+++ b/tests/runtime_tests/test_tree_transofrms.py
@@ -1,6 +1,3 @@
-# Copyright 2025 Pasteur Labs. All Rights Reserved.
-# SPDX-License-Identifier: Apache-2.0
-
 import pytest
 from pydantic import BaseModel
 

--- a/tests/runtime_tests/test_tree_transofrms.py
+++ b/tests/runtime_tests/test_tree_transofrms.py
@@ -2,8 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
-from tesseract_core.runtime.tree_transforms import path_to_index_op
+from pydantic import BaseModel
+from tesseract_core.runtime.tree_transforms import path_to_index_op, get_at_path
 
 
 class TestPathToIndexOp:
@@ -51,6 +51,7 @@ class TestPathToIndexOp:
             "{}",
             "[pi]",
             "[1.5]",
+            # Negative indices not supported
             "[-1]",
             # Invalid attribute names
             "attr-with-dashes",
@@ -68,3 +69,111 @@ class TestPathToIndexOp:
         """Test invalid path patterns raise ValueError."""
         with pytest.raises(ValueError, match="Invalid path"):
             path_to_index_op(invalid_path)
+
+
+class TestGetAtPath:
+    """Test cases for get_at_path function."""
+
+    @pytest.fixture
+    def sample_tree(self):
+        """Create a sample nested tree for testing."""
+        class SimpleObj:
+            def __init__(self):
+                self.attr = "object_attribute"
+                self.nested = {"key": "nested_value"}
+                self.list_data = [1, 2, {"inner": "list_dict"}]
+
+        class TestModel(BaseModel):
+            field1: str
+            field2: dict
+            
+        model = TestModel(field1="pydantic_value", field2={"nested": "pydantic_nested"})
+
+        return {
+            "root_key": "root_value",
+            "numbers": [10, 20, 30],
+            "nested_dict": {
+                "level1": {
+                    "level2": "deep_value"
+                }
+            },
+            "mixed_list": [
+                {"item": "first"},
+                {"item": "second", "extra": [100, 200]}
+            ],
+            "object": SimpleObj(),
+            "pydantic_model": model,
+            "dict_with_special_keys": {
+                "key with spaces": "space_value",
+                "key-with-dashes": "dash_value",
+                "123": "numeric_key"
+            }
+        }
+    
+    def test_empty_path_returns_root(self, sample_tree):
+        """Test that empty path returns the entire tree."""
+        result = get_at_path(sample_tree, "")
+        assert result is sample_tree
+
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            # Simple dictionary access
+            ("root_key", "root_value"),
+            # List indexing
+            ("numbers.[0]", 10),
+            ("numbers.[1]", 20),
+            ("numbers.[2]", 30),
+            # Dictionary access
+            ("nested_dict.{level1}", {"level2": "deep_value"}),
+            ("nested_dict.{level1}.{level2}", "deep_value"),
+            # Attribute syntax also works for dicts
+            ("nested_dict.level1", {"level2": "deep_value"}),
+            ("nested_dict.level1.level2", "deep_value"),
+            # Mixed list and dict access
+            ("mixed_list.[0].item", "first"),
+            ("mixed_list.[1].item", "second"),
+            ("mixed_list.[1].extra.[0]", 100),
+            ("mixed_list.[1].extra.[1]", 200),
+            # Object attribute access
+            ("object.attr", "object_attribute"),
+            ("object.nested.key", "nested_value"),
+            ("object.list_data.[0]", 1),
+            ("object.list_data.[2].inner", "list_dict"),
+            # Dictionary keys with special characters
+            ("dict_with_special_keys.{key with spaces}", "space_value"),
+            ("dict_with_special_keys.{key-with-dashes}", "dash_value"),
+            ("dict_with_special_keys.{123}", "numeric_key"),
+            # Pydantic model field access
+            ("pydantic_model.field1", "pydantic_value"),
+            ("pydantic_model.field2.nested", "pydantic_nested"),
+        ],
+    )
+    def test_valid_paths(self, sample_tree, path, expected):
+        """Test get_at_path with valid paths."""
+        result = get_at_path(sample_tree, path)
+        assert result == expected
+
+    @pytest.mark.parametrize(
+        "invalid_path,expected_error",
+        [
+            # Non-existent keys in dictionary
+            ("nonexistent", KeyError),
+            # String has no attribute
+            ("root_key.nonexistent", AttributeError),
+            # Nested dict access
+            ("nested_dict.nonexistent", KeyError),
+            # Invalid list indices
+            ("numbers.[99]", IndexError),
+            # Negative indices not supported
+            ("numbers.[-1]", ValueError),
+            # Sequence doesn't have an attribute
+            ("numbers.invalid_syntax", AttributeError),
+            # Object attribute that doesn't exist
+            ("object.nonexistent_attr", AttributeError),
+        ],
+    )
+    def test_invalid_paths(self, sample_tree, invalid_path, expected_error):
+        """Test get_at_path with invalid paths raises appropriate errors."""
+        with pytest.raises(expected_error):
+            get_at_path(sample_tree, invalid_path)

--- a/tests/runtime_tests/test_tree_transofrms.py
+++ b/tests/runtime_tests/test_tree_transofrms.py
@@ -3,7 +3,12 @@
 
 import pytest
 from pydantic import BaseModel
-from tesseract_core.runtime.tree_transforms import path_to_index_op, get_at_path
+
+from tesseract_core.runtime.tree_transforms import (
+    get_at_path,
+    path_to_index_op,
+    set_at_path,
+)
 
 
 class TestPathToIndexOp:
@@ -71,45 +76,40 @@ class TestPathToIndexOp:
             path_to_index_op(invalid_path)
 
 
+@pytest.fixture
+def sample_tree():
+    """Create a sample nested tree for get/set at path testing."""
+
+    class SimpleObj:
+        def __init__(self):
+            self.attr = "object_attribute"
+            self.nested = {"key": "nested_value"}
+            self.list_data = [1, 2, {"inner": "list_dict"}]
+
+    class TestModel(BaseModel):
+        field1: str
+        field2: dict
+
+    model = TestModel(field1="pydantic_value", field2={"nested": "pydantic_nested"})
+
+    return {
+        "root_key": "root_value",
+        "numbers": [10, 20, 30],
+        "nested_dict": {"level1": {"level2": "deep_value"}},
+        "mixed_list": [{"item": "first"}, {"item": "second", "extra": [100, 200]}],
+        "object": SimpleObj(),
+        "pydantic_model": model,
+        "dict_with_special_keys": {
+            "key with spaces": "space_value",
+            "key-with-dashes": "dash_value",
+            "123": "numeric_key",
+        },
+    }
+
+
 class TestGetAtPath:
     """Test cases for get_at_path function."""
 
-    @pytest.fixture
-    def sample_tree(self):
-        """Create a sample nested tree for testing."""
-        class SimpleObj:
-            def __init__(self):
-                self.attr = "object_attribute"
-                self.nested = {"key": "nested_value"}
-                self.list_data = [1, 2, {"inner": "list_dict"}]
-
-        class TestModel(BaseModel):
-            field1: str
-            field2: dict
-            
-        model = TestModel(field1="pydantic_value", field2={"nested": "pydantic_nested"})
-
-        return {
-            "root_key": "root_value",
-            "numbers": [10, 20, 30],
-            "nested_dict": {
-                "level1": {
-                    "level2": "deep_value"
-                }
-            },
-            "mixed_list": [
-                {"item": "first"},
-                {"item": "second", "extra": [100, 200]}
-            ],
-            "object": SimpleObj(),
-            "pydantic_model": model,
-            "dict_with_special_keys": {
-                "key with spaces": "space_value",
-                "key-with-dashes": "dash_value",
-                "123": "numeric_key"
-            }
-        }
-    
     def test_empty_path_returns_root(self, sample_tree):
         """Test that empty path returns the entire tree."""
         result = get_at_path(sample_tree, "")
@@ -177,3 +177,194 @@ class TestGetAtPath:
         """Test get_at_path with invalid paths raises appropriate errors."""
         with pytest.raises(expected_error):
             get_at_path(sample_tree, invalid_path)
+
+
+class TestSetAtPath:
+    """Test cases for set_at_path function."""
+
+    def test_set_at_path_creates_deep_copy(self, sample_tree):
+        """Test that set_at_path creates a deep copy and doesn't modify original."""
+        original_value = sample_tree["root_key"]
+        result = set_at_path(sample_tree, {"root_key": "new_value"})
+
+        # Original should be unchanged
+        assert sample_tree["root_key"] == original_value
+        # Result should have new value
+        assert result["root_key"] == "new_value"
+        # Should be different objects
+        assert result is not sample_tree
+
+    @pytest.mark.parametrize(
+        "path_values,verification_path,expected_value",
+        [
+            # Simple dictionary access
+            ({"root_key": "new_root_value"}, "root_key", "new_root_value"),
+            # List indexing
+            ({"numbers.[0]": 999}, "numbers.[0]", 999),
+            ({"numbers.[1]": 888}, "numbers.[1]", 888),
+            ({"numbers.[2]": 777}, "numbers.[2]", 777),
+            # Dictionary access with {key} syntax
+            (
+                {"nested_dict.{level1}.{level2}": "new_deep_value"},
+                "nested_dict.{level1}.{level2}",
+                "new_deep_value",
+            ),
+            # Attribute syntax for dicts (dict fallback)
+            (
+                {"nested_dict.level1.level2": "fallback_value"},
+                "nested_dict.level1.level2",
+                "fallback_value",
+            ),
+            # Mixed list and dict access
+            ({"mixed_list.[0].item": "new_first"}, "mixed_list.[0].item", "new_first"),
+            ({"mixed_list.[1].extra.[0]": 555}, "mixed_list.[1].extra.[0]", 555),
+            # Object attribute access
+            (
+                {"object.attr": "new_object_attribute"},
+                "object.attr",
+                "new_object_attribute",
+            ),
+            (
+                {"object.nested.key": "new_nested_value"},
+                "object.nested.key",
+                "new_nested_value",
+            ),
+            (
+                {"object.list_data.[2].inner": "new_list_dict"},
+                "object.list_data.[2].inner",
+                "new_list_dict",
+            ),
+            # Dictionary keys with special characters
+            (
+                {"dict_with_special_keys.{key with spaces}": "new_space_value"},
+                "dict_with_special_keys.{key with spaces}",
+                "new_space_value",
+            ),
+            (
+                {"dict_with_special_keys.{123}": "new_numeric_value"},
+                "dict_with_special_keys.{123}",
+                "new_numeric_value",
+            ),
+            # Pydantic model field access
+            (
+                {"pydantic_model.field1": "new_pydantic_value"},
+                "pydantic_model.field1",
+                "new_pydantic_value",
+            ),
+            (
+                {"pydantic_model.field2.nested": "new_pydantic_nested"},
+                "pydantic_model.field2.nested",
+                "new_pydantic_nested",
+            ),
+        ],
+    )
+    def test_set_single_path(
+        self, sample_tree, path_values, verification_path, expected_value
+    ):
+        """Test setting values at various single paths."""
+        result = set_at_path(sample_tree, path_values)
+        actual_value = get_at_path(result, verification_path)
+        assert actual_value == expected_value
+
+    def test_set_multiple_paths(self, sample_tree):
+        """Test setting multiple paths in a single call."""
+        path_values = {
+            "root_key": "multi_new_root",
+            "numbers.[0]": 111,
+            "numbers.[1]": 222,
+            "nested_dict.level1.level2": "multi_deep_value",
+            "object.attr": "multi_object_attr",
+            "mixed_list.[0].item": "multi_first",
+        }
+
+        result = set_at_path(sample_tree, path_values)
+
+        # Verify all changes were applied
+        assert get_at_path(result, "root_key") == "multi_new_root"
+        assert get_at_path(result, "numbers.[0]") == 111
+        assert get_at_path(result, "numbers.[1]") == 222
+        assert get_at_path(result, "nested_dict.level1.level2") == "multi_deep_value"
+        assert get_at_path(result, "object.attr") == "multi_object_attr"
+        assert get_at_path(result, "mixed_list.[0].item") == "multi_first"
+
+        # Verify unchanged paths remain the same
+        assert get_at_path(result, "numbers.[2]") == get_at_path(
+            sample_tree, "numbers.[2]"
+        )
+        assert get_at_path(result, "mixed_list.[1].item") == get_at_path(
+            sample_tree, "mixed_list.[1].item"
+        )
+
+    def test_set_complex_nested_structures(self, sample_tree):
+        """Test setting complex nested data structures."""
+        new_complex_dict = {"new_key": "new_value", "new_list": [1, 2, 3]}
+        new_complex_list = [{"nested": "data"}, 42, [7, 8, 9]]
+
+        path_values = {
+            "nested_dict.{level1}": new_complex_dict,
+            "mixed_list.[1].extra": new_complex_list,
+        }
+
+        result = set_at_path(sample_tree, path_values)
+
+        assert get_at_path(result, "nested_dict.{level1}") == new_complex_dict
+        assert get_at_path(result, "mixed_list.[1].extra") == new_complex_list
+        assert get_at_path(result, "nested_dict.{level1}.new_key") == "new_value"
+        assert get_at_path(result, "mixed_list.[1].extra.[0].nested") == "data"
+
+    def test_set_empty_values_dict(self, sample_tree):
+        """Test that setting with empty values dict returns unchanged copy."""
+        result = set_at_path(sample_tree, {})
+
+        # Should be a deep copy
+        assert result is not sample_tree
+        # But with same values
+        assert get_at_path(result, "root_key") == get_at_path(sample_tree, "root_key")
+        assert get_at_path(result, "numbers") == get_at_path(sample_tree, "numbers")
+
+    @pytest.mark.parametrize(
+        "invalid_path_values,expected_error",
+        [
+            # String has no attribute
+            ({"root_key.nonexistent": "value"}, AttributeError),
+            # Invalid list indices
+            ({"numbers.[99]": "value"}, IndexError),
+            ({"numbers.[-1]": "value"}, ValueError),
+            # Invalid path syntax
+            ({"numbers.invalid_syntax": "value"}, AttributeError),
+            # Object attribute that doesn't exist
+            ({"object.nonexistent_attr": "value"}, AttributeError),
+        ],
+    )
+    def test_set_invalid_paths(self, sample_tree, invalid_path_values, expected_error):
+        """Test that setting invalid paths raises appropriate errors."""
+        with pytest.raises(expected_error):
+            set_at_path(sample_tree, invalid_path_values)
+
+    def test_set_creates_new_dict_keys(self, sample_tree):
+        """Test that setting non-existent dict keys creates them (dict fallback)."""
+        # Despite the fact that attributes do not exist,
+        # the set should succeed and create new keys due to attribute -> dict fallback
+        result = set_at_path(sample_tree, {"nonexistent": "new_value"})
+        assert get_at_path(result, "nonexistent") == "new_value"
+
+        result = set_at_path(
+            sample_tree, {"nested_dict.nonexistent": "nested_new_value"}
+        )
+        assert get_at_path(result, "nested_dict.nonexistent") == "nested_new_value"
+
+    def test_set_preserves_unmodified_branches(self, sample_tree):
+        """Test that setting values preserves unmodified branches of the tree."""
+        original_mixed_list = sample_tree["mixed_list"]
+        original_object = sample_tree["object"]
+
+        result = set_at_path(sample_tree, {"root_key": "changed_root"})
+
+        # Changed path should be different
+        assert result["root_key"] != sample_tree["root_key"]
+
+        # Unmodified branches should be deep copies but with same content
+        assert result["mixed_list"] is not original_mixed_list
+        assert result["mixed_list"] == original_mixed_list
+        assert result["object"] is not original_object
+        assert result["object"].attr == original_object.attr


### PR DESCRIPTION
#### Relevant issue or PR

This is in line with #9, as tree transforms are the least covered logic in the runtime.

#### Description of changes

Extensive unit tests for runtime/tree_transforms.py and related minor fixes:

1. More precise type hints aligned with the actual usage in the example tesseracts.
2. Stricter path string checks in `path_to_index_op`, especially for attribute names, to prevent failures down the road when trying to access invalid attributes.
3. Interpret empty path as "the root of the tree" in `get_at_path` to allow accessing the complete tree, also aligned with JAX conventions.  

#### Testing done

Unit tests pass