### PR TITLE
fix(sdk): Cast sets to tuples in Pytorch template when used as positional args

### DIFF
--- a/examples/vectoradd_torch/tesseract_api.py
+++ b/examples/vectoradd_torch/tesseract_api.py
@@ -113,6 +113,9 @@ def jacobian(
     jac_inputs: set[str],
     jac_outputs: set[str],
 ):
+    # Cast to tuples for consistent ordering
+    jac_inputs = tuple(jac_inputs)
+    jac_outputs = tuple(jac_outputs)
     # convert all numbers and arrays to torch tensors
     tensor_inputs = tree_map(to_tensor, inputs.model_dump())
 
@@ -152,6 +155,9 @@ def jacobian_vector_product(
     jvp_outputs: set[str],
     tangent_vector: dict[str, Any],
 ):
+    # Cast to tuples for consistent ordering
+    jvp_inputs = tuple(jvp_inputs)
+    jvp_outputs = tuple(jvp_outputs)
     # Make ordering of tangent_vector identical to jvp_inputs
     tangent_vector = {key: tangent_vector[key] for key in jvp_inputs}
 
@@ -176,6 +182,9 @@ def vector_jacobian_product(
     vjp_outputs: set[str],
     cotangent_vector: dict[str, Any],
 ):
+    # Cast to tuples for consistent ordering
+    vjp_inputs = tuple(vjp_inputs)
+    vjp_outputs = tuple(vjp_outputs)
     # Make ordering of cotangent_vector identical to vjp_inputs
     cotangent_vector = {key: cotangent_vector[key] for key in vjp_outputs}
 

--- a/examples/vectoradd_torch/tesseract_api.py
+++ b/examples/vectoradd_torch/tesseract_api.py
@@ -113,9 +113,8 @@ def jacobian(
     jac_inputs: set[str],
     jac_outputs: set[str],
 ):
-    # Cast to tuples for consistent ordering
+    # Cast to tuples for consistent ordering in positional function
     jac_inputs = tuple(jac_inputs)
-    jac_outputs = tuple(jac_outputs)
     # convert all numbers and arrays to torch tensors
     tensor_inputs = tree_map(to_tensor, inputs.model_dump())
 
@@ -155,9 +154,8 @@ def jacobian_vector_product(
     jvp_outputs: set[str],
     tangent_vector: dict[str, Any],
 ):
-    # Cast to tuples for consistent ordering
+    # Cast to tuples for consistent ordering in positional function
     jvp_inputs = tuple(jvp_inputs)
-    jvp_outputs = tuple(jvp_outputs)
     # Make ordering of tangent_vector identical to jvp_inputs
     tangent_vector = {key: tangent_vector[key] for key in jvp_inputs}
 
@@ -182,9 +180,8 @@ def vector_jacobian_product(
     vjp_outputs: set[str],
     cotangent_vector: dict[str, Any],
 ):
-    # Cast to tuples for consistent ordering
+    # Cast to tuples for consistent ordering in positional function
     vjp_inputs = tuple(vjp_inputs)
-    vjp_outputs = tuple(vjp_outputs)
     # Make ordering of cotangent_vector identical to vjp_inputs
     cotangent_vector = {key: cotangent_vector[key] for key in vjp_outputs}
 

--- a/tesseract_core/sdk/templates/pytorch/tesseract_api.py
+++ b/tesseract_core/sdk/templates/pytorch/tesseract_api.py
@@ -71,6 +71,9 @@ def jacobian(
     jac_inputs: set[str],
     jac_outputs: set[str],
 ):
+    # Cast to tuples for consistent ordering
+    jac_inputs = tuple(jac_inputs)
+    jac_outputs = tuple(jac_outputs)
     # convert all numbers and arrays to torch tensors
     tensor_inputs = tree_map(to_tensor, inputs.model_dump())
 
@@ -110,6 +113,9 @@ def jacobian_vector_product(
     jvp_outputs: set[str],
     tangent_vector: dict[str, Any],
 ):
+    # Cast to tuples for consistent ordering
+    jvp_inputs = tuple(jvp_inputs)
+    jvp_outputs = tuple(jvp_outputs)
     # Make ordering of tangent_vector identical to jvp_inputs
     tangent_vector = {key: tangent_vector[key] for key in jvp_inputs}
 
@@ -134,6 +140,9 @@ def vector_jacobian_product(
     vjp_outputs: set[str],
     cotangent_vector: dict[str, Any],
 ):
+    # Cast to tuples for consistent ordering
+    vjp_inputs = tuple(vjp_inputs)
+    vjp_outputs = tuple(vjp_outputs)
     # Make ordering of cotangent_vector identical to vjp_inputs
     cotangent_vector = {key: cotangent_vector[key] for key in vjp_outputs}
 

--- a/tesseract_core/sdk/templates/pytorch/tesseract_api.py
+++ b/tesseract_core/sdk/templates/pytorch/tesseract_api.py
@@ -71,9 +71,8 @@ def jacobian(
     jac_inputs: set[str],
     jac_outputs: set[str],
 ):
-    # Cast to tuples for consistent ordering
+    # Cast to tuples for consistent ordering in positional function
     jac_inputs = tuple(jac_inputs)
-    jac_outputs = tuple(jac_outputs)
     # convert all numbers and arrays to torch tensors
     tensor_inputs = tree_map(to_tensor, inputs.model_dump())
 
@@ -113,9 +112,8 @@ def jacobian_vector_product(
     jvp_outputs: set[str],
     tangent_vector: dict[str, Any],
 ):
-    # Cast to tuples for consistent ordering
+    # Cast to tuples for consistent ordering in positional function
     jvp_inputs = tuple(jvp_inputs)
-    jvp_outputs = tuple(jvp_outputs)
     # Make ordering of tangent_vector identical to jvp_inputs
     tangent_vector = {key: tangent_vector[key] for key in jvp_inputs}
 
@@ -140,9 +138,8 @@ def vector_jacobian_product(
     vjp_outputs: set[str],
     cotangent_vector: dict[str, Any],
 ):
-    # Cast to tuples for consistent ordering
+    # Cast to tuples for consistent ordering in positional function
     vjp_inputs = tuple(vjp_inputs)
-    vjp_outputs = tuple(vjp_outputs)
     # Make ordering of cotangent_vector identical to vjp_inputs
     cotangent_vector = {key: cotangent_vector[key] for key in vjp_outputs}
 


### PR DESCRIPTION
The iteration order of a `set` is not guaranteed but is relied upon by the filtered positional arguments. To ensure behaviour is as expected these are now cast to `tuple`s. This already happens in the jax template to satisfy jit.

#### Relevant issue or PR
- #344 

#### Description of changes
Cast `jvp_inputs` `jac_inputs` `vjp_inputs` to `tuple`s . Output paths are not cast as these are used as keys to a dictionary so order is not important.

#### Testing done
CI passes, I should maybe add some specific tests to catch edge cases. Let me know if you'd like this!