### PR TITLE
feat(sdk): add deprecation tombstone registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ This file contains counter-intuitive rules and aspects of the Tesseract codebase
 - **Don't add mocks for Docker.** Tests that need Docker should be marked as end-to-end tests and skipped in fast test runs.
 - **Rarely test exceptions.** Only test exception handling when control flow is complex or the error message is critical for UX. Don't write tests that just verify an exception is raised.
 - **Never skip or disable tests without asking.** If a test is failing and you want to skip it, ask the user first. Don't add `@pytest.skip`, `@pytest.mark.xfail`, or comment out tests without explicit approval.
+- **Do not add new markers or skip conditions without asking.** If you want to add a new marker or skip condition, ask the user first. Don't add `@pytest.mark.skipif` or similar without approval.
 - **Always run appropriate tests and verify code you touched works end-to-end before presenting it as complete.** Do not wait for the user to ask 'did you test this?'
 
 ## Code style

--- a/tesseract_core/_deprecations.py
+++ b/tesseract_core/_deprecations.py
@@ -1,0 +1,73 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Registry of scheduled deprecation removals ("tombstones").
+
+Deprecations rot: a warning ships, the shim stays forever because nothing forces
+anyone to revisit it. A tombstone pins a deprecation to the version it must be
+gone by, and :func:`overdue_tombstones` reports any that are due. The
+accompanying test checks this against the version being cut, so a release PR
+that would ship a stale shim fails before it merges (merging a release PR is what
+triggers the actual release).
+
+To schedule a removal:
+
+1. Add a :class:`Tombstone` to :data:`TOMBSTONES`, targeting a concrete future
+   version.
+2. When the release-PR test starts failing, delete the deprecated code *and* its
+   tombstone in the same PR.
+
+Target a version the release automation can actually reach. Automated bumps are
+capped at ``minor`` (see ``.github/workflows/get_bump_type.sh``), so a new major
+is never cut automatically; a ``2.0.0`` target would never fire. Use the next
+minor or a later minor instead.
+"""
+
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+from packaging.version import Version
+
+
+class Tombstone(NamedTuple):
+    """A deprecation scheduled for removal by a specific version."""
+
+    remove_at: str
+    """Version by which the deprecated code must be gone (e.g. ``"1.13.0"``)."""
+
+    what: str
+    """Short name of the deprecated feature, shown when the removal is due."""
+
+    hint: str
+    """What to delete, so the person hitting the failure knows where to look."""
+
+
+# Deprecations awaiting removal. Delete an entry together with its code once the
+# scheduled version arrives.
+TOMBSTONES: tuple[Tombstone, ...] = ()
+
+
+def _repo_changelog_path() -> Path:
+    """Path to the repository ``CHANGELOG.md``, if running from a source checkout."""
+    return Path(__file__).resolve().parent.parent / "CHANGELOG.md"
+
+
+def latest_changelog_version(changelog: str) -> Version | None:
+    """Return the topmost ``## [version]`` entry in a changelog, or None if absent.
+
+    On a release PR the changelog is regenerated with the version being cut at the
+    top, so this is the version a merge would release.
+    """
+    match = re.search(r"^##\s*\[([^\]]+)\]", changelog, re.MULTILINE)
+    if match is None:
+        return None
+    try:
+        return Version(match.group(1))
+    except ValueError:
+        return None
+
+
+def overdue_tombstones(version: Version) -> list[Tombstone]:
+    """Return tombstones whose removal is due at or before ``version``."""
+    return [t for t in TOMBSTONES if version >= Version(t.remove_at)]

--- a/tesseract_core/_deprecations.py
+++ b/tesseract_core/_deprecations.py
@@ -3,12 +3,10 @@
 
 """Registry of scheduled deprecation removals ("tombstones").
 
-Deprecations rot: a warning ships, the shim stays forever because nothing forces
-anyone to revisit it. A tombstone pins a deprecation to the version it must be
+A tombstone pins a deprecation to the version it must be
 gone by, and :func:`overdue_tombstones` reports any that are due. The
 accompanying test checks this against the version being cut, so a release PR
-that would ship a stale shim fails before it merges (merging a release PR is what
-triggers the actual release).
+with active tombstones fails.
 
 To schedule a removal:
 
@@ -17,17 +15,14 @@ To schedule a removal:
 2. When the release-PR test starts failing, delete the deprecated code *and* its
    tombstone in the same PR.
 
