### PR TITLE
doc: Set runtime license

### DIFF
--- a/tesseract_core/runtime/meta/pyproject.toml.jinja
+++ b/tesseract_core/runtime/meta/pyproject.toml.jinja
@@ -1,6 +1,7 @@
 [project]
 name = "tesseract_runtime"
 version = "{{ version }}"
+license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 
 dependencies = [


### PR DESCRIPTION
#### Description of changes
Noticed that runtime does not declare its license.

#### Testing done
Running inside the tesseract container. Before:
```
root@03636bb48852:/tesseract# pip-licenses | grep tesseract
 tesseract_runtime                   1.11.1.dev6+g15486dc71  UNKNOWN 
```

After:
```
 root@722db7425cae:/tesseract# pip-licenses | grep tesseract
 tesseract_runtime                   1.11.1.dev6+g15486dc71  Apache-2.0 
```