### PR TITLE
fix: force building for the current arch when platform is set to native

### DIFF
--- a/tesseract_core/sdk/templates/Dockerfile.base
+++ b/tesseract_core/sdk/templates/Dockerfile.base
@@ -2,8 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Stage 1: Build Python environment and install requirements
+# For "native", pin to $BUILDPLATFORM (the host platform BuildKit runs on) so the
+# base image manifest is re-resolved for the host architecture instead of reusing a
+# wrong-arch image that may already be in the local cache.
 {% if config.build_config.target_platform.strip() == "native" %}
-FROM {{ config.build_config.base_image }} AS build_stage
+FROM --platform=$BUILDPLATFORM {{ config.build_config.base_image }} AS build_stage
 {% else %}
 FROM --platform={{ config.build_config.target_platform }} {{ config.build_config.base_image }} AS build_stage
 {% endif %}


### PR DESCRIPTION
#### Relevant issue or PR

n/a

#### Description of changes

When not specifying a platform arg, Docker will pull what's available which may not match the native processor arch. Since Tesseract explicitly documents this as "build for the native architecture", we should force a platform and fail loudly when it's not available.

#### Testing done

none