### PR TITLE
fix(sdk): purge auto-created output tempdirs on garbage collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
-
-### Bug Fixes
-
-- Auto-created output temp directories are now purged when the `Tesseract` client is garbage collected, instead of accumulating under the system temp directory. User-supplied output paths are left untouched.
-
 ## [1.11.0] - 2026-07-23
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Auto-created output temp directories are now purged when the `Tesseract` client is garbage collected, instead of accumulating under the system temp directory. User-supplied output paths are left untouched.
+
 ## [1.11.0] - 2026-07-23
 
 ### Features

--- a/docs/content/reference/array-encodings.md
+++ b/docs/content/reference/array-encodings.md
@@ -108,6 +108,8 @@ $ curl \
 
 The `json+binref` format stores array data in separate `.bin` files and puts only references in the JSON. This enables lazy loading via [LazySequence](#tesseract_core.runtime.experimental.LazySequence). See the [`Array` docstring](#tesseract_core.runtime.Array) for more details.
 
+Because the `.bin` files are written to disk, an output path is required: `tesseract run` and `tesseract serve` reject `json+binref` unless `--output-path` is set. Without it, the `.bin` files would be written inside the container and lost on teardown, leaving the JSON references dangling.
+
 ::::{tab-set}
 :::{tab-item} CLI
 :sync: cli

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -860,9 +860,10 @@ def serve(
         raise ValueError("Tesseract image name must be provided")
 
     if output_format == "json+binref" and output_path is None:
-        logger.warning(
-            "Consider specifying --output-path when using the 'json+binref' output format "
-            "to easily retrieve .bin files."
+        raise UserError(
+            "The 'json+binref' output format writes array buffers to .bin files, "
+            "which are lost when the container is torn down unless an output path "
+            "is set. Specify one with --output-path (or output_path=...)."
         )
 
     image = docker_client.images.get(image_name)
@@ -1202,9 +1203,10 @@ def run_tesseract(
         Tuple with the stdout and stderr of the Tesseract.
     """
     if output_format == "json+binref" and output_path is None:
-        logger.warning(
-            "Consider specifying --output-path when using the 'json+binref' output format "
-            "to easily retrieve .bin files."
+        raise UserError(
+            "The 'json+binref' output format writes array buffers to .bin files, "
+            "which are lost when the container is torn down unless an output path "
+            "is set. Specify one with --output-path (or output_path=...)."
         )
 
     if user is None:

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import shutil
 import sys
 import tempfile
 import traceback
@@ -28,6 +29,15 @@ from .logs import LogStreamer
 
 PathLike: TypeAlias = str | Path
 BoolOrCallable: TypeAlias = bool | Callable[[str], Any]
+
+
+def _purge_tempdir(path: str) -> None:
+    """Remove an auto-created output tempdir. Used as a weakref finalizer.
+
+    Errors are ignored: the dir may already be gone, and a finalizer must never
+    raise (it can run at interpreter shutdown).
+    """
+    shutil.rmtree(path, ignore_errors=True)
 
 
 def requires_client(func: Callable) -> Callable:
@@ -192,6 +202,7 @@ class Tesseract:
             volumes = []
         if input_path is not None:
             input_path = Path(input_path).resolve()
+        auto_output_path = output_path is None
         if output_path is not None:
             output_path = Path(output_path).resolve()
         else:
@@ -200,6 +211,10 @@ class Tesseract:
 
         obj._stream_logs = stream_logs
         obj._timeout = timeout
+        # Purge the auto-created tempdir when the object is garbage collected.
+        # User-supplied output paths are left untouched.
+        if auto_output_path:
+            weakref.finalize(obj, _purge_tempdir, str(output_path))
         obj._spawn_config = dict(
             image_name=image_name,
             volumes=volumes,
@@ -942,6 +957,8 @@ class LocalClient:
 
         if output_path is None:
             output_path = Path(tempfile.mkdtemp(prefix="tesseract_output_"))
+            # Purge the auto-created tempdir when this client is garbage collected.
+            weakref.finalize(self, _purge_tempdir, str(output_path))
         self._output_path = output_path
 
     def run_tesseract(

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -423,6 +423,30 @@ def test_run_tesseract(mocked_docker):
     assert res["device_requests"] is None
 
 
+def test_run_binref_without_output_path_errors(mocked_docker, tmp_path):
+    """json+binref without an output path is a hard error, not silent data loss.
+
+    Without an output path, the runtime writes .bin buffers inside the container,
+    which are discarded on teardown, leaving dangling references in the result.
+    """
+    with pytest.raises(UserError, match="json\\+binref"):
+        engine.run_tesseract(
+            "foobar",
+            "apply",
+            ['{"inputs": {"a": [1, 2, 3], "b": [4, 5, 6]}}'],
+            output_format="json+binref",
+        )
+
+    # With an output path it goes through.
+    engine.run_tesseract(
+        "foobar",
+        "apply",
+        ['{"inputs": {"a": [1, 2, 3], "b": [4, 5, 6]}}'],
+        output_format="json+binref",
+        output_path=str(tmp_path),
+    )
+
+
 def test_run_debug(mocked_docker):
     """Test running a tesseract in debug mode forwards a debugpy port."""
     res_out, _ = engine.run_tesseract(

--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -167,6 +167,31 @@ def test_del_tesseract_triggers_teardown(mock_serving):
     assert teardown_mock.call_count == 1
 
 
+def test_del_tesseract_purges_auto_tempdir(mock_serving):
+    """The auto-created output tempdir is removed when the Tesseract is collected."""
+    import gc
+
+    t = Tesseract.from_image("sometesseract:0.2.3")
+    output_path = t._spawn_config["output_path"]
+    assert output_path.is_dir()
+
+    del t
+    gc.collect()
+    assert not output_path.exists()
+
+
+def test_user_output_path_is_not_purged(mock_serving, tmp_path):
+    """A user-supplied output path must survive garbage collection of the Tesseract."""
+    import gc
+
+    t = Tesseract.from_image("sometesseract:0.2.3", output_path=tmp_path)
+    assert t._spawn_config["output_path"] == tmp_path.resolve()
+
+    del t
+    gc.collect()
+    assert tmp_path.is_dir()
+
+
 def test_Tesseract_schema_method(mocker, mock_serving):
     mocked_run = mocker.patch("tesseract_core.sdk.tesseract.HTTPClient.run_tesseract")
     mocked_run.return_value = {"#defs": {"some": "stuff"}}


### PR DESCRIPTION
Closes #566 

## Summary

`Tesseract` clients auto-create a temporary directory for output when no output path is given — in `Tesseract.from_image` and in the local client backing `Tesseract.from_tesseract_api`. Nothing ever removed these, so `tesseract_output_*` directories accumulated under the system temp directory across runs (worse for long-lived servers / HPC nodes where `/tmp` isn't cleared on reboot).

This registers a `weakref.finalize` per auto-created directory that `rmtree`s it when the owning object is garbage collected, mirroring the existing container-teardown finalizer. User-supplied output paths are left untouched.

## Changes

- Add `_purge_tempdir` helper (swallows errors — a finalizer must never raise, and may run at interpreter shutdown).
- Register the finalizer at both auto-tempdir sites: `from_image` and `LocalClient.__init__`.
- Only auto-created dirs are purged; a path the user passed in is never removed.
- Fail loudly if `tesseract run/serve --output-path binref` is used without an output directory.

## Notes

- Cleanup is on garbage collection (or interpreter exit), not deterministically at `with` scope end — consistent with how container teardown-on-GC already behaves. `teardown()` reads server logs into `_lastlog` before returning, so nothing reads the dir after it could be purged.

## Testing

- New fast tests: `test_del_tesseract_purges_auto_tempdir` (dir gone after GC) and `test_user_output_path_is_not_purged` (user path survives).
- `test_tesseract.py` + `test_engine.py`: 110 passed. `pre-commit`: passed.