### PR TITLE
feat: use .gitignore info to reduce size of build context

### DIFF
--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -303,6 +303,12 @@ def build_image(
             help="Only generate the build context and do not actually build the image."
         ),
     ] = False,
+    gitignore: Annotated[
+        bool,
+        typer.Option(
+            help="Use .gitignore file to exclude files from the build context."
+        ),
+    ] = False,
 ) -> None:
     """Build a new Tesseract from a context directory.
 
@@ -333,6 +339,7 @@ def build_image(
                 inject_ssh=forward_ssh_agent,
                 config_override=parsed_config_override,
                 generate_only=generate_only,
+                gitignore=gitignore,
             )
     except BuildError as e:
         # raise from None to Avoid overly long tracebacks,


### PR DESCRIPTION
Use information from .gitignore files of local dependencies to reduce the size of build context.

#### Description of changes
This PR introduces a local ignore function in `sdk.engine.prepare_build_context` that prevents copying files that are specified in a `.gitignore` file into the local dependency's build context. This behavior is controlled by a boolean flag, `gitignore`, that can be passed to `tesseract build` and defaults to `False`.

#### Testing done
- Local testing with various `.gitignore` patterns; verified build context size reduction
