### PR TITLE
fix: squash all requirement handling bugs

### DIFF
--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -154,10 +154,8 @@ def _split_local_dependency(line: str) -> tuple[str, str]:
     Returns a ``(path, extras)`` tuple where ``extras`` includes the surrounding
     brackets (e.g. ``"[extra]"``) or is empty if none are present.
     """
+    # This pattern matches any non-empty string, so a match is always found.
     match = re.match(r"^(?P<path>.+?)(?P<extras>\[[^\]]*\])?\s*\Z", line.strip())
-    if match is None:
-        # Should not happen for a non-empty line, but fall back to the raw path.
-        return line.strip(), ""
     return match.group("path"), match.group("extras") or ""
 
 

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -9,6 +9,7 @@ import logging
 import optparse
 import os
 import random
+import re
 import socket
 import tempfile
 import time
@@ -20,6 +21,7 @@ from shutil import copy, copytree, rmtree
 from typing import TYPE_CHECKING, Any, Literal
 
 import requests
+import yaml
 from jinja2 import Environment, PackageLoader, StrictUndefined
 from packaging.requirements import Requirement
 
@@ -140,6 +142,54 @@ def parse_requirements(
         else:
             remote_dependencies.append(line)
     return local_dependencies, remote_dependencies
+
+
+def _split_local_dependency(line: str) -> tuple[str, str]:
+    """Split a local dependency line into its filesystem path and extras suffix.
+
+    A local requirement may carry an extras specifier, e.g. ``./mypkg[extra]``.
+    The extras belong to the install spec, not to the path on disk, so they must
+    be separated before the path is resolved and staged.
+
+    Returns a ``(path, extras)`` tuple where ``extras`` includes the surrounding
+    brackets (e.g. ``"[extra]"``) or is empty if none are present.
+    """
+    match = re.match(r"^(?P<path>.+?)(?P<extras>\[[^\]]*\])?\s*\Z", line.strip())
+    if match is None:
+        # Should not happen for a non-empty line, but fall back to the raw path.
+        return line.strip(), ""
+    return match.group("path"), match.group("extras") or ""
+
+
+def _stage_local_dependency(
+    path: str, extras: str, src_dir: Path, local_requirements_path: Path
+) -> str:
+    """Copy a local dependency into the build context and return its install spec.
+
+    The source path is resolved relative to ``src_dir`` (so ``.``/``..`` segments
+    are collapsed) to derive a valid, unique destination name under
+    ``local_requirements/``. Returns the install spec relative to the build
+    working directory, with any extras suffix preserved.
+    """
+    resolved_src = (src_dir / path).resolve()
+
+    # Derive a valid, unique destination name from the resolved path. Using the
+    # raw path directly would break for lines like ``../..`` (whose ``.name`` is
+    # ``..``, not a real directory name).
+    dest_name = resolved_src.name
+    dest = local_requirements_path / dest_name
+    counter = 1
+    while dest.exists():
+        dest_name = f"{resolved_src.stem}_{counter}{resolved_src.suffix}"
+        dest = local_requirements_path / dest_name
+        counter += 1
+
+    if resolved_src.is_file():
+        copy(resolved_src, dest)
+    else:
+        copytree(resolved_src, dest)
+
+    return f"./local_requirements/{dest_name}{extras}"
 
 
 def get_runtime_dir() -> Path:
@@ -315,23 +365,61 @@ def prepare_build_context(
         else:
             local_dependencies, remote_dependencies = [], []
 
-        if local_dependencies:
-            for dependency in local_dependencies:
-                src = src_dir / dependency
-                dest = context_dir / "local_requirements" / src.name
-                if src.is_file():
-                    copy(src, dest)
-                else:
-                    copytree(src, dest)
+        # Stage each local dependency into the build context and rewrite it to
+        # point at the staged copy (preserving any extras suffix). The install
+        # specs are written back into the requirements file so pip installs them
+        # alongside the remote dependencies.
+        staged_dependencies = []
+        for dependency in local_dependencies:
+            path, extras = _split_local_dependency(dependency)
+            staged_dependencies.append(
+                _stage_local_dependency(path, extras, src_dir, local_requirements_path)
+            )
 
-        # We need to write a new requirements file in the build dir, where we explicitly
-        # removed the local dependencies
+        # We need to write a new requirements file in the build dir, where the
+        # local dependencies are rewritten to their staged locations.
         requirements_file_path = (
             context_dir / "__tesseract_source__" / "tesseract_requirements.txt"
         )
         with requirements_file_path.open("w", encoding="utf-8") as f:
             for dependency in remote_dependencies:
                 f.write(f"{dependency}\n")
+            for dependency in staged_dependencies:
+                f.write(f"{dependency}\n")
+
+    elif requirement_config.provider == "conda":
+        # The conda environment file may declare local-path pip dependencies via
+        # a `pip:` sub-list (e.g. `- ./mypkg_src`). conda resolves those paths
+        # relative to the environment file, but only the file itself is copied
+        # into the build stage, not the surrounding Tesseract source. Stage each
+        # local path into the build context and rewrite it to point at the
+        # staged copy, mirroring the python-pip provider.
+        env_file = src_dir / requirement_config._filename
+        env_dest = context_dir / "__tesseract_source__" / requirement_config._filename
+        if env_file.exists():
+            with env_file.open(encoding="utf-8") as f:
+                env_spec = yaml.safe_load(f) or {}
+
+            for entry in env_spec.get("dependencies", []) or []:
+                if not (isinstance(entry, dict) and "pip" in entry):
+                    continue
+                rewritten_pip = []
+                for pip_dep in entry["pip"] or []:
+                    if isinstance(pip_dep, str) and pip_dep.strip().startswith(
+                        (".", "/", "file://")
+                    ):
+                        path, extras = _split_local_dependency(pip_dep)
+                        rewritten_pip.append(
+                            _stage_local_dependency(
+                                path, extras, src_dir, local_requirements_path
+                            )
+                        )
+                    else:
+                        rewritten_pip.append(pip_dep)
+                entry["pip"] = rewritten_pip
+
+            with env_dest.open("w", encoding="utf-8") as f:
+                yaml.safe_dump(env_spec, f, sort_keys=False)
 
     def _ignore_pycache(_: Any, names: list[str]) -> list[str]:
         ignore = []

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -19,6 +19,8 @@ from importlib.metadata import requires
 from pathlib import Path
 from shutil import copy, copytree, rmtree
 from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 import requests
 import yaml
@@ -137,11 +139,26 @@ def parse_requirements(
             # this is probably a cli option like --extra-index-url, so we make
             # sure to keep it.
             remote_dependencies.append(line)
-        elif parsed_line.requirement.startswith((".", "/", "file://")):
+        elif _is_local_dependency(parsed_line.requirement):
             local_dependencies.append(line)
         else:
             remote_dependencies.append(line)
     return local_dependencies, remote_dependencies
+
+
+# Prefixes that mark a requirement as a local filesystem path rather than a
+# package name to resolve from an index.
+_LOCAL_DEPENDENCY_PREFIXES = (".", "/", "file://")
+
+
+def _is_local_dependency(spec: str) -> bool:
+    """Return whether a requirement spec refers to a local filesystem path."""
+    return spec.startswith(_LOCAL_DEPENDENCY_PREFIXES)
+
+
+def _ignore_pycache(_: Any, names: list[str]) -> list[str]:
+    """`copytree` ignore filter that drops ``__pycache__`` directories."""
+    return ["__pycache__"] if "__pycache__" in names else []
 
 
 def _split_local_dependency(line: str) -> tuple[str, str]:
@@ -151,16 +168,25 @@ def _split_local_dependency(line: str) -> tuple[str, str]:
     The extras belong to the install spec, not to the path on disk, so they must
     be separated before the path is resolved and staged.
 
+    A ``file://`` scheme is stripped so the returned path is a plain filesystem
+    path (``file://`` URLs are always absolute).
+
     Returns a ``(path, extras)`` tuple where ``extras`` includes the surrounding
     brackets (e.g. ``"[extra]"``) or is empty if none are present.
     """
     # This pattern matches any non-empty string, so a match is always found.
     match = re.match(r"^(?P<path>.+?)(?P<extras>\[[^\]]*\])?\s*\Z", line.strip())