-Target a version the release automation can actually reach. Automated bumps are
-capped at ``minor`` (see ``.github/workflows/get_bump_type.sh``), so a new major
-is never cut automatically; a ``2.0.0`` target would never fire. Use the next
-minor or a later minor instead.
+Deprecations always target a *minor* version (no breaking changes on patch releases).
 """
 
 import re
 from pathlib import Path
 from typing import NamedTuple
 
-from packaging.version import Version
+from packaging.version import VERSION_PATTERN, InvalidVersion, Version
 
 
 class Tombstone(NamedTuple):
@@ -45,7 +40,14 @@ class Tombstone(NamedTuple):
 
 # Deprecations awaiting removal. Delete an entry together with its code once the
 # scheduled version arrives.
-TOMBSTONES: tuple[Tombstone, ...] = ()
+TOMBSTONES: tuple[Tombstone, ...] = (
+    # Example:
+    # Tombstone(
+    #     remove_at="0.99.0",
+    #     what="--foo alias from `tesseract build`",
+    #     hint="remove backend support from engine.py, too"
+    # ),
+)
 
 
 def _repo_changelog_path() -> Path:
@@ -53,19 +55,37 @@ def _repo_changelog_path() -> Path:
     return Path(__file__).resolve().parent.parent / "CHANGELOG.md"
 
 
-def latest_changelog_version(changelog: str) -> Version | None:
-    """Return the topmost ``## [version]`` entry in a changelog, or None if absent.
-
-    On a release PR the changelog is regenerated with the version being cut at the
-    top, so this is the version a merge would release.
-    """
-    match = re.search(r"^##\s*\[([^\]]+)\]", changelog, re.MULTILINE)
+def _version_from_changelog(changelog: str) -> Version | None:
+    """Return the topmost ``## [version]`` entry in a changelog, or None if absent."""
+    match = re.search(
+        rf"^\#\#\s*\[({VERSION_PATTERN})\]",
+        changelog,
+        re.MULTILINE | re.VERBOSE | re.IGNORECASE,
+    )
     if match is None:
         return None
     try:
         return Version(match.group(1))
-    except ValueError:
+    except InvalidVersion:
         return None
+
+
+def latest_changelog_version() -> Version:
+    """Return the topmost ``## [version]`` entry in a changelog.
+
+    On a release PR the changelog is regenerated with the version being cut at the
+    top, so this is the version a merge would release.
+    """
+    changelog_path = _repo_changelog_path()
+    if not changelog_path.exists():
+        raise FileNotFoundError(
+            f"Could not find {changelog_path} to check for overdue deprecations"
+        )
+    changelog = changelog_path.read_text(encoding="utf-8")
+    version = _version_from_changelog(changelog)
+    if version is None:
+        raise ValueError(f"Could not find a valid version entry in {changelog_path}")
+    return version
 
 
 def overdue_tombstones(version: Version) -> list[Tombstone]:

--- a/tests/sdk_tests/test_deprecations.py
+++ b/tests/sdk_tests/test_deprecations.py
@@ -1,0 +1,59 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Enforce scheduled deprecation removals against the version being released.
+
+On a release PR the changelog is regenerated with the new version at the top, so
+this test fails there if a deprecation is due for removal. Because merging the
+release PR is what triggers the release, the stale shim is caught before it
+ships. On ordinary PRs the top changelog version is the last release, so the test
+only fires once a release actually crosses a tombstone's target.
+"""
+
+import pytest
+from packaging.version import Version
+
+from tesseract_core import _deprecations
+from tesseract_core._deprecations import (
+    Tombstone,
+    _repo_changelog_path,
+    latest_changelog_version,
+    overdue_tombstones,
+)
+
+
+def test_no_overdue_deprecations():
+    changelog_path = _repo_changelog_path()
+    if not changelog_path.exists():
+        pytest.skip("CHANGELOG.md not available (not a source checkout)")
+
+    version = latest_changelog_version(changelog_path.read_text(encoding="utf-8"))
+    if version is None:
+        pytest.skip("Could not determine a version from CHANGELOG.md")
+
+    overdue = overdue_tombstones(version)
+    assert not overdue, "Deprecations due for removal by version {}:\n{}".format(
+        version,
+        "\n".join(f"  - {t.what} (remove_at {t.remove_at}): {t.hint}" for t in overdue),
+    )
+
+
+def test_latest_changelog_version_parses_top_entry():
+    changelog = "# Changelog\n\n## [1.13.0] - 2026-09-01\n\n## [1.12.0] - 2026-08-01\n"
+    assert latest_changelog_version(changelog) == Version("1.13.0")
+    assert latest_changelog_version("# Changelog\n\nnothing here") is None
+
+
+def test_overdue_fires_at_target_but_not_on_prerelease(monkeypatch):
+    """A tombstone is due at its target version, but not on a dev/rc of it."""
+    monkeypatch.setattr(
+        _deprecations,
+        "TOMBSTONES",
+        (Tombstone(remove_at="1.13.0", what="thing", hint="delete it"),),
+    )
+    assert overdue_tombstones(Version("1.12.0")) == []
+    # dev/rc sort before the final release, so the release PR (which shows the
+    # final version) is what trips the check, not an earlier dev build.
+    assert overdue_tombstones(Version("1.13.0.dev5")) == []
+    assert len(overdue_tombstones(Version("1.13.0"))) == 1
+    assert len(overdue_tombstones(Version("1.14.0"))) == 1

--- a/tests/sdk_tests/test_deprecations.py
+++ b/tests/sdk_tests/test_deprecations.py
@@ -10,13 +10,13 @@ ships. On ordinary PRs the top changelog version is the last release, so the tes
 only fires once a release actually crosses a tombstone's target.
 """
 
