### PR TITLE
feat: prevent orphaned containers when using `Tesseract.from_image`

### DIFF
--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -10,7 +10,9 @@ import re
 import shlex
 import subprocess
 import sys
+import tempfile
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from io import IOBase
@@ -146,6 +148,34 @@ def _run_process(
             proc.stderr.close()
 
     return proc.returncode, b"".join(stdout_lines), b"".join(stderr_lines)
+
+
+def _read_cidfile(path: str, timeout: float = 30.0) -> str:
+    """Read a container ID from a cidfile, polling until it is written.
+
+    Docker writes the container ID to the cidfile asynchronously after
+    container creation. This function polls until the file is non-empty.
+
+    Args:
+        path: Path to the cidfile.
+        timeout: Maximum time to wait in seconds.
+
+    Returns:
+        The container ID string.
+
+    Raises:
+        TimeoutError: If the cidfile is not written within the timeout.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            content = Path(path).read_text().strip()
+            if content:
+                return content
+        except FileNotFoundError:
+            pass
+        time.sleep(0.05)
+    raise TimeoutError(f"Timed out waiting for container ID in cidfile {path}")
 
 
 def _is_valid_docker_tag(tag: str) -> bool:
@@ -727,6 +757,7 @@ class Containers:
         extra_args: list_[str] | None = None,  # noqa: UP006
         stream_stdout: BoolOrCallable = False,
         stream_stderr: BoolOrCallable = False,
+        background: bool = False,
     ) -> Container | tuple[bytes, bytes] | bytes:
         """Run a command in a container from an image.
 
@@ -756,9 +787,13 @@ class Containers:
             stream_stderr: If True, stream stderr to sys.stderr in real-time. Can also be
                     a callable that accepts a string to use as a custom sink.
                     Cannot be used with detach.
+            background: If True, launch the container via `docker run` as a child process.
+                    The container process remains a child of the current process, so it will
+                    be cleaned up if the parent process dies. Cannot be used with detach.
 
         Returns:
-            Container object if detach is True, otherwise returns list of stdout and stderr.
+            Container object if detach or background is True,
+            otherwise returns list of stdout and stderr.
         """
         config = get_config()
         docker = _get_docker_executable()
@@ -803,6 +838,8 @@ class Containers:
             raise ValueError(
                 "Cannot set both remove and detach to True when running a container."
             )
+        if background and detach:
+            raise ValueError("Cannot use background with detach.")
         if (stream_stdout or stream_stderr) and detach:
             raise ValueError(
                 "Cannot use stream_stdout or stream_stderr with detach=True."
@@ -819,6 +856,16 @@ class Containers:
         if extra_args is None:
             extra_args = []
 
+        if background:
+            # Docker requires the cidfile to not exist, so we create a
+            # NamedTemporaryFile, grab its name, then delete it before
+            # passing the path to docker run.
+            cidfile = tempfile.NamedTemporaryFile(prefix="tesseract_cid_", delete=False)
+            cidfile_path = cidfile.name
+            cidfile.close()
+            os.unlink(cidfile_path)
+            optional_args.extend(["--cidfile", cidfile_path])
+
         full_cmd = [
             *docker,
             "run",
@@ -830,6 +877,21 @@ class Containers:
         ]
 
         logger.debug(f"Running command: {full_cmd}")
+
+        if background:
+            subprocess.Popen(
+                full_cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            try:
+                container_id = _read_cidfile(cidfile_path)
+            finally:
+                try:
+                    os.unlink(cidfile_path)
+                except OSError:
+                    pass
+            return Containers.get(container_id)
 
         returncode, stdout_data, stderr_data = _run_process(
             full_cmd,

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger("tesseract")
 docker_client = CLIDockerClient()
 
+
 # Jinja2 Environment
 ENV = Environment(
     loader=PackageLoader("tesseract_core.sdk", "templates"),
@@ -609,6 +610,7 @@ def serve(
     output_format: Literal["json", "json+base64", "json+binref"] | None = None,
     docker_args: list[str] | None = None,
     runtime_config: dict[str, Any] | None = None,
+    detach: bool = True,
 ) -> tuple:
     """Serve one or more Tesseract images.
 
@@ -637,9 +639,12 @@ def serve(
         runtime_config: Dictionary of runtime configuration options to pass to the Tesseract.
             These are converted to TESSERACT_* environment variables. For example,
             ``{"profiling": True}`` sets ``TESSERACT_PROFILING=1``.
+        detach: If True (default), run the container in detached mode. If False,
+            the container runs as a child process of the current Python process,
+            so it is cleaned up automatically if the parent process dies.
 
     Returns:
-        A tuple of the Tesseract container name and the port it is serving on.
+        A tuple of the Tesseract container name and the Container object.
     """
     if not image_name or not isinstance(image_name, str):
         raise ValueError("Tesseract image name must be provided")
@@ -747,7 +752,8 @@ def serve(
         device_requests=gpus,
         ports=port_mappings,
         network=network,
-        detach=True,
+        detach=detach,
+        background=not detach,
         volumes=parsed_volumes,
         user=user,
         memory=memory,

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -308,7 +308,7 @@ class Tesseract:
             raise RuntimeError("Can only serve a Tesseract created via from_image.")
         if self._serve_context is not None:
             raise RuntimeError("Tesseract is already being served.")
-        container_name, container = engine.serve(**self._spawn_config)
+        container_name, container = engine.serve(**self._spawn_config, detach=False)
         self._serve_context = dict(
             container_name=container_name,
             port=container.host_port,

--- a/tests/endtoend_tests/test_tesseract_sdk.py
+++ b/tests/endtoend_tests/test_tesseract_sdk.py
@@ -214,6 +214,8 @@ def test_signature_consistency():
         "output_format",
         # stream_logs is SDK-only for streaming logs to a callback
         "stream_logs",
+        # detach is engine-only (SDK always uses detach=False)
+        "detach",
     ]
 
     from_image_sig = dict(inspect.signature(Tesseract.from_image).parameters)

--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -163,7 +163,7 @@ def test_serve_lifecycle(mock_serving, mock_clients):
     # Output_path is auto-created as a temp directory
     assert call_kwargs["output_path"].is_dir()
     # Check that no unexpected kwargs were passed
-    assert call_kwargs.keys() == expected_kwargs.keys() | {"output_path"}
+    assert call_kwargs.keys() == expected_kwargs.keys() | {"output_path", "detach"}
 
     mock_serving["teardown_mock"].assert_called_with("container-id-123")
 


### PR DESCRIPTION
#### Relevant issue or PR

n/a

#### Description of changes

I noticed that I'd sometimes get orphaned containers if using `Tesseract.from_image` and the Python process dies violently.

This PR makes it so `from_image` maps to a regular `docker run` without `--detach` in a subprocess. That way, if the main process dies, the subprocess will be reaped as well and the container is torn down.

#### Testing done

CI