-    return match.group("path"), match.group("extras") or ""
+    path = match.group("path")
+    if path.startswith("file://"):
+        # `Path(...)` does not understand the `file://` scheme, so convert the
+        # URL back to a native filesystem path (handles percent-encoding and an
+        # optional `localhost` authority).
+        path = url2pathname(urlparse(path).path)
+    return path, match.group("extras") or ""
 
 
 def _stage_local_dependency(
-    path: str, extras: str, src_dir: Path, local_requirements_path: Path
+    line: str, src_dir: Path, local_requirements_path: Path
 ) -> str:
     """Copy a local dependency into the build context and return its install spec.
 
@@ -169,23 +195,30 @@ def _stage_local_dependency(
     ``local_requirements/``. Returns the install spec relative to the build
     working directory, with any extras suffix preserved.
     """
+    path, extras = _split_local_dependency(line)
     resolved_src = (src_dir / path).resolve()
+
+    if not resolved_src.exists():
+        raise RuntimeError(
+            f"local dependency not found: {path} (resolved to {resolved_src})"
+        )
 
     # Derive a valid, unique destination name from the resolved path. Using the
     # raw path directly would break for lines like ``../..`` (whose ``.name`` is
-    # ``..``, not a real directory name).
+    # ``..``, not a real directory name). The collision suffix uses the full
+    # name so versioned names like ``pkg-1.0`` are not split on the dot.
     dest_name = resolved_src.name
     dest = local_requirements_path / dest_name
     counter = 1
     while dest.exists():
