### PR TITLE
chore: allow benchmark reporting on fork PR's

### DIFF
--- a/.github/workflows/benchmark_report.yml
+++ b/.github/workflows/benchmark_report.yml
@@ -1,0 +1,123 @@
+name: Benchmark Report
+
+# Posts the benchmark comparison produced by the `Benchmarks` workflow as a PR
+# comment.
+#
+# This is split out because `pull_request` runs on fork PRs get no secrets and a
+# read-only `GITHUB_TOKEN`, so they cannot comment at all. `workflow_run` runs in
+# the context of the base branch, where both are available.
+#
+# SECURITY: this workflow is privileged. It must never check out or execute code
+# from the pull request. It only downloads artifacts and posts a comment, and it
+# treats every artifact byte as untrusted input.
+
+on:
+  workflow_run:
+    workflows: ["Benchmarks"]
+    types: [completed]
+
+concurrency:
+  group: benchmark-report-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+jobs:
+  report:
+    # A failed benchmark run has nothing worth posting, and the `benchmark`
+    # check already surfaces that failure on the PR. Gating here (as mosaic's
+    # docs-publish.yml does) skips the runner entirely rather than starting up
+    # only to find no report.
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download benchmark results
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v7
+        with:
+          name: benchmark-results
+          path: benchmark-results
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      # A missing report means the benchmark run produced nothing to post, which
+      # the `benchmark` check already surfaces on the PR. Bail out quietly
+      # rather than adding a second red X.
+      - name: Check for a report
+        id: check
+        run: |
+          if [ ! -s benchmark-results/benchmark_report.md ]; then
+            echo "::notice::No benchmark report to post, skipping"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+
+      # Which PR to comment on is derived entirely from the event payload, which
+      # a fork cannot influence — never from the artifact, whose producer
+      # workflow file comes from the PR head. `workflow_run.pull_requests` is
+      # empty for fork PRs and `commits/{sha}/pulls` has the same blind spot,
+      # but head_repository + head_branch identify the source branch, which is
+      # enough to look the PR up.
+      - name: Resolve PR number
+        id: pr
+        if: steps.check.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_LABEL: "${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}"
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          matches=$(gh api -X GET "/repos/$REPO/pulls" \
+            -f "head=$HEAD_LABEL" -f state=open \
+            -q '.[] | "\(.number) \(.head.sha)"')
+
+          if [ -z "$matches" ]; then
+            echo "::warning::No open PR found for $HEAD_LABEL; skipping comment"
+            exit 0
+          fi
+
+          # One branch can back several open PRs (differing base branches). With
+          # a single match take it, so a force-push mid-run still gets its
+          # comment; otherwise disambiguate on this run's SHA.
+          if [ "$(printf '%s\n' "$matches" | wc -l | tr -d ' ')" -eq 1 ]; then
+            number=$(printf '%s\n' "$matches" | awk '{print $1}')
+          else
+            number=$(printf '%s\n' "$matches" | awk -v sha="$RUN_SHA" '$2 == sha {print $1; exit}')
+          fi
+
+          if [ -z "$number" ]; then
+            echo "::warning::Could not unambiguously resolve a PR for $HEAD_LABEL at $RUN_SHA; skipping"
+            exit 0
+          fi
+
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Find existing comment
+        if: steps.pr.outputs.number != ''
+        uses: peter-evans/find-comment@v4
+        id: find-comment
+        with:
+          issue-number: ${{ steps.pr.outputs.number }}
+          comment-author: "PasteurBot"
+          body-includes: "## Benchmark Results"
+
+      # `body-path` rather than `body`, so the report is never interpolated into
+      # a `run:` block or a `$GITHUB_OUTPUT` heredoc it could break out of.
+      - name: Create or update PR comment
+        if: >-
+          steps.pr.outputs.number != ''
+          && github.event.workflow_run.actor.login != 'dependabot[bot]'
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          token: ${{ secrets.PL_PASTEURBOT_PAT_PUBLIC }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body-path: benchmark-results/benchmark_report.md
+          edit-mode: replace

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,7 +17,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   benchmark:
@@ -86,9 +85,14 @@ jobs:
 
           echo "has_baseline=true" >> $GITHUB_OUTPUT
 
+      # Secrets are withheld from `pull_request` runs on fork PRs, so the comment
+      # is posted by the privileged `Benchmark Report` workflow instead. It works
+      # out which PR this is from the `workflow_run` event payload, so nothing
+      # needs to be handed over here beyond the report itself.
       - name: Generate comparison report
         if: github.event_name == 'pull_request'
-        id: comparison
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           baseline_flag=""
           if [ "${{ steps.baseline.outputs.has_baseline }}" = "true" ]; then
@@ -98,36 +102,11 @@ jobs:
           python benchmarks/compare_benchmarks.py \
             $baseline_flag \
             --current current_benchmarks.json \
+            --pr-number "$PR_NUMBER" \
             --output benchmark_report.md
 
-          # Set output as multiline string
-          {
-            echo 'report<<BENCHMARK_REPORT_END'
-            cat benchmark_report.md
-            echo ''
-            echo 'BENCHMARK_REPORT_END'
-          } >> $GITHUB_OUTPUT
-
-      - name: Find existing comment
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v4
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "PasteurBot"
-          body-includes: "## Benchmark Results"
-
-      - name: Create or update PR comment
-        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          token: ${{ secrets.PL_PASTEURBOT_PAT_PUBLIC }}
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: ${{ steps.comparison.outputs.report }}
-          edit-mode: replace
-
       - name: Upload benchmark results
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: benchmark-results

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -86,9 +86,7 @@ jobs:
           echo "has_baseline=true" >> $GITHUB_OUTPUT
 
       # Secrets are withheld from `pull_request` runs on fork PRs, so the comment
-      # is posted by the privileged `Benchmark Report` workflow instead. It works
-      # out which PR this is from the `workflow_run` event payload, so nothing
-      # needs to be handed over here beyond the report itself.
+      # is posted by the privileged `Benchmark Report` workflow instead.
       - name: Generate comparison report
         if: github.event_name == 'pull_request'
         env:

--- a/benchmarks/compare_benchmarks.py
+++ b/benchmarks/compare_benchmarks.py
@@ -97,6 +97,15 @@ def _get_runner_description(data: dict) -> str:
     return " ".join(parts) if parts else "unknown"
 
 
+def _metadata_lines(current_data: dict, pr_number: str | None) -> list[str]:
+    """Provenance bullets describing where the results came from."""
+    lines = []
+    if pr_number is not None:
+        lines.append(f"- **PR:** #{pr_number}")
+    lines.append(f"- **Runner:** {_get_runner_description(current_data)}")
+    return lines
+
+
 def _load_benchmark_file(path: str | None) -> dict | None:
     """Load benchmark file, returning None if it doesn't exist."""
     if path is None or not Path(path).exists():
@@ -182,7 +191,9 @@ def _format_comparison_row(comp: dict) -> str:
     return f"| `{comp['name']}` | {base_str} | {curr_str} | {change_str} | {comp['status']} |"
 
 
-def _generate_current_only_report(current: dict[str, dict], current_data: dict) -> str:
+def _generate_current_only_report(
+    current: dict[str, dict], current_data: dict, pr_number: str | None = None
+) -> str:
     """Generate a report when no baseline exists, marking every benchmark as new."""
     all_names = _sort_names(list(current.keys()))
     comparisons = [
@@ -203,14 +214,13 @@ def _generate_current_only_report(current: dict[str, dict], current_data: dict) 
     for comp in comparisons:
         lines.append(_format_comparison_row(comp))
 
-    runner = _get_runner_description(current_data)
     lines.extend(
         [
             "",
             "<details>",
             "<summary>Benchmark details</summary>",
             "",
-            f"- **Runner:** {runner}",
+            *_metadata_lines(current_data, pr_number),
             "",
             "</details>",
         ]
@@ -219,7 +229,9 @@ def _generate_current_only_report(current: dict[str, dict], current_data: dict) 
     return "\n".join(lines)
 
 
-def generate_report(baseline_path: str | None, current_path: str) -> str | None:
+def generate_report(
+    baseline_path: str | None, current_path: str, pr_number: str | None = None
+) -> str | None:
     """Generate markdown comparison report.
 
     Returns None only if current results don't exist.
@@ -234,7 +246,7 @@ def generate_report(baseline_path: str | None, current_path: str) -> str | None:
     current = _index_benchmarks(current_data)
 
     if baseline_data is None:
-        return _generate_current_only_report(current, current_data)
+        return _generate_current_only_report(current, current_data, pr_number)
 
     baseline = _index_benchmarks(baseline_data)
 
@@ -288,11 +300,10 @@ def generate_report(baseline_path: str | None, current_path: str) -> str | None:
     for comp in comparisons:
         lines.append(_format_comparison_row(comp))
 
-    runner = _get_runner_description(current_data)
     lines.extend(
         [
             "",
-            f"- **Runner:** {runner}",
+            *_metadata_lines(current_data, pr_number),
             "",
             "</details>",
         ]
@@ -307,13 +318,16 @@ def main() -> int:
     parser.add_argument("--baseline", default=None, help="Baseline benchmark JSON file")
     parser.add_argument("--current", required=True, help="Current benchmark JSON file")
     parser.add_argument("--output", required=True, help="Output markdown report path")
+    parser.add_argument(
+        "--pr-number", default=None, help="PR number to record in the report"
+    )
     args = parser.parse_args()
 
     if not Path(args.current).exists():
         print(f"Current benchmark file not found: {args.current}", file=sys.stderr)
         return 1
 
-    report = generate_report(args.baseline, args.current)
+    report = generate_report(args.baseline, args.current, args.pr_number)
 
     if report is None:
         print(


### PR DESCRIPTION
#### Description of changes

Same fix as in tesseract-jax.

The benchmarks CI failed on fork PR's (e.g. #667) because GitHub withholds secrets from pull_request runs on forks, so secrets.PL_PASTEURBOT_PAT_PUBLIC was empty and create-or-update-comment threw Parameter token or opts.auth is required. This splits the benchmarks job into two, one that runs on pull_request and uploads artifacts but is now un-privileged, and one new privileged job that runs on the base branch (triggered by workflow_run), which works out which PR to comment on from the event payload and downloads the artifacts to post the comment.

The PR number is now also rendered into benchmark_report.md via a new --pr-number flag, for provenance.

Note this PR won't post a benchmark comment — workflow_run workflows only fire once they're on the default branch, so the first real test is the next fork PR after merge. We'll want the same change in tesseract-core (#667 is failing there identically).

If this works we also need to add it in tesseract-core.

#### Testing done

Locally: compare_benchmarks.py output is byte-identical to main when --pr-number is omitted (diffed both the baseline and current-only paths), and all report variants render. pre-commit clean.

The fork path can't be exercised until this is on main.
