### PR TITLE
chore: point to pasteurlabs/mirror-prettier, add toml linting and pyproject.toml validation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,11 +27,6 @@ repos:
       - id: trailing-whitespace
         additional_dependencies: [--isolated]
 
-  - repo: https://github.com/henryiii/validate-pyproject-schema-store
-    rev: 2025.11.21
-    hooks:
-      - id: validate-pyproject
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.14.9


### PR DESCRIPTION
#### Description of changes

Point to frozen Pasteur-hosted mirror-prettier, this enables:
* Support of prettier v3.7.4 which supports the prettier-plugin-toml for toml linting
* Minimal maintenance and robust security as all updates would happen only on request

Add validate pyproject pre-commit hook.

We can add these to the pasteur-python-template once happy with here.
 
#### Testing done

- CI (including pre-commit on all files) passes