-        dest_name = f"{resolved_src.stem}_{counter}{resolved_src.suffix}"
+        dest_name = f"{resolved_src.name}_{counter}"
         dest = local_requirements_path / dest_name
         counter += 1
 
     if resolved_src.is_file():
         copy(resolved_src, dest)
     else:
-        copytree(resolved_src, dest)
+        copytree(resolved_src, dest, ignore=_ignore_pycache)
 
     return f"./local_requirements/{dest_name}{extras}"
 
@@ -367,23 +400,20 @@ def prepare_build_context(
         # point at the staged copy (preserving any extras suffix). The install
         # specs are written back into the requirements file so pip installs them
         # alongside the remote dependencies.
-        staged_dependencies = []
-        for dependency in local_dependencies:
-            path, extras = _split_local_dependency(dependency)
-            staged_dependencies.append(
-                _stage_local_dependency(path, extras, src_dir, local_requirements_path)
-            )
+        staged_dependencies = [
+            _stage_local_dependency(dependency, src_dir, local_requirements_path)
+            for dependency in local_dependencies
+        ]
 
         # We need to write a new requirements file in the build dir, where the
         # local dependencies are rewritten to their staged locations.
         requirements_file_path = (
             context_dir / "__tesseract_source__" / "tesseract_requirements.txt"
         )
+        lines = remote_dependencies + staged_dependencies
         with requirements_file_path.open("w", encoding="utf-8") as f:
-            for dependency in remote_dependencies:
-                f.write(f"{dependency}\n")
-            for dependency in staged_dependencies:
-                f.write(f"{dependency}\n")
+            if lines:
+                f.write("\n".join(lines) + "\n")
 
     elif requirement_config.provider == "conda":
         # The conda environment file may declare local-path pip dependencies via
@@ -403,13 +433,12 @@ def prepare_build_context(
                     continue
                 rewritten_pip = []
                 for pip_dep in entry["pip"] or []:
-                    if isinstance(pip_dep, str) and pip_dep.strip().startswith(
-                        (".", "/", "file://")
+                    if isinstance(pip_dep, str) and _is_local_dependency(
+                        pip_dep.strip()
                     ):
-                        path, extras = _split_local_dependency(pip_dep)
                         rewritten_pip.append(
                             _stage_local_dependency(
-                                path, extras, src_dir, local_requirements_path
+                                pip_dep, src_dir, local_requirements_path
                             )
                         )
                     else:
@@ -418,12 +447,6 @@ def prepare_build_context(
 
             with env_dest.open("w", encoding="utf-8") as f:
                 yaml.safe_dump(env_spec, f, sort_keys=False)
-
-    def _ignore_pycache(_: Any, names: list[str]) -> list[str]:
-        ignore = []
-        if "__pycache__" in names:
-            ignore.append("__pycache__")
-        return ignore
 
     runtime_source_dir = get_runtime_dir()
     copytree(

--- a/tesseract_core/sdk/templates/build_pip_venv.sh
+++ b/tesseract_core/sdk/templates/build_pip_venv.sh
@@ -17,14 +17,10 @@ else
 fi
 source /python-env/bin/activate
 
-# Collect dependencies
-TESSERACT_DEPS=$(find ./local_requirements/ -mindepth 1 -maxdepth 1 2>/dev/null || true)
-
-# Append requirements file
-TESSERACT_DEPS+=" -r tesseract_requirements.txt"
-
-# Install dependencies
-uv -v pip install --compile-bytecode $TESSERACT_DEPS
+# Install dependencies. Local dependencies (if any) are rewritten into the
+# requirements file as paths under ./local_requirements/, so a single install
+# from the requirements file covers both remote and local dependencies.
+uv -v pip install --compile-bytecode -r tesseract_requirements.txt
 
 # HACK: If `tesseract_core` is part of tesseract_requirements.txt, it may install an incompatible version
 # of the runtime from PyPI. We remove the runtime folder and install the local version instead.

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -202,10 +202,51 @@ def test_prepare_build_context_local_dependency_with_extras(tmp_path_factory):
     # The rewritten requirements file installs it from the staged copy, keeping
     # the extra so pip installs it.
     reqs = (
-        build_dir / "__tesseract_source__" / "tesseract_requirements.txt"
-    ).read_text()
+        (build_dir / "__tesseract_source__" / "tesseract_requirements.txt")
+        .read_text()
+        .splitlines()
+    )
     assert "numpy" in reqs
     assert "./local_requirements/mylocaldep[extra]" in reqs
+    # The original local line is rewritten, not carried over verbatim.
+    assert "./mylocaldep[extra]" not in reqs
+
+
+def test_prepare_build_context_local_dependency_file_url(tmp_path_factory):
+    """Local pip dependency given as a file:// URL is staged (issue #643)."""
+    dep_dir = tmp_path_factory.mktemp("dep") / "mylocaldep"
+    dep_dir.mkdir()
+    (dep_dir / "setup.py").touch()
+    src_dir = tmp_path_factory.mktemp("src")
+    (src_dir / "tesseract_api.py").touch()
+    (src_dir / "tesseract_requirements.txt").write_text(f"numpy\nfile://{dep_dir}\n")
+    build_dir = tmp_path_factory.mktemp("build")
+
+    config = TesseractConfig(name="foobar")
+    engine.prepare_build_context(src_dir, build_dir, config)
+
+    # The file:// URL is resolved to a native path and staged by its name.
+    assert (build_dir / "local_requirements" / "mylocaldep").is_dir()
+
+    reqs = (
+        (build_dir / "__tesseract_source__" / "tesseract_requirements.txt")
+        .read_text()
+        .splitlines()
+    )
+    assert "numpy" in reqs
+    assert "./local_requirements/mylocaldep" in reqs
+
+
+def test_prepare_build_context_local_dependency_not_found(tmp_path_factory):
+    """A local dependency that does not exist raises a clear error."""
+    src_dir = tmp_path_factory.mktemp("src")
+    (src_dir / "tesseract_api.py").touch()
+    (src_dir / "tesseract_requirements.txt").write_text("./does_not_exist\n")
+    build_dir = tmp_path_factory.mktemp("build")
+
+    config = TesseractConfig(name="foobar")
+    with pytest.raises(RuntimeError, match="local dependency not found"):
+        engine.prepare_build_context(src_dir, build_dir, config)
 
 
 def test_prepare_build_context_local_dependency_parent_path(tmp_path_factory):
@@ -227,9 +268,12 @@ def test_prepare_build_context_local_dependency_parent_path(tmp_path_factory):
     assert (build_dir / "local_requirements" / "mypkg").is_dir()
     assert [p.name for p in (build_dir / "local_requirements").iterdir()] == ["mypkg"]
     reqs = (
-        build_dir / "__tesseract_source__" / "tesseract_requirements.txt"
-    ).read_text()
+        (build_dir / "__tesseract_source__" / "tesseract_requirements.txt")
+        .read_text()
+        .splitlines()
+    )
     assert "./local_requirements/mypkg" in reqs
+    assert "../../mypkg" not in reqs
 
 
 def test_prepare_build_context_conda_local_dependency(tmp_path_factory):
@@ -270,6 +314,8 @@ def test_prepare_build_context_conda_local_dependency(tmp_path_factory):
     pip_entry = next(e["pip"] for e in rewritten["dependencies"] if isinstance(e, dict))
     assert "requests" in pip_entry
     assert "./local_requirements/mypkg_src" in pip_entry
+    # The original local path is rewritten, not carried over verbatim.
+    assert "./mypkg_src" not in pip_entry
 
 
 @pytest.mark.parametrize("generate_only", [True, False])
@@ -764,6 +810,8 @@ def test_prepare_build_context_conda_no_env_file(tmp_path_factory):
         ("../../pkg[a,b]", ("../../pkg", "[a,b]")),
         ("/abs/path", ("/abs/path", "")),
         ("./a[b] ", ("./a", "[b]")),
+        ("file:///abs/path", ("/abs/path", "")),
+        ("file:///abs/path[extra]", ("/abs/path", "[extra]")),
     ],
 )
 def test_split_local_dependency(line, expected):
@@ -779,7 +827,7 @@ def test_stage_local_dependency_file(tmp_path):
     local_requirements.mkdir()
 
     spec = engine._stage_local_dependency(
-        "./mypkg-1.0-py3-none-any.whl", "", src_dir, local_requirements
+        "./mypkg-1.0-py3-none-any.whl", src_dir, local_requirements
     )
     staged = local_requirements / "mypkg-1.0-py3-none-any.whl"
     assert spec == "./local_requirements/mypkg-1.0-py3-none-any.whl"
@@ -795,12 +843,8 @@ def test_stage_local_dependency_name_collision(tmp_path):
     local_requirements = tmp_path / "local_requirements"
     local_requirements.mkdir()
 
-    spec_a = engine._stage_local_dependency(
-        "./a/mypkg", "", src_dir, local_requirements
-    )
-    spec_b = engine._stage_local_dependency(
-        "./b/mypkg", "", src_dir, local_requirements
-    )
+    spec_a = engine._stage_local_dependency("./a/mypkg", src_dir, local_requirements)
+    spec_b = engine._stage_local_dependency("./b/mypkg", src_dir, local_requirements)
     assert spec_a == "./local_requirements/mypkg"
     assert spec_b == "./local_requirements/mypkg_1"
     assert (local_requirements / "mypkg").is_dir()

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -219,7 +219,8 @@ def test_prepare_build_context_local_dependency_file_url(tmp_path_factory):
     (dep_dir / "setup.py").touch()
     src_dir = tmp_path_factory.mktemp("src")
     (src_dir / "tesseract_api.py").touch()
-    (src_dir / "tesseract_requirements.txt").write_text(f"numpy\nfile://{dep_dir}\n")
+    # `Path.as_uri()` yields a well-formed file:// URL on any platform.
+    (src_dir / "tesseract_requirements.txt").write_text(f"numpy\n{dep_dir.as_uri()}\n")
     build_dir = tmp_path_factory.mktemp("build")
 
     config = TesseractConfig(name="foobar")
@@ -810,12 +811,24 @@ def test_prepare_build_context_conda_no_env_file(tmp_path_factory):
         ("../../pkg[a,b]", ("../../pkg", "[a,b]")),
         ("/abs/path", ("/abs/path", "")),
         ("./a[b] ", ("./a", "[b]")),
-        ("file:///abs/path", ("/abs/path", "")),
-        ("file:///abs/path[extra]", ("/abs/path", "[extra]")),
     ],
 )
 def test_split_local_dependency(line, expected):
     assert engine._split_local_dependency(line) == expected
