### PR TITLE
fix(sdk): pin uv image to target platform for cross-arch builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This file contains counter-intuitive rules and aspects of the Tesseract codebase
 
 - **Read the actual code before proposing an architecture or approach.** Do not speculate about capabilities or patterns.
 - **Reproduce the problem before trying to solve it.** If a user reports a bug, try to reproduce it locally before proposing a fix. If you have a hypothesis regarding a root cause, verify it. If that's not possible, communicate it clearly.
+- **Do not touch `CHANGELOG.md`.** It is auto-generated from PR titles when a release is triggered.
 
 ## Environment setup
 
@@ -50,3 +51,4 @@ Each of these is a separate repository/Python package.
 - **Tesseract-JAX** is a mature package that supports full integration of Tesseract calls into JAX programs, including JIT compilation and automatic differentiation of code that mixes Tesseract calls and JAX operations.
 - **Tesseract-Torch** is the PyTorch counterpart to Tesseract-JAX: it embeds Tesseract calls as PyTorch operators so that `torch.autograd` flows through code that mixes Tesseract calls and PyTorch operations.
 - **Tesseract-Streamlit** provides tools to auto-generate Streamlit apps from (externally running / locally built) Tesseracts. It can be used to quickly create interactive demos for Tesseracts and custom visualization without writing any Streamlit code, but is limited to forward application (`apply`).
+- **cookiecutter-tesseract** is a template for creating new Tesseract repositories. It includes a pre-configured Python package, Dockerfile, and GitHub Actions CI/CD pipeline.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Bug Fixes
+
+- Building for a non-native `target_platform` together with a pinned `python_version` no longer fails: the `uv` image is now pinned to the target platform so `uv python install` fetches an interpreter for the target architecture instead of the host's. The `uv` image is also pinned to a released version instead of `latest` for reproducible builds (#684).
+
 ## [1.11.0] - 2026-07-23
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
-
-### Bug Fixes
-
-- Building for a non-native `target_platform` together with a pinned `python_version` no longer fails: the `uv` image is now pinned to the target platform so `uv python install` fetches an interpreter for the target architecture instead of the host's. The `uv` image is also pinned to a released version instead of `latest` for reproducible builds (#684).
-
 ## [1.11.0] - 2026-07-23
 
 ### Features

--- a/tesseract_core/sdk/templates/Dockerfile.base
+++ b/tesseract_core/sdk/templates/Dockerfile.base
@@ -18,11 +18,7 @@ FROM --platform={{ config.build_config.target_platform }} {{ config.build_config
 # Ensure root user for build commands (some base images set a non-root default)
 USER root
 
-# Obtain uv and companions. The uv stage is pinned to the same platform as the
-# build stage so that `uv python install` downloads an interpreter matching the
-# target architecture. A bare `COPY --from=ghcr.io/astral-sh/uv` would resolve
-# the image for $BUILDPLATFORM (the host) instead, causing a wrong-arch
-# interpreter to be fetched when target_platform differs from the host.
+# Obtain uv and companions
 COPY --from=uv /uv /uvx /bin/
 
 ENV UV_LINK_MODE=copy

--- a/tesseract_core/sdk/templates/Dockerfile.base
+++ b/tesseract_core/sdk/templates/Dockerfile.base
@@ -2,20 +2,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Stage 1: Build Python environment and install requirements
+# uv is pinned to a released version for reproducible builds; bump it manually
+# to pick up new uv features and newer bundled CPython builds.
 # For "native", pin to $BUILDPLATFORM (the host platform BuildKit runs on) so the
 # base image manifest is re-resolved for the host architecture instead of reusing a
 # wrong-arch image that may already be in the local cache.
 {% if config.build_config.target_platform.strip() == "native" %}
+FROM --platform=$BUILDPLATFORM ghcr.io/astral-sh/uv:0.12.5 AS uv
 FROM --platform=$BUILDPLATFORM {{ config.build_config.base_image }} AS build_stage
 {% else %}
+FROM --platform={{ config.build_config.target_platform }} ghcr.io/astral-sh/uv:0.12.5 AS uv
 FROM --platform={{ config.build_config.target_platform }} {{ config.build_config.base_image }} AS build_stage
 {% endif %}
 
 # Ensure root user for build commands (some base images set a non-root default)
 USER root
 
-# Obtain uv and companions
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Obtain uv and companions. The uv stage is pinned to the same platform as the
+# build stage so that `uv python install` downloads an interpreter matching the
+# target architecture. A bare `COPY --from=ghcr.io/astral-sh/uv` would resolve
+# the image for $BUILDPLATFORM (the host) instead, causing a wrong-arch
+# interpreter to be fetched when target_platform differs from the host.
+COPY --from=uv /uv /uvx /bin/
 
 ENV UV_LINK_MODE=copy
 

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import re
 import socket
 import time
 from contextlib import closing
@@ -57,6 +58,39 @@ def test_prepare_build_context_python_version(tmp_path_factory):
 
     dockerfile_default = (build_dir2 / "Dockerfile").read_text()
     assert "TESSERACT_PYTHON_VERSION" not in dockerfile_default
+
+
+def test_prepare_build_context_uv_platform(tmp_path_factory):
+    """The uv image must be pinned to the same platform as the build stage.
+
+    Otherwise `uv python install` fetches an interpreter for the host arch
+    instead of the target arch (see #684).
+    """
+    src_dir = tmp_path_factory.mktemp("src")
+    (src_dir / "foo").touch()
+
+    # Non-native target: uv stage is pinned to the target platform, not the host.
+    build_dir = tmp_path_factory.mktemp("build")
+    config = TesseractConfig(
+        name="foobar",
+        build_config=TesseractBuildConfig(target_platform="linux/amd64"),
+    )
+    engine.prepare_build_context(src_dir, build_dir, config)
+    dockerfile = (build_dir / "Dockerfile").read_text()
+    assert re.search(
+        r"FROM --platform=linux/amd64 ghcr\.io/astral-sh/uv:\S+ AS uv", dockerfile
+    )
+    assert "COPY --from=uv /uv /uvx /bin/" in dockerfile
+
+    # Native target: uv stage follows $BUILDPLATFORM.
+    build_dir2 = tmp_path_factory.mktemp("build2")
+    config_native = TesseractConfig(name="foobar")
+    engine.prepare_build_context(src_dir, build_dir2, config_native)
+    dockerfile_native = (build_dir2 / "Dockerfile").read_text()
+    assert re.search(
+        r"FROM --platform=\$BUILDPLATFORM ghcr\.io/astral-sh/uv:\S+ AS uv",
+        dockerfile_native,
+    )
 
 
 def test_prepare_build_context_env(tmp_path_factory):


### PR DESCRIPTION
#### Relevant issue or PR

Fixes #684

#### Description of changes

When building for a non-native target_platform (e.g. linux/amd64 on an arm64 host) with a pinned python_version, the build failed during venv setup with "Python interpreter not found at .../cpython-...-linux-aarch64-...".

`COPY --from=ghcr.io/astral-sh/uv:latest` resolves the uv image for `$BUILDPLATFORM` (the host) rather than the build stage's target platform, so the copied-in uv binary is the host-arch binary. `uv python install` keys the interpreter download off its own binary's architecture, fetching a host-arch interpreter that does not match the emulated target stage.

Declare uv as a named build stage pinned to the same platform as build_stage and COPY from it, so uv downloads a target-arch interpreter. Also pin the uv image to a released version (0.12.5) instead of `latest` for reproducible builds.

#### Testing done

CI, original reproducer passes now