### PR TITLE
fix: require name and version to be non-empty in TesseractConfig

### DIFF
--- a/tesseract_core/sdk/api_parse.py
+++ b/tesseract_core/sdk/api_parse.py
@@ -151,8 +151,10 @@ OptionalBuildConfig = Annotated[
 class TesseractConfig(BaseModel, validate_assignment=True):
     """Configuration options for Tesseracts. Defines valid options in ``tesseract_config.yaml``."""
 
-    name: StrictStr = Field(..., description="Name of the Tesseract.")
-    version: StrictStr = Field("unknown", description="Version of the Tesseract.")
+    name: StrictStr = Field(..., description="Name of the Tesseract.", min_length=1)
+    version: StrictStr = Field(
+        "unknown", description="Version of the Tesseract.", min_length=1
+    )
     description: StrictStr = Field(
         "",
         description="Free-text description of what the Tesseract does.",


### PR DESCRIPTION
#### Relevant issue or PR
#335 

#### Description of changes
requires minimum length for name and version in `TesseractConfig`.

#### Testing done
Runs locally and gives better error messages compared to the ones described in #335
