### PR TITLE
feat: remove unused tesseract-dir option and fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,24 +38,6 @@ def pytest_addoption(parser):
         dest="run_endtoend",
         help="Skip end-to-end tests",
     )
-    parser.addoption(
-        "--tesseract-dir",
-        action="store",
-        default=None,
-        dest="tesseract_dir",
-        help="Directory of your tesseract api",
-    )
-
-
-@pytest.fixture
-def tesseract_dir(request):
-    """Return the tesseract directory."""
-    # This is used to set the tesseract_dir fixture
-    # in the pytest_generate_tests function above.
-    tesseract_dir = request.config.getoption("tesseract_dir")
-    if tesseract_dir:
-        return Path(tesseract_dir)
-    return None
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
#### Relevant issue or PR
- #149 (see old [commit](https://github.com/pasteurlabs/tesseract-core/pull/149/changes/7351d56dfe6eb791e90d431779cfd3bd473f3929#diff-0db00bf8bd4f80a902d6f483798b55a6412187373f2666d1e009c0c7daf3e6efR44-R49) for usage example) 

#### Description of changes
The tesseract-dir option is unused and does nothing, it's doc string gives misleading/incorrect information about the usage of `pytest_generate_tests` propose to remove to avoid confusion.

#### Testing done
- CI passes
