### PR TITLE
fix(runtime): skip absent optional containers when expanding paths

### DIFF
--- a/tesseract_core/runtime/testing/finite_differences.py
+++ b/tesseract_core/runtime/testing/finite_differences.py
@@ -62,11 +62,7 @@ def expand_path_pattern(path_pattern: str, inputs: dict[str, Any]) -> list[str]:
             return [".".join(current_path)]
 
         if current_inputs is None:
-            # An optional container that was not supplied. There is nothing
-            # left to expand, and every branch below would raise on None:
-            # `[]` and `{}` iterate it, and a named part subscripts it. The
-            # pattern comes from the schema, so this is a normal absent
-            # field rather than a bad path.
+            # An optional container (e.g. `list | None`) that was not supplied.
             return []
 
         paths = []

--- a/tesseract_core/runtime/testing/finite_differences.py
+++ b/tesseract_core/runtime/testing/finite_differences.py
@@ -61,6 +61,14 @@ def expand_path_pattern(path_pattern: str, inputs: dict[str, Any]) -> list[str]:
         if not parts:
             return [".".join(current_path)]
 
+        if current_inputs is None:
+            # An optional container that was not supplied. There is nothing
+            # left to expand, and every branch below would raise on None:
+            # `[]` and `{}` iterate it, and a named part subscripts it. The
+            # pattern comes from the schema, so this is a normal absent
+            # field rather than a bad path.
+            return []
+
         paths = []
         part = parts[0]
 

--- a/tests/runtime_tests/test_finite_differences.py
+++ b/tests/runtime_tests/test_finite_differences.py
@@ -195,3 +195,67 @@ class TestExpandPathPatternOptionalFields:
     )
     def test_populated_paths_are_unchanged(self, pattern, inputs, expected):
         assert expand_path_pattern(pattern, inputs) == expected
+
+
+class _OptionalExtra(BaseModel):
+    w: Differentiable[Array[(3,), Float32]]
+
+
+class OptionalContainerModule(ModuleType):
+    """A schema with an optional sub-model, as real Tesseracts have.
+
+    Optional initial conditions, boundary data or preconditioner state are
+    ordinary inputs. The differentiable path ``extra.w`` is still declared
+    when ``extra`` is absent, so the path walk meets ``None``.
+    """
+
+    class InputSchema(BaseModel):
+        x: Differentiable[Array[(3,), Float32]]
+        extra: _OptionalExtra | None = None
+
+    class OutputSchema(BaseModel):
+        y: Differentiable[Array[(3,), Float32]]
+
+    def apply(self, inputs: InputSchema) -> OutputSchema:
+        y = 2.0 * np.asarray(inputs.x, dtype=np.float32)
+        if inputs.extra is not None:
+            y = y + np.asarray(inputs.extra.w, dtype=np.float32)
+        return {"y": y}
+
+    def jacobian(
+        self,
+        inputs: InputSchema,
+        jac_inputs: set[str],
+        jac_outputs: set[str],
+    ):
+        return {
+            "y": {
+                p: (2.0 if p == "x" else 1.0) * np.eye(3, dtype=np.float32)
+                for p in jac_inputs
+            }
+        }
+
+
+def test_check_gradients_runs_with_an_absent_optional_container():
+    """End-to-end: an absent optional input must not abort the whole check.
+
+    ``extra.w`` stays in ``differentiable_arrays`` whether or not ``extra``
+    was supplied, so the path walk meets ``None`` and every branch of it
+    raises. On an unguarded tree this fails with ``TypeError: 'NoneType'
+    object is not subscriptable`` before a single gradient is checked.
+    """
+    module = OptionalContainerModule("optional_container_module")
+
+    num_evals_total = 0
+    for _endpoint, failures, num_evals in check_gradients(
+        module,
+        {"inputs": {"x": np.ones(3, dtype=np.float32), "extra": None}},
+        base_dir=None,
+        endpoints=["jacobian"],
+        max_evals=6,
+        seed=0,
+    ):
+        num_evals_total += num_evals
+        assert not failures
+
+    assert num_evals_total > 0, "nothing was checked, so this proves nothing"

--- a/tests/runtime_tests/test_finite_differences.py
+++ b/tests/runtime_tests/test_finite_differences.py
@@ -5,7 +5,10 @@ import pytest
 from pydantic import BaseModel
 
 from tesseract_core.runtime import Array, Differentiable, Float32
