### PR TITLE
fix: strip trailing slash from URL's passed to Tesseract HTTP client

### DIFF
--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -497,6 +497,7 @@ class HTTPClient:
             parsed = urlparse(url)
 
         sanitized = urlunparse((parsed.scheme, parsed.netloc, parsed.path, "", "", ""))
+        sanitized = sanitized.rstrip("/")
         return sanitized
 
     @property


### PR DESCRIPTION
#### Description of changes
The current URL sanitizer doesn't sanitize trailing slashes. Trailing slashes in the URL lead to double slashes in requests. In some circumstances, this leads to issues. E.g., a default http server in Go reroutes double slash URL POST requests to GET requests without body on the sanitized URL.

#### Testing done
Local testing