### PR TITLE
fix: allow digits in the pre-release semver tag

### DIFF
--- a/tesseract_core/sdk/api_parse.py
+++ b/tesseract_core/sdk/api_parse.py
@@ -172,7 +172,7 @@ class TesseractConfig(BaseModel, validate_assignment=True):
     @classmethod
     def validate_version(cls, v: str) -> str:
         """Validate that the version string is a valid semantic version."""
-        version_pattern = r"""^\d+\.\d+\.\d+[a-zA-Z-0-9]*$"""
+        version_pattern = r"^\d+\.\d+\.\d+[a-zA-Z-0-9]*$"
 
         if not re.match(version_pattern, v):
             raise ValueError(

--- a/tesseract_core/sdk/api_parse.py
+++ b/tesseract_core/sdk/api_parse.py
@@ -174,7 +174,7 @@ class TesseractConfig(BaseModel, validate_assignment=True):
         """Validate that the version string is a valid semantic version."""
         version_pattern = r"""^\d+\.\d+\.\d+[a-zA-Z-0-9]*$"""
 
-        if (not re.match(version_pattern, v)) and v != "unknown":
+        if not re.match(version_pattern, v):
             raise ValueError(
                 f"Version '{v}' is not a valid version number for a Tesseract. "
                 "You can only use three dot-separated digits (e.g. 1.2.3), to which "

--- a/tesseract_core/sdk/api_parse.py
+++ b/tesseract_core/sdk/api_parse.py
@@ -172,7 +172,7 @@ class TesseractConfig(BaseModel, validate_assignment=True):
     @classmethod
     def validate_version(cls, v: str) -> str:
         """Validate that the version string is a valid semantic version."""
-        version_pattern = r"""^\d+\.\d+\.\d+[a-zA-Z-]*$"""
+        version_pattern = r"""^\d+\.\d+\.\d+[a-zA-Z-0-9]*$"""
 
         if (not re.match(version_pattern, v)) and v != "unknown":
             raise ValueError(

--- a/tesseract_core/sdk/api_parse.py
+++ b/tesseract_core/sdk/api_parse.py
@@ -174,7 +174,7 @@ class TesseractConfig(BaseModel, validate_assignment=True):
         """Validate that the version string is a valid semantic version."""
         version_pattern = r"^\d+\.\d+\.\d+[a-zA-Z-0-9]*$"
 
-        if not re.match(version_pattern, v):
+        if (not re.match(version_pattern, v)) and v != "unknown":
             raise ValueError(
                 f"Version '{v}' is not a valid version number for a Tesseract. "
                 "You can only use three dot-separated digits (e.g. 1.2.3), to which "

--- a/tests/sdk_tests/test_api_parse.py
+++ b/tests/sdk_tests/test_api_parse.py
@@ -44,7 +44,7 @@ def valid_tesseract_config() -> str:
     return dedent(
         """
         name: foo
-        version: "unknown"
+        version: "1.2.3-rc2"
 
         build_config:
             package_data:


### PR DESCRIPTION
#### Relevant issue or PR

#### Description of changes
Currently, tesseracts are not allowed to have digits in the pre-release section of the version/tag. This changes that behavior to allow that, e.g. `1.2.3-rc2`.

#### Testing done
Tested manually:

```console
$ uv run tesseract build --tag 1.2.3-rc2 examples/vectoradd
 [i] Building image ...
 [i] Built image sha256:41b380c24c95, ['vectoradd:1.2.3-rc2']
["vectoradd:1.2.3-rc2"]
```