-from tesseract_core.runtime.testing.finite_differences import check_gradients
+from tesseract_core.runtime.testing.finite_differences import (
+    check_gradients,
+    expand_path_pattern,
+)
 from tesseract_core.runtime.tree_transforms import get_at_path
 
 
@@ -153,3 +156,42 @@ def test_check_gradients(input_paths, output_paths, endpoints):
             "jacobian_vector_product",
             "vector_jacobian_product",
         ]
+
+
+class TestExpandPathPatternOptionalFields:
+    """Optional container fields must not abort path expansion.
+
+    The pattern comes from the schema, so an optional field that was simply
+    not supplied is a normal input rather than a bad path. Every branch of
+    the walk raises on ``None`` though: ``[]`` and ``{}`` iterate it and a
+    named part subscripts it, so a Tesseract with an optional container
+    input used to fail before checking a single gradient.
+    """
+
+    @pytest.mark.parametrize(
+        "pattern,inputs",
+        [
+            ("a.[].b", {"a": None}),
+            ("a.b", {"a": None}),
+            ("a.{}.b", {"a": None}),
+        ],
+        ids=["optional_list", "optional_submodel", "optional_dict"],
+    )
+    def test_absent_optional_container_expands_to_nothing(self, pattern, inputs):
+        assert expand_path_pattern(pattern, inputs) == []
+
+    def test_none_entry_inside_a_populated_list_is_skipped(self):
+        """The present entries still expand; only the missing one drops out."""
+        assert expand_path_pattern("a.[].b", {"a": [{"b": 1}, None]}) == ["a.[0].b"]
+
+    @pytest.mark.parametrize(
+        "pattern,inputs,expected",
+        [
+            ("a.[].b", {"a": [{"b": 1}, {"b": 2}]}, ["a.[0].b", "a.[1].b"]),
+            ("a.{}.b", {"a": {"x": {"b": 1}}}, ["a.{x}.b"]),
+            ("a.b", {"a": {"b": 1}}, ["a.b"]),
+        ],
+        ids=["list", "dict", "plain"],
+    )
+    def test_populated_paths_are_unchanged(self, pattern, inputs, expected):
+        assert expand_path_pattern(pattern, inputs) == expected


### PR DESCRIPTION
Extracted from @jpbrodrick89's #552 so it can land on its own, per @dionhaefner's review comment there on 2026-04-21 ("Sounds like this should be an independent fix?"). #552 is still a draft and the rest of it is the Julia example, which this does not touch.

`expand_path_pattern` walks a schema-derived pattern against the actual inputs, and every branch of that walk raises on `None`: `[]` and `{}` iterate it, and a named part subscripts it. So a Tesseract with an optional container input aborts `check-gradients` before checking anything, with a bare traceback out of a path helper. Nothing at the CLI wraps the call.

On current `main`:

```
a.[].b   {"a": None}                -> TypeError: 'NoneType' object is not iterable
a.b      {"a": None}                -> TypeError: 'NoneType' object is not subscriptable
a.{}.b   {"a": None}                -> TypeError: 'NoneType' object is not iterable
a.[].b   {"a": [{"b": 1}, None]}    -> TypeError: 'NoneType' object is not subscriptable
```

After, with the populated cases unchanged:

```
a.[].b   {"a": None}                -> []
a.b      {"a": None}                -> []
a.{}.b   {"a": None}                -> []
a.[].b   {"a": [{"b": 1}, None]}    -> ['a.[0].b']
```

The pattern comes from the schema, so a field that was simply not supplied is a normal input rather than a bad path. A `None` entry inside a populated list drops out the same way while its siblings still expand.

## What I deliberately left out

#552 also swaps the named-part lookup for `.get()` / `getattr(..., None)`. That would turn a genuinely missing field from a loud `KeyError` into a silently dropped path, which is a different and less obviously desirable change, so it stays in #552.

## Tests

`expand_path_pattern` had no direct tests. Added seven: the three absent-optional shapes, the `None`-inside-a-list case, and three populated controls that assert nothing else moved. The first four fail on `main`; the controls pass either way by construction, which is the point of having them.

`tests/runtime_tests` is 420 passed. `ruff` on the touched files is unchanged at the 2 pre-existing `BLE001`.

No conflict with #688, which touches a different part of the same file.
