### PR TITLE
fix: Create tesseract user and group

### DIFF
--- a/tesseract_core/sdk/templates/Dockerfile.base
+++ b/tesseract_core/sdk/templates/Dockerfile.base
@@ -102,6 +102,8 @@ RUN mkdir -p /tesseract/input_data /tesseract/output_data && \
     chmod 777 /tesseract/output_data
 VOLUME ["/tesseract/input_data", "/tesseract/output_data"]
 
+RUN groupadd -g 1000 tesseract
+RUN useradd -g tesseract -u 1000 tesseract
 USER 1000:1000
 
 ENV TESSERACT_INPUT_PATH="/tesseract/input_data"


### PR DESCRIPTION
#### Relevant issue or PR

In #367 , some errors are happening because a module (MLFlow) cannot find the user's home directory. Just setting `USER 1000:1000` in the Dockerfile results in weird behaviour in general

#### Description of changes
Added a `groupadd` and `useradd` for tesseract:tesseract in the dockerfile.

#### Testing done
Locally works as expected on helloworld