### PR TITLE
chore: Mark InputPath/OutputPath fields with format: "path" in JSON schema

### DIFF
--- a/tesseract_core/runtime/experimental.py
+++ b/tesseract_core/runtime/experimental.py
@@ -271,6 +271,16 @@ class InputPath(Path):
         )
 
     @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        _core_schema: core_schema.CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        schema = handler(_core_schema)
+        schema["format"] = "path"
+        return schema
+
+    @classmethod
     def _validate(cls, value: Any, info: ValidationInfo) -> Path:
         return cls._resolve(Path(value), info)
 
@@ -349,6 +359,16 @@ class OutputPath(Path):
                 cls._serialize,
             ),
         )
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls,
+        _core_schema: core_schema.CoreSchema,
+        handler: GetJsonSchemaHandler,
+    ) -> JsonSchemaValue:
+        schema = handler(_core_schema)
+        schema["format"] = "path"
+        return schema
 
 
 def _resolve_input_file(path: Path, info: ValidationInfo) -> Path:

--- a/tests/runtime_tests/test_path_types.py
+++ b/tests/runtime_tests/test_path_types.py
@@ -40,8 +40,16 @@ class ListPathModel(BaseModel):
 
 def test_json_schema_basic():
     schema = PathModel.model_json_schema()
-    assert schema["properties"]["inp"] == {"title": "Inp", "type": "string"}
-    assert schema["properties"]["out"] == {"title": "Out", "type": "string"}
+    assert schema["properties"]["inp"] == {
+        "title": "Inp",
+        "type": "string",
+        "format": "path",
+    }
+    assert schema["properties"]["out"] == {
+        "title": "Out",
+        "type": "string",
+        "format": "path",
+    }
     assert set(schema["required"]) == {"inp", "out"}
 
 
@@ -50,6 +58,7 @@ def test_json_schema_in_list():
     inp_prop = schema["properties"]["inputs"]
     assert inp_prop["type"] == "array"
     assert inp_prop["items"]["type"] == "string"
+    assert inp_prop["items"]["format"] == "path"
 
 
 def test_json_schema_with_annotated_validator():
@@ -64,7 +73,9 @@ def test_json_schema_with_annotated_validator():
 
     schema = M.model_json_schema()
     assert schema["properties"]["inp"]["type"] == "string"
+    assert schema["properties"]["inp"]["format"] == "path"
     assert schema["properties"]["out"]["type"] == "string"
+    assert schema["properties"]["out"]["format"] == "path"
 
 
 # -- InputPath validation --


### PR DESCRIPTION
#### Relevant issue or PR

Follow up to https://github.com/pasteurlabs/tesseract-core/pull/555 ; in that pr, the schema emitted by the `InputPath` / `OutputPath` models didn't contain `"format": "path"`, making it difficult to distinguish them from plain strings from the schema alone.

This is done to improve consistency with schemas generated by pydantic for paths (which are not just marked as strings, but also contain `"format": "path"`; this consistency, in turn, makes it easier for applications orchestrating Tesseracts to distinguish paths from plain strings.

For more detail, have a look at the changed lines in the test, in particular `{"title": "Inp", "type": "string"}` (no format present).

#### Description of changes

Restored the format: path annotation Pydantic emits for plain pathlib.Path fields, lost when we override __get_pydantic_core_schema__

#### Testing done

Local pytest + hopefully CI passes