### PR TITLE
feat: Make the debugpy address configurable

### DIFF
--- a/tesseract_core/runtime/cli.py
+++ b/tesseract_core/runtime/cli.py
@@ -231,7 +231,7 @@ def _schema_to_docstring(schema: Any, current_indent: int = 0) -> str:
     return "\n".join(docstring)
 
 
-def _start_debug_server(wait_for_client: bool, port: int = 5678) -> None:
+def _start_debug_server(wait_for_client: bool, host: str, port: int) -> None:
     """Start a debugpy server for remote debugging.
 
     The long-running ``serve`` command launches a non-blocking server that a
@@ -242,7 +242,11 @@ def _start_debug_server(wait_for_client: bool, port: int = 5678) -> None:
 
     Args:
         wait_for_client: If True, block until a debugger attaches.
-        port: Port to listen on inside the container.
+        host: Address to bind, e.g. "127.0.0.1" for debuggers on this machine
+            only, "0.0.0.0" for any. Whoever reaches this port can run code as
+            this process.
+        port: Port to bind. Two Tesseracts cannot share one unless they are in
+            separate containers.
     """
     # Python 3.11+ freezes stdlib bootstrap modules, which makes debugpy print a
     # noisy "frozen modules" warning (it could only ever miss breakpoints inside
@@ -251,7 +255,19 @@ def _start_debug_server(wait_for_client: bool, port: int = 5678) -> None:
 
     import debugpy
 
