### PR TITLE
feat: allow file I/O from s3

### DIFF
--- a/tesseract_core/runtime/experimental.py
+++ b/tesseract_core/runtime/experimental.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import (
     Annotated,
     Any,
+    ClassVar,
     get_args,
     get_origin,
 )
@@ -225,6 +226,10 @@ class InputPath(Path):
     Resolves relative paths against ``RuntimeConfig().input_path`` and validates
     that the resolved path stays within the input directory and exists.
 
+    If the path is a URL (contains a scheme like ``https://`` or ``s3://``),
+    the file is downloaded to a local temporary directory via fsspec and the
+    local path is returned.
+
     Use ``Annotated[InputPath, AfterValidator(...)]`` to add custom validation
     that runs after path resolution (receives the absolute, resolved path).
     """
@@ -244,6 +249,35 @@ class InputPath(Path):
         if not skip and not tess_path.exists():
             raise ValueError(f"Input path {tess_path} does not exist.")
         return tess_path
+
+    _temp_dirs: ClassVar[list[Path]] = []
+
+    @classmethod
+    def _download_url(cls, url: str) -> Path:
+        """Download a URL to a local temporary file and return its path."""
+        import tempfile
+        from urllib.parse import urlparse
+
+        import fsspec
+
+        remote_name = Path(urlparse(url).path).name or "download"
+        tmp_dir = Path(tempfile.mkdtemp(prefix="tesseract_input_"))
+        cls._temp_dirs.append(tmp_dir)
+        local_path = tmp_dir / remote_name
+
+        with fsspec.open(url, "rb") as remote:
+            local_path.write_bytes(remote.read())
+
+        return local_path
+
+    @classmethod
+    def cleanup(cls) -> None:
+        """Remove all temporary directories created by URL downloads."""
+        import shutil
+
+        while cls._temp_dirs:
+            tmp_dir = cls._temp_dirs.pop()
+            shutil.rmtree(tmp_dir, ignore_errors=True)
 
     @classmethod
     def __get_pydantic_core_schema__(
@@ -282,6 +316,13 @@ class InputPath(Path):
 
     @classmethod
     def _validate(cls, value: Any, info: ValidationInfo) -> Path:
+        from tesseract_core.runtime.file_interactions import is_url
+
+        # Avoid converting URLs to Path, which mangles the scheme (e.g. strips slashes)
+        value_str = str(value)
+        if is_url(value_str):
+            return cls._download_url(value_str)
+
         return cls._resolve(Path(value), info)
 
 

--- a/tesseract_core/runtime/serve.py
+++ b/tesseract_core/runtime/serve.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel
 
 from .config import get_config
 from .core import create_endpoints
+from .experimental import InputPath
 from .file_interactions import SUPPORTED_FORMATS, join_paths, output_to_bytes
 from .mpa import start_run
 from .profiler import Profiler
@@ -71,16 +72,19 @@ def create_rest_api(api_module: ModuleType) -> FastAPI:
             rundir_name = f"run_{run_id}"
             rundir = join_paths(output_path, rundir_name)
             profiler = Profiler()
-            with start_run(base_dir=rundir):
-                with profiler:
-                    result = endpoint_func(*args, **kwargs)
+            try:
+                with start_run(base_dir=rundir):
+                    with profiler:
+                        result = endpoint_func(*args, **kwargs)
 
-                # Print profiling stats inside start_run context
-                # so they go through stdio redirection to the log file
-                profiler.print_stats()
-            return create_response(
-                result, accept, base_dir=output_path, binref_dir=rundir_name
-            )
+                    # Print profiling stats inside start_run context
+                    # so they go through stdio redirection to the log file
+                    profiler.print_stats()
+                return create_response(
+                    result, accept, base_dir=output_path, binref_dir=rundir_name
+                )
+            finally:
+                InputPath.cleanup()
 
         if endpoint_func.__name__ not in endpoints_to_wrap:
             return endpoint_func

--- a/tests/runtime_tests/test_path_types.py
+++ b/tests/runtime_tests/test_path_types.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from typing import Annotated
 
+import fsspec
 import pytest
 from pydantic import AfterValidator, BaseModel, ValidationError
 
@@ -303,3 +304,59 @@ def test_output_path_accepts_path_object(path_dirs):
     m = M(f=output_dir / "out.txt")
     assert m.f == output_dir / "out.txt"
     assert m.model_dump()["f"] == "out.txt"
+
+
+# -- URL input paths --
+
+
+@pytest.fixture
+def memory_fs():
+    """Set up an fsspec memory filesystem with a test file."""
+    fs = fsspec.filesystem("memory")
+    fs.mkdir("/test")
+    fs.pipe("/test/remote_data.json", b'{"key": "value"}')
+    yield fs
+    fs.rm("/test", recursive=True)
+    InputPath.cleanup()
+
+
+def test_input_path_downloads_url(memory_fs):
+    class M(BaseModel):
+        inp: InputPath
+
+    model = M.model_validate({"inp": "memory:///test/remote_data.json"})
+    assert model.inp.exists()
+    assert model.inp.read_bytes() == b'{"key": "value"}'
+
+
+def test_input_path_url_preserves_filename(memory_fs):
+    class M(BaseModel):
+        inp: InputPath
+
+    model = M.model_validate({"inp": "memory:///test/remote_data.json"})
+    assert model.inp.name == "remote_data.json"
+
+
+def test_input_path_cleanup(memory_fs):
+    class M(BaseModel):
+        inp: InputPath
+
+    model = M.model_validate({"inp": "memory:///test/remote_data.json"})
+    tmp_dir = model.inp.parent
+    assert tmp_dir.exists()
+
+    InputPath.cleanup()
+    assert not tmp_dir.exists()
+    assert InputPath._temp_dirs == []
+
+
+def test_input_path_local_paths_still_work(path_dirs):
+    """URL support must not break normal relative path resolution."""
+    input_dir, _ = path_dirs
+    (input_dir / "local.txt").touch()
+
+    class M(BaseModel):
+        inp: InputPath
+
+    model = M.model_validate({"inp": "local.txt"})
+    assert model.inp == input_dir / "local.txt"


### PR DESCRIPTION
#### Relevant issue or PR

n/a

#### Description of changes

`InputPath` and `InputFileReference` now allow `s3://...` urls being passed, which are downloaded to a Tesseract-local tempdir during validation. This makes it so caller and callee don't need to share a common file system to exchange files.

(Not sure what a similar solution would look like for output files, therefore keeping as draft for now.)

#### Testing done

<!-- Describe how the changes were tested; e.g., "CI passes", "Tested manually in stagingrepo#123", screenshots of a terminal session that verify the changes, or any other evidence of testing the changes. -->