-import pytest
 from packaging.version import Version
 
 from tesseract_core import _deprecations
 from tesseract_core._deprecations import (
     Tombstone,
     _repo_changelog_path,
+    _version_from_changelog,
     latest_changelog_version,
     overdue_tombstones,
 )
@@ -25,14 +25,13 @@ from tesseract_core._deprecations import (
 def test_no_overdue_deprecations():
     changelog_path = _repo_changelog_path()
     if not changelog_path.exists():
-        pytest.skip("CHANGELOG.md not available (not a source checkout)")
+        raise FileNotFoundError(
+            f"Could not find {changelog_path} to check for overdue deprecations"
+        )
 
-    version = latest_changelog_version(changelog_path.read_text(encoding="utf-8"))
-    if version is None:
-        pytest.skip("Could not determine a version from CHANGELOG.md")
-
+    version = latest_changelog_version()
     overdue = overdue_tombstones(version)
-    assert not overdue, "Deprecations due for removal by version {}:\n{}".format(
+    assert len(overdue) == 0, "Deprecations due for removal by version {}:\n{}".format(
         version,
         "\n".join(f"  - {t.what} (remove_at {t.remove_at}): {t.hint}" for t in overdue),
     )
@@ -40,8 +39,8 @@ def test_no_overdue_deprecations():
 
 def test_latest_changelog_version_parses_top_entry():
     changelog = "# Changelog\n\n## [1.13.0] - 2026-09-01\n\n## [1.12.0] - 2026-08-01\n"
-    assert latest_changelog_version(changelog) == Version("1.13.0")
-    assert latest_changelog_version("# Changelog\n\nnothing here") is None
+    assert _version_from_changelog(changelog) == Version("1.13.0")
+    assert _version_from_changelog("# Changelog\n\nnothing here") is None
 
 
 def test_overdue_fires_at_target_but_not_on_prerelease(monkeypatch):


### PR DESCRIPTION
#### Relevant issue or PR

Base of the stack under #680, which registers the first tombstone.

#### Description of changes

Deprecations tend to rot: a warning ships, and the compatibility shim lingers indefinitely because nothing forces anyone to revisit it. This adds a small registry that pins each deprecation to the version it must be gone by, and a test that enforces it at the right moment in the release process.

- `tesseract_core/_deprecations.py` holds a `TOMBSTONES` tuple of `Tombstone(remove_at, what, hint)` entries and a helper that reads the top `## [version]` entry from `CHANGELOG.md`.
- The accompanying test fails if any tombstone's `remove_at` is at or below the version at the top of the changelog.

The timing is the point. The release workflow cuts a release by opening a `bot/release/<version>` PR that regenerates `CHANGELOG.md` with the new version at the top; merging that PR is what triggers the release. So on a release PR the test sees the version about to ship and fails *before* the merge, catching a stale shim while it can still be removed. On ordinary PRs the top changelog entry is the last release, so the check stays quiet until a release actually crosses a target.

One constraint worth noting: the release automation caps automated bumps at `minor` (`get_bump_type.sh`), so a new major is never cut automatically. A `2.0.0` target would never fire, so tombstones must target a reachable minor. This is documented in the module.

The registry ships empty; deprecations add their own `Tombstone` alongside the code they deprecate (the first one lands in #680).

#### Testing done

`pytest tests/sdk_tests/test_deprecations.py` — covers changelog parsing, and that a tombstone fires at its target version but not on a `dev`/`rc` prerelease of it (so the release PR's final version is what trips it). Full fast suite passes.
