### PR TITLE
fix: Always become root at the start of docker builds

### DIFF
--- a/tesseract_core/sdk/templates/Dockerfile.base
+++ b/tesseract_core/sdk/templates/Dockerfile.base
@@ -8,6 +8,9 @@ FROM {{ config.build_config.base_image }} AS build_stage
 FROM --platform={{ config.build_config.target_platform }} {{ config.build_config.base_image }} AS build_stage
 {% endif %}
 
+# Ensure root user for build commands (some base images set a non-root default)
+USER root
+
 # Obtain uv and companions
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
@@ -57,6 +60,9 @@ FROM {{ config.build_config.base_image }} AS run_stage
 {% else %}
 FROM --platform={{ config.build_config.target_platform }} {{ config.build_config.base_image }} AS run_stage
 {% endif %}
+
+# Ensure root user for build commands (some base images set a non-root default)
+USER root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libnss-wrapper \


### PR DESCRIPTION
#### Relevant issue or PR

n/a

#### Description of changes

Currently, builds fail during `apt-get` when base images set a non-root `USER`. This fixes it by explicitly acquiring root permissions at the start of every build.

#### Testing done

None.