-    debugpy.listen(("0.0.0.0", port))
+    debugpy.listen((host, port))
+    # Report the address actually bound. Callers that remap it (a container
+    # publishing it on a different host port) report the reachable address
+    # themselves; this is the only report when there is no remapping.
+    #
+    # WARNING: the SDK parses this line to check a container honoured the port it
+    # was given -- see `_warn_if_debugger_unreachable` in tesseract_core/sdk/engine.py.
+    # Reformatting it will make that check miss and warn about a working setup.
+    print(
+        f"Debugger listening on {host}:{port}",
+        file=sys.stderr,
+        flush=True,
+    )
     if wait_for_client:
         print(
             "Debug mode enabled, waiting for debugger to attach...",
@@ -425,9 +441,14 @@ def serve(
     num_workers: Annotated[int, typer.Option(help="Number of worker processes")] = 1,
 ) -> None:
     """Start running this Tesseract's web server."""
-    if get_config().debug:
+    config = get_config()
+    if config.debug:
         # The server is long-running, so a debugger can attach at any time.
-        _start_debug_server(wait_for_client=False)
+        _start_debug_server(
+            wait_for_client=False,
+            host=config.debugpy_host,
+            port=config.debugpy_port,
+        )
     serve_(host=host, port=port, num_workers=num_workers)
 
 
@@ -608,8 +629,13 @@ def main() -> None:
         # `_configure_required_file_load` above): `serve` launches its own
         # non-blocking debugger and must not block, and help should not block.
         skip_debug_wait_args = {"serve", "-h", "--help"}
-        if get_config().debug and not skip_debug_wait_args.intersection(sys.argv):
-            _start_debug_server(wait_for_client=True)
+        config = get_config()
+        if config.debug and not skip_debug_wait_args.intersection(sys.argv):
+            _start_debug_server(
+                wait_for_client=True,
+                host=config.debugpy_host,
+                port=config.debugpy_port,
+            )
 
         _add_user_commands_to_cli(app, out_stream=orig_stdout)
         app(auto_envvar_prefix="TESSERACT_RUNTIME")

--- a/tesseract_core/runtime/cli.py
+++ b/tesseract_core/runtime/cli.py
@@ -245,8 +245,7 @@ def _start_debug_server(wait_for_client: bool, host: str, port: int) -> None:
         host: Address to bind, e.g. "127.0.0.1" for debuggers on this machine
             only, "0.0.0.0" for any. Whoever reaches this port can run code as
             this process.
-        port: Port to bind. Two Tesseracts cannot share one unless they are in
-            separate containers.
+        port: Port to bind, must be unique per host/container.
     """
     # Python 3.11+ freezes stdlib bootstrap modules, which makes debugpy print a
     # noisy "frozen modules" warning (it could only ever miss breakpoints inside

--- a/tesseract_core/runtime/cli.py
+++ b/tesseract_core/runtime/cli.py
@@ -243,8 +243,8 @@ def _start_debug_server(wait_for_client: bool, host: str, port: int) -> None:
     Args:
         wait_for_client: If True, block until a debugger attaches.
         host: Address to bind, e.g. "127.0.0.1" for debuggers on this machine
-            only, "0.0.0.0" for any. Whoever reaches this port can run code as
-            this process.
+            only, "0.0.0.0" for any. WARNING: Whoever connects to the debugger
+            can run arbitrary code, use with caution.
         port: Port to bind, must be unique per host/container.
     """
     # Python 3.11+ freezes stdlib bootstrap modules, which makes debugpy print a

--- a/tesseract_core/runtime/config.py
+++ b/tesseract_core/runtime/config.py
@@ -36,6 +36,8 @@ class RuntimeConfig(BaseModel):
     description: str = ""
     version: str = "unknown"
     debug: bool = False
+    debugpy_host: str = "127.0.0.1"
+    debugpy_port: int = 5678
     input_path: str = "."
     output_path: str = "."
     output_format: supported_format_type = "json"

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -4,6 +4,7 @@
 """Engine to power Tesseract commands."""
 
 import datetime
+import ipaddress
 import linecache
 import logging
 import optparse
@@ -728,6 +729,97 @@ class _PortInUseError(RuntimeError):
 _PORT_CONFLICT_MARKERS = ("address already in use", "port is already allocated")
 
 
+def _warn_if_debugger_unreachable(container: Container, expected_port: str) -> None:
+    """Warn if the container did not bind the debug port we published a mapping to.
+
+    Which port it binds is decided by the runtime inside the image, and one built
+    before the port was configurable ignores it and uses the default, leaving the
+    mapping published with nothing behind it. Nothing else fails -- the Tesseract
+    is healthy and only the debugger is unreachable -- so it would otherwise look
+    like it worked.
+
+    A warning rather than an error, because this reads a log line the runtime
+    prints: reformatting it there would make this miss and condemn a working
+    setup. Serving is still useful either way.
+    """
+    logs = container.logs(stdout=True, stderr=True).decode("utf-8", errors="replace")
+    match = re.search(r"Debugger listening on \S+?:(\d+)", logs)
+    if match is not None and match.group(1) == expected_port:
+        return
+    bound = f"port {match.group(1)}" if match else "an unknown port"
+    logger.warning(
+        f"Tesseract is debugging on {bound}, not the requested {expected_port}, "
+        "so no debugger can attach. Rebuild it to choose the port."
+    )
+
+
+def _debug_setting(environment: dict[str, str], setting: str) -> str | None:
+    """Read a runtime setting, honouring both names it can arrive under.
+
+    Typer binds every config option to ``TESSERACT_RUNTIME_*`` as well, and that
+    takes precedence over the ``TESSERACT_*`` the config itself reads.
+    """
+    return environment.get(f"TESSERACT_RUNTIME_{setting}") or environment.get(
+        f"TESSERACT_{setting}"
+    )
+
+
+def _is_loopback(host: str) -> bool:
+    """Whether an address only accepts connections from the same host."""
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return host.lower() == "localhost"
+
+
+def _resolve_container_debug_address(
+    requested_port: str | None,
+    requested_host: str | None,
+    *,
+    port_mapped: bool,
+    reserved_ports: Collection[str],
+) -> tuple[dict[str, str], str]:
+    """Settle the debugpy address for a container, without touching the caller's.
+
+    A published mapping sends a host port to a port on the container, so the port
+    debugpy binds and the container side of that mapping must agree. Nothing is
+    special about the default, so a chosen port is honoured and published against.
+    Refused only where it cannot work: a port already taken inside the container,
+    or, under port mapping, a loopback host -- publishing reaches the container
+    over its network interface, so it cannot see a debugger that only accepts
+    connections from inside. Any routable address is fine, including the
+    container's own.
+
+    Returns:
+        Environment entries to apply, and the port debugpy will bind, which the
+        caller must publish against.
+    """
+    port = requested_port or CONTAINER_DEBUGPY_PORT
+
+    if port in reserved_ports:
+        raise UserError(
+            f"Port {port} is already in use inside the container. Choose another "
+            f"debug port, or leave it unset to use {CONTAINER_DEBUGPY_PORT}."
+        )
+
+    if port_mapped and requested_host is not None and _is_loopback(requested_host):
+        raise UserError(
+            f"TESSERACT_DEBUGPY_HOST={requested_host} will not work in a "
+            "container: its published port reaches the container from outside, "
+            "which an address that only accepts local connections rejects. Leave "
+            "it unset."
+        )
+
+    # Written under both names, so a value inherited under the other cannot win.
+    updates = {f"TESSERACT{p}_DEBUGPY_PORT": port for p in ("", "_RUNTIME")}
+    if port_mapped:
+        # All interfaces unless asked for something specific, which the runtime
+        # would otherwise default to loopback and be unreachable.
+        host = requested_host or "0.0.0.0"
+        updates.update({f"TESSERACT{p}_DEBUGPY_HOST": host for p in ("", "_RUNTIME")})
+    return updates, port
+
+
 def _is_port_conflict(stderr: str) -> bool:
     """Whether runtime stderr/logs indicate a host port collision."""
     lowered = stderr.lower()
@@ -897,6 +989,11 @@ def serve(
     if output_format:
         environment["TESSERACT_OUTPUT_FORMAT"] = output_format
 
+    # Read after runtime_config lands in the environment, which is how the SDK
+    # passes it. Only a port the caller asked for needs checking afterwards; the
+    # default works whatever the image was built with.
+    requested_debugpy_port = _debug_setting(environment, "DEBUGPY_PORT")
+
     # A port picked by get_free_port can be grabbed by another process between
     # our check and the container binding it (an unavoidable race, since the
     # port must be released before the container can bind it). When we choose
@@ -945,13 +1042,25 @@ def serve(
         args.extend(["--host", "0.0.0.0"])
 
         if debug:
-            # debugpy binds a fixed port inside the container; only its host
-            # mapping is dynamic. Exclude the host API port so the two host
-            # ports never collide (they share the same range).
+            environment["TESSERACT_DEBUG"] = "1"
+            debug_updates, container_debugpy_port = _resolve_container_debug_address(
+                requested_debugpy_port,
+                _debug_setting(environment, "DEBUGPY_HOST"),
+                port_mapped=port_mappings is not None,
+                reserved_ports={container_api_port},
+            )
+            environment.update(debug_updates)
+            # Only the host side of the debugger's mapping is dynamic. Exclude
+            # the host API port so the two host ports never collide (they share
+            # the same range).
             debugpy_port = str(get_free_port(exclude=(int(port),)))
             if port_mappings is not None:
-                port_mappings[f"{host_ip}:{debugpy_port}"] = CONTAINER_DEBUGPY_PORT
-            environment["TESSERACT_DEBUG"] = "1"
+                port_mappings[f"{host_ip}:{debugpy_port}"] = container_debugpy_port
+            else:
+                # Host networking: the container binds the host's namespace
+                # directly, so there is nothing to map and the port it binds is
+                # the one to attach to.
+                debugpy_port = container_debugpy_port
 
         extra_args = [
             "--restart",
@@ -1013,10 +1122,15 @@ def serve(
             continue
         break
 
+    if debug and requested_debugpy_port and not skip_health_check:
+        _warn_if_debugger_unreachable(container, container_debugpy_port)
+
     logger.info(f"Serving Tesseract at http://{ping_ip}:{port}")
     logger.info(f"View Tesseract: http://{ping_ip}:{port}/docs")
     if debug:
-        logger.info(f"Debugpy server listening at http://{ping_ip}:{debugpy_port}")
+        logger.info(
+            f"Debug mode enabled. Attach a debugger to {ping_ip}:{debugpy_port}"
+        )
 
     return container.name, container
 
@@ -1264,16 +1378,34 @@ def run_tesseract(
         _ensure_network_exists(network)
 
     if debug:
+        requested_debugpy_port = _debug_setting(environment, "DEBUGPY_PORT")
         environment["TESSERACT_DEBUG"] = "1"
+        debug_updates, container_debugpy_port = _resolve_container_debug_address(
+            requested_debugpy_port,
+            _debug_setting(environment, "DEBUGPY_HOST"),
+            port_mapped=network != "host",
+            reserved_ports=set(),
+        )
+        environment.update(debug_updates)
+        if requested_debugpy_port:
+            # This command blocks until a debugger attaches and never hands
+            # control back, so unlike `serve` there is no point at which we could
+            # check the port was honoured.
+            logger.warning(
+                "Cannot verify whether the debugpy port is configurable when "
+                "using `tesseract run`. Configuration is not possible for some "
+                "old Tesseracts; rebuild the Tesseract if your debugger cannot "
+                "attach."
+            )
         # `network="host"` binds the container's debugpy port directly on the host,
         # so no explicit port mapping is needed (and would actually be rejected).
         if network == "host":
-            debugpy_port = CONTAINER_DEBUGPY_PORT
+            debugpy_port = container_debugpy_port
         else:
             debugpy_port = str(get_free_port())
             if ports is None:
                 ports = {}
-            ports[f"127.0.0.1:{debugpy_port}"] = CONTAINER_DEBUGPY_PORT
+            ports[f"127.0.0.1:{debugpy_port}"] = container_debugpy_port
         logger.info(
             f"Debug mode enabled. Attach a debugger to localhost:{debugpy_port} "
             "to start execution (see the 'Debug mode' section of the docs for a "

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -753,8 +753,8 @@ def _warn_if_debugger_unreachable(container: Container, expected_port: str) -> N
     )
 
 
-def _debug_setting(environment: dict[str, str], setting: str) -> str | None:
-    """Read a runtime setting, honouring both names it can arrive under.
+def _get_runtime_setting(environment: dict[str, str], setting: str) -> str | None:
+    """Read a runtime setting from an environment, under either name it takes.
 
     Typer binds every config option to ``TESSERACT_RUNTIME_*`` as well, and that
     takes precedence over the ``TESSERACT_*`` the config itself reads.
@@ -992,7 +992,7 @@ def serve(
     # Read after runtime_config lands in the environment, which is how the SDK
     # passes it. Only a port the caller asked for needs checking afterwards; the
     # default works whatever the image was built with.
-    requested_debugpy_port = _debug_setting(environment, "DEBUGPY_PORT")
+    requested_debugpy_port = _get_runtime_setting(environment, "DEBUGPY_PORT")
 
     # A port picked by get_free_port can be grabbed by another process between
     # our check and the container binding it (an unavoidable race, since the
@@ -1045,7 +1045,7 @@ def serve(
             environment["TESSERACT_DEBUG"] = "1"
             debug_updates, container_debugpy_port = _resolve_container_debug_address(
                 requested_debugpy_port,
-                _debug_setting(environment, "DEBUGPY_HOST"),
+                _get_runtime_setting(environment, "DEBUGPY_HOST"),
                 port_mapped=port_mappings is not None,
                 reserved_ports={container_api_port},
             )
@@ -1378,11 +1378,11 @@ def run_tesseract(
         _ensure_network_exists(network)
 
     if debug:
-        requested_debugpy_port = _debug_setting(environment, "DEBUGPY_PORT")
+        requested_debugpy_port = _get_runtime_setting(environment, "DEBUGPY_PORT")
         environment["TESSERACT_DEBUG"] = "1"
         debug_updates, container_debugpy_port = _resolve_container_debug_address(
             requested_debugpy_port,
-            _debug_setting(environment, "DEBUGPY_HOST"),
+            _get_runtime_setting(environment, "DEBUGPY_HOST"),
             port_mapped=network != "host",
             reserved_ports=set(),
         )
@@ -1394,7 +1394,7 @@ def run_tesseract(
             logger.warning(
                 "Cannot verify whether the debugpy port is configurable when "
                 "using `tesseract run`. Configuration is not possible for some "
-                "old Tesseracts; rebuild the Tesseract if your debugger cannot "
+                "old Tesseracts. Rebuild the Tesseract if your debugger cannot "
                 "attach."
             )
         # `network="host"` binds the container's debugpy port directly on the host,

--- a/tests/runtime_tests/test_runtime_cli.py
+++ b/tests/runtime_tests/test_runtime_cli.py
@@ -642,7 +642,7 @@ def test_start_debug_server_blocks_until_client(monkeypatch):
     returned = threading.Event()
 
     def run():
-        cli._start_debug_server(wait_for_client=True, port=12345)
+        cli._start_debug_server(wait_for_client=True, host="127.0.0.1", port=12345)
         returned.set()
 
     server_thread = threading.Thread(target=run, daemon=True)
@@ -650,7 +650,7 @@ def test_start_debug_server_blocks_until_client(monkeypatch):
 
     # The server should be listening but blocked, since no client has attached.
     server_thread.join(timeout=1.0)
-    assert calls["listen"] == ("0.0.0.0", 12345)
+    assert calls["listen"] == ("127.0.0.1", 12345)
     assert not returned.is_set(), "Debug server returned before a client attached"
 
     # Simulate a debugger attaching; the call should now return promptly.
@@ -675,10 +675,60 @@ def test_start_debug_server_no_wait(monkeypatch):
     fake_debugpy.wait_for_client = wait_for_client
     monkeypatch.setitem(sys.modules, "debugpy", fake_debugpy)
 
-    cli._start_debug_server(wait_for_client=False, port=12345)
+    cli._start_debug_server(wait_for_client=False, host="127.0.0.1", port=12345)
 
-    assert calls["listen"] == ("0.0.0.0", 12345)
+    assert calls["listen"] == ("127.0.0.1", 12345)
     assert calls["wait"] == 0, "Debug server blocked on a client when it should not"
+
+
+def _fake_debugpy(monkeypatch, calls):
+    import types
+
+    fake = types.SimpleNamespace()
+    fake.listen = lambda addr: calls.setdefault("listen", addr)
+    fake.wait_for_client = lambda: None
+    monkeypatch.setitem(sys.modules, "debugpy", fake)
+    return fake
+
+
+def test_debug_server_binds_and_reports_given_address(monkeypatch, capsys):
+    """Host and port are arguments so several Tesseracts can be debugged at once."""
+    from tesseract_core.runtime import cli
+
+    calls = {}
+    _fake_debugpy(monkeypatch, calls)
+
+    cli._start_debug_server(wait_for_client=False, host="127.0.0.1", port=54321)
+
+    assert calls["listen"] == ("127.0.0.1", 54321)
+    # The bound address must be reported, or it cannot be attached to
+    assert "127.0.0.1:54321" in capsys.readouterr().err
+
+
+def test_debug_server_defaults_to_loopback():
+    """A debugger is unauthenticated code execution, so default to loopback.
+
+    Containers need all interfaces for their port mapping to reach the listener,
+    and set that explicitly; nothing else should have to opt out of exposing a
+    debugger on every interface of the machine it runs on.
+    """
+    from tesseract_core.runtime.config import get_config, update_config
+
+    update_config(debug=True)
+    config = get_config()
+
+    assert (config.debugpy_host, config.debugpy_port) == ("127.0.0.1", 5678)
+
+
+def test_debugpy_port_from_env_var(monkeypatch):
+    from tesseract_core.runtime.config import get_config, update_config
+
+    monkeypatch.setenv("TESSERACT_DEBUGPY_PORT", "45678")
+    monkeypatch.setenv("TESSERACT_DEBUGPY_HOST", "127.0.0.1")
+    update_config()
+
+    config = get_config()
+    assert (config.debugpy_host, config.debugpy_port) == ("127.0.0.1", 45678)
 
 
 def test_local_module(cli, cli_runner, dummy_tesseract_package):

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -454,7 +454,7 @@ def test_run_warns_about_a_chosen_debugpy_port(mocked_docker, caplog):
             environment={"TESSERACT_DEBUGPY_PORT": "6789"},
         )
 
-    assert any("rebuild the Tesseract" in r.message for r in caplog.records)
+    assert any("debugger cannot attach" in r.message for r in caplog.records)
 
 
 def test_run_debugpy_host_network(mocked_docker):

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -19,7 +19,7 @@ from tesseract_core.sdk.api_parse import (
     validate_tesseract_api,
 )
 from tesseract_core.sdk.cli import AVAILABLE_RECIPES
-from tesseract_core.sdk.docker_client import Image, NotFound
+from tesseract_core.sdk.docker_client import Container, Image, NotFound
 from tesseract_core.sdk.exceptions import UserError
 
 
@@ -439,7 +439,25 @@ def test_run_debug(mocked_docker):
     assert engine.CONTAINER_DEBUGPY_PORT in res["ports"].values()
 
 
-def test_run_debug_host_network(mocked_docker):
+def test_run_warns_about_a_chosen_debugpy_port(mocked_docker, caplog):
+    """This command never hands control back, so there is nothing to check.
+
+    An image that ignores the request waits for a debugger on an unpublished
+    port, so say up front that a rebuild is what fixes it.
+    """
+    with caplog.at_level(logging.WARNING, logger="tesseract"):
+        engine.run_tesseract(
+            "foobar",
+            "apply",
+            ["{}"],
+            debug=True,
+            environment={"TESSERACT_DEBUGPY_PORT": "6789"},
+        )
+
+    assert any("rebuild the Tesseract" in r.message for r in caplog.records)
+
+
+def test_run_debugpy_host_network(mocked_docker):
     """With host networking, debugpy binds the host port directly (no mapping)."""
     res_out, _ = engine.run_tesseract(
         "foobar",
@@ -712,7 +730,7 @@ def test_serve_tesseract_volumes(mocked_docker, tmpdir):
         engine.serve("foobar", input_path=str(indir), output_path=str(indir))
 
 
-def test_serve_debug_port_distinct_from_api_port(mocked_docker, monkeypatch):
+def test_serve_debugpy_port_distinct_from_api_port(mocked_docker, monkeypatch):
     """The debugpy port must never reuse the API port.
 
     Regression test: in debug mode, ``serve`` picks two free ports (API and
@@ -745,6 +763,146 @@ def test_serve_debug_port_distinct_from_api_port(mocked_docker, monkeypatch):
     # Both the API and debugpy mappings must survive as separate entries.
     assert len(port_mappings) == 2, f"port mapping collapsed: {port_mappings}"
     assert len(set(host_ports)) == 2, f"debug and API host ports collided: {host_ports}"
+
+
+@pytest.fixture
+def skip_debugger_check(monkeypatch):
+    """The mocked container cannot report a debug address; tested separately."""
+    monkeypatch.setattr(engine, "_warn_if_debugger_unreachable", lambda *a: None)
+
+
+def test_chosen_container_debugpy_port_is_published(mocked_docker, skip_debugger_check):
+    """A caller-chosen port must be honoured, with the mapping following it.
+
+    Nothing is special about the default: the only requirement is that the port
+    debugpy binds and the container side of the published mapping agree.
+    """
+    res, _ = engine.serve(
+        "foobar", debug=True, environment={"TESSERACT_DEBUGPY_PORT": "6789"}
+    )
+    parsed = json.loads(res)
+
+    assert parsed["environment"]["TESSERACT_DEBUGPY_PORT"] == "6789"
+    # Both spellings, since TESSERACT_RUNTIME_* would otherwise take precedence
+    assert parsed["environment"]["TESSERACT_RUNTIME_DEBUGPY_PORT"] == "6789"
+    # The mapping must target what the container actually binds
+    assert "6789" in parsed["ports"].values()
+    assert engine.CONTAINER_DEBUGPY_PORT not in parsed["ports"].values()
+
+
+def test_default_container_debugpy_port_is_unchanged(mocked_docker):
+    """Left unset, the container side stays fixed, as #649 established."""
+    res, _ = engine.serve("foobar", debug=True)
+    parsed = json.loads(res)
+
+    assert parsed["environment"]["TESSERACT_DEBUGPY_PORT"] == (
+        engine.CONTAINER_DEBUGPY_PORT
+    )
+    assert engine.CONTAINER_DEBUGPY_PORT in parsed["ports"].values()
+
+
+def test_container_debugpy_port_colliding_with_api_is_rejected(mocked_docker):
+    """The one port that cannot work: the API already has it inside the container."""
+    with pytest.raises(UserError, match="already in use inside the container"):
+        engine.serve(
+            "foobar",
+            debug=True,
+            environment={"TESSERACT_DEBUGPY_PORT": engine.CONTAINER_API_PORT},
+        )
+
+
+class _ReportingContainer(Container):
+    """Minimal container that reports a given startup log."""
+
+    def __init__(self, report: bytes):
+        self._report = report
+
+    def logs(self, **kwargs):
+        return self._report
+
+
+@pytest.mark.parametrize(
+    "report,should_warn",
+    [
+        (b"Debugger listening on 0.0.0.0:6789\n", False),
+        # An image whose runtime ignores the setting binds the old default
+        (b"Debugger listening on 0.0.0.0:5678\n", True),
+        # One old enough not to report at all, or a reformatted line
+        (b"Uvicorn running\n", True),
+    ],
+)
+def test_warn_if_debugger_unreachable(report, should_warn, caplog):
+    """The container's own report of where it listens is what gives it away.
+
+    Nothing else fails when a request is ignored: the Tesseract is healthy and
+    only the debugger is unreachable. A warning rather than an error, since a
+    reformatted log line would otherwise condemn a working setup.
+    """
+    with caplog.at_level(logging.WARNING, logger="tesseract"):
+        engine._warn_if_debugger_unreachable(_ReportingContainer(report), "6789")
+
+    warned = any("no debugger can attach" in r.message for r in caplog.records)
+    assert warned is should_warn
+
+
+def test_serve_checks_only_a_requested_debugpy_port(mocked_docker, monkeypatch):
+    """The check costs a log read, and the default needs none."""
+    checked = []
+    monkeypatch.setattr(
+        engine, "_warn_if_debugger_unreachable", lambda _c, port: checked.append(port)
+    )
+
+    engine.serve("foobar", debug=True)
+    assert checked == []
+
+    engine.serve("foobar", debug=True, environment={"TESSERACT_DEBUGPY_PORT": "6789"})
+    assert checked == ["6789"]
+
+    # The SDK passes it as runtime_config, which only reaches the environment
+    # further down; capturing the request too early would skip the check there.
+    engine.serve("foobar", debug=True, runtime_config={"debugpy_port": 4321})
+    assert checked == ["6789", "4321"]
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["127.0.0.1", "localhost", "::1", "127.1.2.3"],
+)
+def test_container_debugpy_loopback_host_is_rejected(mocked_docker, host):
+    """Only a loopback bind is impossible, and it is impossible at any version.
+
+    Publishing reaches the container from outside, which an address accepting
+    only local connections rejects -- and it fails unhelpfully, with docker's
+    proxy accepting on the host before failing to reach the container. Verified
+    against a current image.
+    """
+    with pytest.raises(UserError, match="only accepts local connections"):
+        engine.serve("foobar", debug=True, environment={"TESSERACT_DEBUGPY_HOST": host})
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "172.17.0.3", "some-hostname"])
+def test_routable_container_debugpy_host_is_honoured(
+    mocked_docker, skip_debugger_check, host
+):
+    """Anything the published port can actually reach is fine, not just 0.0.0.0.
+
+    A container's own address on its network works, so do not insist on all
+    interfaces.
+    """
+    res, _ = engine.serve(
+        "foobar", debug=True, environment={"TESSERACT_DEBUGPY_HOST": host}
+    )
+    parsed = json.loads(res)
+
+    assert parsed["environment"]["TESSERACT_DEBUGPY_HOST"] == host
+    assert parsed["environment"]["TESSERACT_RUNTIME_DEBUGPY_HOST"] == host
+
+
+def test_container_debugpy_host_defaults_to_all_interfaces(mocked_docker):
+    """Unset, it must not inherit the runtime's loopback default."""
+    res, _ = engine.serve("foobar", debug=True)
+
+    assert json.loads(res)["environment"]["TESSERACT_DEBUGPY_HOST"] == "0.0.0.0"
 
 
 def test_serve_container_port_decoupled_from_host_port(mocked_docker):


### PR DESCRIPTION
#### Description of changes

This is preparation work for allowing `from_tesseract_api` with subprocess isolation. The primary use case of this will be for debugging but right now we hard code the debugpy serve port to `5678` meaning that we can only ever have one non-containerised served Tesseract in debug mode which is suboptimal. This PR adds debug_host/debug_port to RuntimeConfig to make this configurable with either environment variables or CLI flags

This also changes the default debug host for non-containerised Tesseracts to `127.0.0.1` to avoid overexposing.

The bound address will be reported for diagnostic purposes.

The original hardcoded values for containerised Tesseracts are maintained and errors are raised if a user tries to configure them (there should be no need to do this).

#### Testing done

New tests in CI plus some manual testing.