+
+
+def test_split_local_dependency_file_url(tmp_path):
+    """A file:// URL is converted back to a native filesystem path."""
+    target = tmp_path / "mypkg"
+    # `Path.as_uri()` produces a correctly-formed file:// URL on any platform,
+    # so this round-trips regardless of the OS path separator.
+    path, extras = engine._split_local_dependency(target.as_uri())
+    assert path == str(target)
+    assert extras == ""
+
+    path, extras = engine._split_local_dependency(target.as_uri() + "[extra]")
+    assert path == str(target)
+    assert extras == "[extra]"
 
 
 def test_stage_local_dependency_file(tmp_path):

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -184,6 +184,94 @@ def test_prepare_build_context_package_data_not_found(tmp_path_factory):
         engine.prepare_build_context(src_dir, build_dir, config)
 
 
+def test_prepare_build_context_local_dependency_with_extras(tmp_path_factory):
+    """Local pip dependency with an extras specifier is staged (issue #643)."""
+    src_dir = tmp_path_factory.mktemp("src")
+    (src_dir / "tesseract_api.py").touch()
+    (src_dir / "mylocaldep").mkdir()
+    (src_dir / "tesseract_requirements.txt").write_text("numpy\n./mylocaldep[extra]\n")
+    build_dir = tmp_path_factory.mktemp("build")
+
+    config = TesseractConfig(name="foobar")
+    engine.prepare_build_context(src_dir, build_dir, config)
+
+    # The directory (without the extras suffix) is staged.
+    assert (build_dir / "local_requirements" / "mylocaldep").is_dir()
+    assert not (build_dir / "local_requirements" / "mylocaldep[extra]").exists()
+
+    # The rewritten requirements file installs it from the staged copy, keeping
+    # the extra so pip installs it.
+    reqs = (
+        build_dir / "__tesseract_source__" / "tesseract_requirements.txt"
+    ).read_text()
+    assert "numpy" in reqs
+    assert "./local_requirements/mylocaldep[extra]" in reqs
+
+
+def test_prepare_build_context_local_dependency_parent_path(tmp_path_factory):
+    """Local pip dependency reached via ../.. is staged (issue #630)."""
+    parent_dir = tmp_path_factory.mktemp("parent")
+    # A package that lives two levels above the Tesseract source directory.
+    (parent_dir / "mypkg").mkdir()
+    (parent_dir / "mypkg" / "setup.py").touch()
+    src_dir = parent_dir / "sub" / "tesseract"
+    src_dir.mkdir(parents=True)
+    (src_dir / "tesseract_api.py").touch()
+    (src_dir / "tesseract_requirements.txt").write_text("../../mypkg\n")
+    build_dir = tmp_path_factory.mktemp("build")
+
+    config = TesseractConfig(name="foobar")
+    engine.prepare_build_context(src_dir, build_dir, config)
+
+    # The staged name comes from the resolved path, not from `../..`.
+    assert (build_dir / "local_requirements" / "mypkg").is_dir()
+    assert [p.name for p in (build_dir / "local_requirements").iterdir()] == ["mypkg"]
+    reqs = (
+        build_dir / "__tesseract_source__" / "tesseract_requirements.txt"
+    ).read_text()
+    assert "./local_requirements/mypkg" in reqs
+
+
+def test_prepare_build_context_conda_local_dependency(tmp_path_factory):
+    """Conda provider stages local-path pip dependencies (issue #641)."""
+    src_dir = tmp_path_factory.mktemp("src")
+    (src_dir / "tesseract_api.py").touch()
+    (src_dir / "mypkg_src").mkdir()
+    (src_dir / "mypkg_src" / "setup.py").touch()
+    env_spec = {
+        "name": "tesseract",
+        "channels": ["conda-forge"],
+        "dependencies": [
+            "python=3.12",
+            "pip",
+            {"pip": ["requests", "./mypkg_src"]},
+        ],
+    }
+    with (src_dir / "tesseract_environment.yaml").open("w") as f:
+        yaml.safe_dump(env_spec, f)
+    build_dir = tmp_path_factory.mktemp("build")
+
+    config = TesseractConfig(
+        name="foobar",
+        build_config=TesseractBuildConfig(
+            requirements={"provider": "conda"},
+        ),
+    )
+    engine.prepare_build_context(src_dir, build_dir, config)
+
+    # The local package is staged into the build context.
+    assert (build_dir / "local_requirements" / "mypkg_src").is_dir()
+
+    # The rewritten environment file points pip at the staged copy while leaving
+    # remote dependencies untouched.
+    rewritten = yaml.safe_load(
+        (build_dir / "__tesseract_source__" / "tesseract_environment.yaml").read_text()
+    )
+    pip_entry = next(e["pip"] for e in rewritten["dependencies"] if isinstance(e, dict))
+    assert "requests" in pip_entry
+    assert "./local_requirements/mypkg_src" in pip_entry
+
+
 @pytest.mark.parametrize("generate_only", [True, False])
 def test_build_tesseract(dummy_tesseract_package, mocked_docker, generate_only, caplog):
     """Test we can build an image for a package and keep build directory."""

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -742,6 +742,71 @@ def test_parse_requirements(tmpdir):
     ]
 
 
