### PR TITLE
fix: bug when using chdir with OutputPath

### DIFF
--- a/tesseract_core/runtime/config.py
+++ b/tesseract_core/runtime/config.py
@@ -6,7 +6,14 @@ import os
 from pathlib import Path
 from typing import Annotated, Any
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, FilePath
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    FilePath,
+    field_validator,
+)
 
 from tesseract_core.runtime.file_interactions import supported_format_type
 
@@ -39,6 +46,11 @@ class RuntimeConfig(BaseModel):
     )
     profiling: bool = False
     tracing: bool = False
+
+    @field_validator("input_path", "output_path")
+    @classmethod
+    def _resolve_path(cls, v: str) -> str:
+        return str(Path(v).resolve())
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 

--- a/tests/runtime_tests/test_path_types.py
+++ b/tests/runtime_tests/test_path_types.py
@@ -250,6 +250,38 @@ def test_input_path_accepts_path_object(path_dirs):
     assert m.f == input_dir / "file.txt"
 
 
+def test_output_path_stable_after_chdir(path_dirs, monkeypatch):
+    """os.chdir() after config init must not break OutputPath validation."""
+    _, output_dir = path_dirs
+    (output_dir / "result.txt").touch()
+
+    subdir = output_dir / "subdir"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+
+    class M(BaseModel):
+        out: OutputPath
+
+    model = M.model_validate({"out": str(output_dir / "result.txt")})
+    assert model.out == output_dir / "result.txt"
+
+
+def test_input_path_stable_after_chdir(path_dirs, monkeypatch):
+    """os.chdir() after config init must not break InputPath validation."""
+    input_dir, _ = path_dirs
+    (input_dir / "data.json").touch()
+
+    subdir = input_dir / "subdir"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+
+    class M(BaseModel):
+        inp: InputPath
+
+    model = M.model_validate({"inp": "data.json"})
+    assert model.inp == input_dir / "data.json"
+
+
 def test_output_path_accepts_path_object(path_dirs):
     _, output_dir = path_dirs
     (output_dir / "out.txt").touch()


### PR DESCRIPTION
#### Relevant issue or PR

n/a

#### Description of changes

`os.chdir` currently messes with validation of `OutputPath` when `output_dir` is relative (e.g. `.`). This fixes it by resolving paths eagerly.

#### Testing done

CI