### PR TITLE
fix: Get rid of hardcoded ports in run_tesseract's debug logic

### DIFF
--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -1268,12 +1268,12 @@ def run_tesseract(
         # `network="host"` binds the container's debugpy port directly on the host,
         # so no explicit port mapping is needed (and would actually be rejected).
         if network == "host":
-            debugpy_port = "5678"
+            debugpy_port = CONTAINER_DEBUGPY_PORT
         else:
             debugpy_port = str(get_free_port())
             if ports is None:
                 ports = {}
-            ports[f"127.0.0.1:{debugpy_port}"] = "5678"
+            ports[f"127.0.0.1:{debugpy_port}"] = CONTAINER_DEBUGPY_PORT
         logger.info(
             f"Debug mode enabled. Attach a debugger to localhost:{debugpy_port} "
             "to start execution (see the 'Debug mode' section of the docs for a "

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -435,8 +435,27 @@ def test_run_debug(mocked_docker):
     res = json.loads(res_out)
     # TESSERACT_DEBUG is set so the runtime starts debugpy and waits for a client.
     assert res["environment"]["TESSERACT_DEBUG"] == "1"
-    # The container's debugpy port (5678) is forwarded to a free port on the host.
-    assert "5678" in res["ports"].values()
+
+    assert engine.CONTAINER_DEBUGPY_PORT in res["ports"].values()
+
+
+def test_run_debug_host_network(mocked_docker):
+    """With host networking, debugpy binds the host port directly (no mapping)."""
+    res_out, _ = engine.run_tesseract(
+        "foobar",
+        "apply",
+        ['{"inputs": {"a": [1, 2, 3], "b": [4, 5, 6]}}'],
+        debug=True,
+        network="host",
+    )
+
+    res = json.loads(res_out)
+
+    assert res["network"] == "host"
+    assert res["environment"]["TESSERACT_DEBUG"] == "1"
+    # No port mapping is added: the container binds the debugpy port on the host
+    # directly, so an explicit mapping would be rejected.
+    assert not res["ports"]
 
 
 def test_run_gpu(mocked_docker):


### PR DESCRIPTION
#### Relevant issue or PR

#631 was merged before I adapted it to the changes in #649

#### Description of changes

  *  Debugpy ports inside containers were hardcoded to 5678; this uses the newly-defined `CONTAINER_DEBUGPY_PORT` constant
  *  Use constant in test + en-passant add test for debug in host network mode 

#### Testing done
👁️__👁️ 