+def test_prepare_build_context_conda_no_env_file(tmp_path_factory):
+    """Conda provider without an environment file does not error at staging."""
+    src_dir = tmp_path_factory.mktemp("src")
+    (src_dir / "tesseract_api.py").touch()
+    build_dir = tmp_path_factory.mktemp("build")
+
+    config = TesseractConfig(
+        name="foobar",
+        build_config=TesseractBuildConfig(requirements={"provider": "conda"}),
+    )
+    engine.prepare_build_context(src_dir, build_dir, config)
+    assert (build_dir / "Dockerfile").exists()
+
+
+@pytest.mark.parametrize(
+    "line, expected",
+    [
+        ("./mylocaldep", ("./mylocaldep", "")),
+        ("./mylocaldep[extra]", ("./mylocaldep", "[extra]")),
+        ("../../pkg[a,b]", ("../../pkg", "[a,b]")),
+        ("/abs/path", ("/abs/path", "")),
+        ("./a[b] ", ("./a", "[b]")),
+    ],
+)
+def test_split_local_dependency(line, expected):
+    assert engine._split_local_dependency(line) == expected
+
+
+def test_stage_local_dependency_file(tmp_path):
+    """A local file dependency (e.g. a wheel) is copied, not tree-copied."""
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "mypkg-1.0-py3-none-any.whl").write_text("wheel contents")
+    local_requirements = tmp_path / "local_requirements"
+    local_requirements.mkdir()
+
+    spec = engine._stage_local_dependency(
+        "./mypkg-1.0-py3-none-any.whl", "", src_dir, local_requirements
+    )
+    staged = local_requirements / "mypkg-1.0-py3-none-any.whl"
+    assert spec == "./local_requirements/mypkg-1.0-py3-none-any.whl"
+    assert staged.is_file()
+    assert staged.read_text() == "wheel contents"
+
+
+def test_stage_local_dependency_name_collision(tmp_path):
+    """Two dependencies resolving to the same basename get distinct staged names."""
+    src_dir = tmp_path / "src"
+    (src_dir / "a" / "mypkg").mkdir(parents=True)
+    (src_dir / "b" / "mypkg").mkdir(parents=True)
+    local_requirements = tmp_path / "local_requirements"
+    local_requirements.mkdir()
+
+    spec_a = engine._stage_local_dependency(
+        "./a/mypkg", "", src_dir, local_requirements
+    )
+    spec_b = engine._stage_local_dependency(
+        "./b/mypkg", "", src_dir, local_requirements
+    )
+    assert spec_a == "./local_requirements/mypkg"
+    assert spec_b == "./local_requirements/mypkg_1"
+    assert (local_requirements / "mypkg").is_dir()
+    assert (local_requirements / "mypkg_1").is_dir()
+
+
 @pytest.mark.parametrize(
     "spec, expected",
     [


### PR DESCRIPTION
#### Relevant issue or PR

Fixes #630 
Fixes #641 
Fixes #643

#### Description of changes

See corresponding issues for details.

- `../` in `tesseract_requirements.txt` is now working as intended.
- `./mypackage[extra]` in `tesseract_requirements.txt` is now working as intended.
- `pip: ./mypackage` in `tessearct_environment.yaml` (conda provider) is now working as intended.

#### Testing done

CI, new tests
