### PR TITLE
fix: config parsing with string fallbacks

### DIFF
--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -19,7 +19,6 @@ from types import SimpleNamespace
 from typing import Annotated, Any, NoReturn
 
 import typer
-import yaml
 from jinja2 import Environment, PackageLoader, StrictUndefined
 from pydantic import ValidationError as PydanticValidationError
 from rich.console import Console as RichConsole
@@ -223,12 +222,17 @@ def main_callback(
 
 def _parse_config_override(
     options: list[str] | None,
-) -> dict[tuple[str, ...], Any]:
-    """Parse `["path1.path2.path3=value"]` into `[(["path1", "path2", "path3"], "value")]`."""
+) -> dict[tuple[str, ...], str]:
+    """Parse `["path1.path2.path3=value"]` into `{("path1", "path2", "path3"): "value"}`.
+
+    Values are kept as raw strings and coerced to the target field's declared type
+    when applied (see ``engine._coerce_config_override``), so that e.g.
+    ``build_config.python_version=3.12`` does not need to be quoted.
+    """
     if options is None:
         return {}
 
-    def _parse_option(option: str) -> tuple[tuple[str, ...], Any]:
+    def _parse_option(option: str) -> tuple[tuple[str, ...], str]:
         if "=" not in option:
             raise typer.BadParameter(
                 f'Invalid config override "{option}" (must be `keypath=value`)',
@@ -243,15 +247,6 @@ def _parse_config_override(
             )
 
         path = tuple(key.split("."))
-
-        try:
-            value = yaml.safe_load(value)
-        except yaml.YAMLError as e:
-            raise typer.BadParameter(
-                f'Invalid value for config override "{option}", could not parse value as YAML: {e}',
-                param_hint="config_override",
-            ) from e
-
         return path, value
 
     return dict(_parse_option(option) for option in options)

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -566,24 +566,27 @@ def _coerce_config_override(value: Any, annotation: Any, path: tuple[str, ...]) 
     if not isinstance(value, str):
         return adapter.validate_python(value)
 
-    candidates = []
+    # Try the YAML-interpreted value first so structured values (lists, dicts,
+    # ints, bools) work, then fall back to the raw string so string fields accept
+    # unquoted scalars. If both fail, report the error from the YAML-interpreted
+    # value: it matches the user's evident intent, whereas the raw-string error
+    # is often a misleading "not a valid <type>" for non-string fields.
     try:
-        candidates.append(yaml.safe_load(value))
+        parsed = yaml.safe_load(value)
     except yaml.YAMLError:
-        pass
-    candidates.append(value)
+        parsed = value
 
-    last_error: PydanticValidationError | None = None
-    for candidate in candidates:
+    try:
+        return adapter.validate_python(parsed)
+    except PydanticValidationError as parsed_error:
         try:
-            return adapter.validate_python(candidate)
-        except PydanticValidationError as e:
-            last_error = e
-
-    keypath = ".".join(path)
-    raise UserError(
-        f'Invalid value "{value}" for config override "{keypath}": {last_error}'
-    ) from last_error
+            return adapter.validate_python(value)
+        except PydanticValidationError:
+            keypath = ".".join(path)
+            raise UserError(
+                f'Invalid value "{value}" for config override "{keypath}": '
+                f"{parsed_error}"
+            ) from parsed_error
 
 
 def build_tesseract(

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -626,11 +626,24 @@ def build_tesseract(
     if config_override is not None:
         for path, value in config_override.items():
             c = config
-            for k in path[:-1]:
-                c = getattr(c, k)
-            field = type(c).model_fields.get(path[-1])
-            annotation = field.annotation if field is not None else None
-            setattr(c, path[-1], _coerce_config_override(value, annotation, path))
+            for depth, k in enumerate(path):
+                fields = getattr(type(c), "model_fields", None)
+                if fields is None or k not in fields:
+                    keypath = ".".join(path)
+                    reached = ".".join(path[:depth]) or "(top level)"
+                    valid = (
+                        ", ".join(sorted(fields)) if fields is not None else "(none)"
+                    )
+                    raise UserError(
+                        f'Invalid config override "{keypath}": '
+                        f'"{".".join(path[: depth + 1])}" is not a known config '
+                        f"option. Valid options under {reached}: {valid}."
+                    )
+                if depth == len(path) - 1:
+                    annotation = fields[k].annotation
+                    setattr(c, k, _coerce_config_override(value, annotation, path))
+                else:
+                    c = getattr(c, k)
 
     image_name = config.name
     if image_tag:

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -26,6 +26,8 @@ import requests
 import yaml
 from jinja2 import Environment, PackageLoader, StrictUndefined
 from packaging.requirements import Requirement
+from pydantic import TypeAdapter
+from pydantic import ValidationError as PydanticValidationError
 
 from .api_parse import TesseractConfig, get_config, validate_tesseract_api
 from .docker_client import (
@@ -544,6 +546,46 @@ def init_api(
     return target_dir / "tesseract_api.py"
 
 
+def _coerce_config_override(value: Any, annotation: Any, path: tuple[str, ...]) -> Any:
+    """Coerce a config override value to the target field's declared type.
+
+    CLI overrides arrive as raw strings (see ``_parse_config_override``). We first
+    interpret the string as YAML so that structured values (lists, dicts, ints,
+    bools) work, then fall back to the raw string if that fails to validate. This
+    lets string fields like ``python_version=3.12`` work without the user having
+    to quote the value, while ``3.10`` is preserved verbatim instead of being
+    parsed as the float ``3.1``. Non-string values (e.g. passed via the Python
+    SDK) are validated as-is.
+    """
+    if annotation is None:
+        # Unknown field; let the assignment raise a validation error as usual.
+        return value
+
+    adapter = TypeAdapter(annotation)
+
+    if not isinstance(value, str):
+        return adapter.validate_python(value)
+
+    candidates = []
+    try:
+        candidates.append(yaml.safe_load(value))
+    except yaml.YAMLError:
+        pass
+    candidates.append(value)
+
+    last_error: PydanticValidationError | None = None
+    for candidate in candidates:
+        try:
+            return adapter.validate_python(candidate)
+        except PydanticValidationError as e:
+            last_error = e
+
+    keypath = ".".join(path)
+    raise UserError(
+        f'Invalid value "{value}" for config override "{keypath}": {last_error}'
+    ) from last_error
+
+
 def build_tesseract(
     src_dir: str | Path,
     image_tag: str | None,
@@ -583,7 +625,9 @@ def build_tesseract(
             c = config
             for k in path[:-1]:
                 c = getattr(c, k)
-            setattr(c, path[-1], value)
+            field = type(c).model_fields.get(path[-1])
+            annotation = field.annotation if field is not None else None
+            setattr(c, path[-1], _coerce_config_override(value, annotation, path))
 
     image_name = config.name
     if image_tag:

--- a/tests/sdk_tests/test_cli.py
+++ b/tests/sdk_tests/test_cli.py
@@ -86,11 +86,11 @@ def test_config_override(
         argpairs = (
             (
                 "[RUN foo='bar']",
-                {("build_config", "custom_build_steps"): ["RUN foo='bar'"]},
+                {("build_config", "custom_build_steps"): "[RUN foo='bar']"},
             ),
             (
                 '[RUN echo "hello world"]',
-                {("build_config", "custom_build_steps"): ['RUN echo "hello world"']},
+                {("build_config", "custom_build_steps"): '[RUN echo "hello world"]'},
             ),
         )
     elif arg_to_override == "build_config.base_image":
@@ -105,9 +105,9 @@ def test_config_override(
             (
                 '["data/file.txt:/app/data/file.txt"]',
                 {
-                    ("build_config", "package_data"): [
-                        "data/file.txt:/app/data/file.txt"
-                    ]
+                    ("build_config", "package_data"): (
+                        '["data/file.txt:/app/data/file.txt"]'
+                    )
                 },
             ),
         )

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -87,6 +87,23 @@ def test_coerce_config_override(keypath, raw_value, expected):
     setattr(c, keypath[-1], coerced)
 
 
+def test_coerce_config_override_reports_structured_error():
+    """A structurally-wrong value surfaces the error against the parsed value.
+
+    The raw-string fallback exists for string fields; for a non-string field it
+    would report a misleading "not a valid <type>", masking the real problem. The
+    error must instead describe the parsed value (e.g. wrong tuple arity).
+    """
+    keypath = ("build_config", "package_data")
+    annotation = TesseractBuildConfig.model_fields["package_data"].annotation
+    # package_data entries are (source, destination) pairs; three items is wrong.
+    with pytest.raises(UserError) as excinfo:
+        engine._coerce_config_override("[[a, b, c]]", annotation, keypath)
+    message = str(excinfo.value)
+    assert "at most 2 items" in message
+    assert "not a valid tuple" not in message
+
+
 def test_prepare_build_context_env(tmp_path_factory):
     """Test that env variables are rendered as ENV lines in the Dockerfile."""
     src_dir = tmp_path_factory.mktemp("src")

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -72,6 +72,8 @@ def test_prepare_build_context_python_version(tmp_path_factory):
         # Non-string fields still get their structured value.
         (("build_config", "inherit_base_image_packages"), "true", True),
         (("build_config", "extra_packages"), "[a, b]", ("a", "b")),
+        # Values that aren't valid YAML fall back to the raw string.
+        (("build_config", "target_platform"), "@invalid", "@invalid"),
     ],
 )
 def test_coerce_config_override(keypath, raw_value, expected):
@@ -85,6 +87,23 @@ def test_coerce_config_override(keypath, raw_value, expected):
     assert coerced == expected
     # The coerced value must be assignable without a validation error.
     setattr(c, keypath[-1], coerced)
+
+
+def test_coerce_config_override_native_value():
+    """Non-string values (e.g. from the Python SDK) are validated as-is."""
+    annotation = TesseractBuildConfig.model_fields["extra_packages"].annotation
+    coerced = engine._coerce_config_override(
+        ["a", "b"], annotation, ("build_config", "extra_packages")
+    )
+    assert coerced == ("a", "b")
+
+
+def test_coerce_config_override_unknown_field():
+    """An unknown field (no annotation) passes the value through unchanged.
+
+    The subsequent assignment then raises the usual validation error.
+    """
+    assert engine._coerce_config_override("whatever", None, ("nope",)) == "whatever"
 
 
 def test_coerce_config_override_reports_structured_error():

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -59,6 +59,34 @@ def test_prepare_build_context_python_version(tmp_path_factory):
     assert "TESSERACT_PYTHON_VERSION" not in dockerfile_default
 
 
+@pytest.mark.parametrize(
+    "keypath,raw_value,expected",
+    [
+        # Numeric-looking string fields must not be parsed as numbers (#678).
+        (("build_config", "python_version"), "3.12", "3.12"),
+        # Trailing zero must be preserved (YAML would parse 3.10 -> 3.1).
+        (("build_config", "python_version"), "3.10", "3.10"),
+        # Explicit quoting still works.
+        (("build_config", "python_version"), '"3.12"', "3.12"),
+        (("build_config", "target_platform"), "linux/arm64", "linux/arm64"),
+        # Non-string fields still get their structured value.
+        (("build_config", "inherit_base_image_packages"), "true", True),
+        (("build_config", "extra_packages"), "[a, b]", ("a", "b")),
+    ],
+)
+def test_coerce_config_override(keypath, raw_value, expected):
+    """Config override values are coerced to the target field's declared type."""
+    config = TesseractConfig(name="demo")
+    c = config
+    for k in keypath[:-1]:
+        c = getattr(c, k)
+    annotation = type(c).model_fields[keypath[-1]].annotation
+    coerced = engine._coerce_config_override(raw_value, annotation, keypath)
+    assert coerced == expected
+    # The coerced value must be assignable without a validation error.
+    setattr(c, keypath[-1], coerced)
+
+
 def test_prepare_build_context_env(tmp_path_factory):
     """Test that env variables are rendered as ENV lines in the Dockerfile."""
     src_dir = tmp_path_factory.mktemp("src")

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -123,6 +123,40 @@ def test_coerce_config_override_reports_structured_error():
     assert "not a valid tuple" not in message
 
 
+@pytest.mark.parametrize(
+    "keypath,offending",
+    [
+        # Unknown top-level option.
+        (("nonexistent",), "nonexistent"),
+        # Unknown intermediate group (nothing under it can be valid).
+        (("nonexistent", "python_version"), "nonexistent"),
+        # Unknown leaf under a valid group.
+        (("build_config", "nonexistent"), "build_config.nonexistent"),
+        # Descending into a non-model field (e.g. a dict) is also rejected.
+        (("env", "SOME_VAR"), "env.SOME_VAR"),
+    ],
+)
+def test_build_tesseract_unknown_config_override(
+    dummy_tesseract_package, keypath, offending
+):
+    """An unknown config override path raises a helpful UserError, not a traceback.
+
+    The path is validated before the image build, so no Docker mock is needed.
+    """
+    with pytest.raises(UserError) as excinfo:
+        engine.build_tesseract(
+            dummy_tesseract_package,
+            None,
+            config_override={keypath: "whatever"},
+            generate_only=True,
+        )
+    message = str(excinfo.value)
+    assert ".".join(keypath) in message
+    assert f'"{offending}" is not a known config option' in message
+    # The valid options at the offending level are listed to guide the user.
+    assert "Valid options under" in message
+
+
 def test_prepare_build_context_env(tmp_path_factory):
     """Test that env variables are rendered as ENV lines in the Dockerfile."""
     src_dir = tmp_path_factory.mktemp("src")


### PR DESCRIPTION
#### Relevant issue or PR

Fixes #678 

#### Description of changes

Make sure values passed via `tesseract build --config-override` are plumbed through as strings (instead of eagerly applying `yaml.safe_load`, which converts e.g. `python_version=3.13` to a float).

When the time comes to construct a config object we first try the `yaml.safe_load` path, then if that fails we try the raw string (which succeeds for fields that allow strings, and fails everywhere else).

#### Testing done

CI, new tests covering the case from #678
