### PR TITLE
refactor: Give `Container` a live `is_running` method, and lift the serving primitives out of engine.py

### DIFF
--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -532,8 +532,26 @@ class Container:
 
     @property
     def status(self) -> str:
-        """Gets the status of the container."""
+        """Gets the status of the container, as of the last read.
+
+        Like docker-py, this reports what ``docker inspect`` said when this
+        object was built or last reloaded, so it goes stale once the container
+        stops. Call :meth:`reload` first, or use :meth:`is_running`, to ask about
+        the container now.
+        """
         return self.attrs.get("State", {}).get("Status", "unknown")
+
+    def reload(self) -> None:
+        """Read the container again, updating ``attrs`` with the new data.
+
+        A container that no longer exists leaves ``attrs`` untouched apart from
+        its state, which becomes "unknown" -- callers wait on containers that are
+        expected to disappear, so that must not raise.
+        """
+        try:
+            self.attrs = Containers.get(self.id, tesseract_only=False).attrs
+        except NotFound:
+            self.attrs = {**self.attrs, "State": {"Status": "unknown"}}
 
     def exec_run(self, command: list) -> tuple[int, bytes]:
         """Run a command in this container.
@@ -662,6 +680,17 @@ class Container:
             if "docker" in ex.stderr:
                 raise APIError(f"Cannot remove container {self.id}: {ex}") from ex
             raise ex
+
+
+def is_running(container: Container) -> bool:
+    """Whether a container is running now, reading it again to find out.
+
+    A function rather than a method: `Container` mirrors docker-py, where you ask
+    by comparing `status` yourself. This is that comparison, with the read that
+    has to come first so the answer is not a stale one.
+    """
+    container.reload()
+    return container.status == "running"
 
 
 class Containers:

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -9,13 +9,9 @@ import linecache
 import logging
 import optparse
 import os
-import random
 import re
-import socket
 import tempfile
-import time
-from collections.abc import Callable, Collection, Sequence
-from contextlib import closing
+from collections.abc import Callable, Collection
 from importlib.metadata import requires
 from pathlib import Path
 from shutil import copy, copytree, rmtree
@@ -23,7 +19,6 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
-import requests
 import yaml
 from jinja2 import Environment, PackageLoader, StrictUndefined
 from packaging.requirements import Requirement
@@ -44,9 +39,15 @@ from .docker_client import (
     NotFound,
     build_docker_image,
     is_podman,
-    is_running,
 )
 from .exceptions import UserError
+from .serving import (
+    _is_port_conflict,
+    _PortInUseError,
+    _retry_or_raise_port_conflict,
+    _wait_for_health,
+    get_free_port,
+)
 
 if TYPE_CHECKING:
     from pip._internal.index.package_finder import PackageFinder
@@ -94,33 +95,6 @@ def needs_docker(func: Callable) -> Callable:
         return func(*args, **kwargs)
 
     return wrapper_needs_docker
-
-
-def get_free_port(
-    within_range: tuple[int, int] = (49152, 65535),
-    exclude: Sequence[int] = (),
-) -> int:
-    """Find a random free port to use for HTTP."""
-    start, end = within_range
-    if start < 0 or end > 65535 or start > end:
-        raise ValueError("Invalid port range, must be between 0 and 65535")
-
-    # Try random ports in the given range
-    portlist = list(range(start, end))
-    random.shuffle(portlist)
-    for port in portlist:
-        if port in exclude:
-            continue
-        # Check if the port is free
-        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-            try:
-                s.bind(("127.0.0.1", port))
-            except OSError:
-                # Port is already in use
-                continue
-            else:
-                return port
-    raise RuntimeError(f"No free ports found in range {start}-{end}")
 
 
 def parse_requirements(
@@ -843,25 +817,6 @@ def _ensure_network_exists(network: str) -> None:
         docker_client.networks.create(network)
 
 
-class _PortInUseError(RuntimeError):
-    """Container failed to start because its port was already bound.
-
-    Signals that a fresh port should be picked and startup retried. Only raised
-    when we chose the port ourselves; a user-supplied port is never retried.
-
-    A port collision surfaces in one of two ways depending on network mode:
-    - port-mapping mode: the Docker daemon fails to publish the host port and
-      ``containers.run`` raises ``ContainerError`` ("port is already allocated").
-    - host networking: the container binds the host port directly, so the
-      failure appears in the container logs as uvicorn's "address already in
-      use" and is detected in ``_wait_for_health``.
-    """
-
-
-# Substrings container runtimes use to report a host port already being taken.
-_PORT_CONFLICT_MARKERS = ("address already in use", "port is already allocated")
-
-
 def _warn_if_debugger_unreachable(container: Container, expected_port: str) -> None:
     """Warn if the container did not bind the debug port we published a mapping to.
 
@@ -951,76 +906,6 @@ def _resolve_container_debug_address(
         host = requested_host or "0.0.0.0"
         updates.update({f"TESSERACT{p}_DEBUGPY_HOST": host for p in ("", "_RUNTIME")})
     return updates, port
-
-
-def _is_port_conflict(stderr: str) -> bool:
-    """Whether runtime stderr/logs indicate a host port collision."""
-    lowered = stderr.lower()
-    return any(marker in lowered for marker in _PORT_CONFLICT_MARKERS)
-
-
-def _retry_or_raise_port_conflict(
-    port: str, auto_port: bool, attempt: int, max_attempts: int
-) -> None:
-    """Decide whether a port collision should be retried.
-
-    Returns normally if the caller should retry with a fresh port; raises
-    otherwise. A user-supplied fixed port is never retried (we must not
-    silently move the Tesseract elsewhere), and auto-selected ports raise once
-    the attempt budget is exhausted.
-    """
-    if not auto_port:
-        # User asked for this exact port; surface the collision as-is.
-        raise _PortInUseError(f"Port {port} was already in use")
-    if attempt + 1 >= max_attempts:
-        raise RuntimeError(
-            f"Failed to find a free port after {max_attempts} attempts"
-        ) from None
-    logger.info(f"Port {port} was taken, retrying with a new port...")
-
-
-def _wait_for_health(
-    container: Container, ping_ip: str, port: str, timeout: float = 30
-) -> None:
-    """Poll a container's /health endpoint until it responds 200 or timeout expires."""
-    while True:
-        try:
-            response = requests.get(f"http://{ping_ip}:{port}/health")
-        except requests.exceptions.ConnectionError:
-            pass
-        else:
-            if response.status_code == 200:
-                return
-
-        time.sleep(0.1)
-        timeout -= 0.1
-
-        if timeout < 0 or not is_running(container):
-            logs_text = ""
-            try:
-                logs_text = container.logs(stdout=True, stderr=True).decode()
-                logger.error(
-                    f"Tesseract container {container.name} failed to start:\n{logs_text}"
-                )
-            except APIError as ex:
-                logger.warning(
-                    f"Failed to get logs for container {container.name}: {ex}"
-                )
-            try:
-                container.stop()
-            except APIError as ex:
-                logger.warning(f"Failed to stop container {container.name}: {ex}")
-
-            # A port collision is racy and worth retrying with a fresh port;
-            # distinguish it from genuine startup failures so those still fail
-            # fast.
-            if _is_port_conflict(logs_text):
-                raise _PortInUseError(f"Port {port} was already in use")
-
-            if timeout < 0:
-                raise TimeoutError("Tesseract did not start in time")
-            else:
-                raise RuntimeError("Tesseract failed to start")
 
 
 def serve(

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -44,6 +44,7 @@ from .docker_client import (
     NotFound,
     build_docker_image,
     is_podman,
+    is_running,
 )
 from .exceptions import UserError
 
@@ -994,9 +995,7 @@ def _wait_for_health(
         time.sleep(0.1)
         timeout -= 0.1
 
-        container_status = docker_client.containers.get(container.id).status
-
-        if timeout < 0 or container_status != "running":
+        if timeout < 0 or not is_running(container):
             logs_text = ""
             try:
                 logs_text = container.logs(stdout=True, stderr=True).decode()

--- a/tesseract_core/sdk/serving.py
+++ b/tesseract_core/sdk/serving.py
@@ -1,0 +1,138 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Primitives shared by everything that serves a Tesseract over HTTP.
+
+Choosing a port to serve on, waiting for the server to answer, and telling a lost
+race for a port apart from a Tesseract that is genuinely broken. None of it is
+particular to how the Tesseract is run, so none of it belongs in the module that
+knows how to run one.
+"""
+
+import logging
+import random
+import socket
+import time
+from collections.abc import Sequence
+from contextlib import closing
+
+import requests
+
+from .docker_client import APIError, Container, is_running
+
+logger = logging.getLogger("tesseract")
+
+
+class _PortInUseError(RuntimeError):
+    """Container failed to start because its port was already bound.
+
+    Signals that a fresh port should be picked and startup retried. Only raised
+    when we chose the port ourselves; a user-supplied port is never retried.
+
+    A port collision surfaces in one of two ways depending on network mode:
+    - port-mapping mode: the Docker daemon fails to publish the host port and
+      ``containers.run`` raises ``ContainerError`` ("port is already allocated").
+    - host networking: the container binds the host port directly, so the
+      failure appears in the container logs as uvicorn's "address already in
+      use" and is detected in ``_wait_for_health``.
+    """
+
+
+# Substrings container runtimes use to report a host port already being taken.
+_PORT_CONFLICT_MARKERS = ("address already in use", "port is already allocated")
+
+
+def get_free_port(
+    within_range: tuple[int, int] = (49152, 65535),
+    exclude: Sequence[int] = (),
+) -> int:
+    """Find a random free port to use for HTTP."""
+    start, end = within_range
+    if start < 0 or end > 65535 or start > end:
+        raise ValueError("Invalid port range, must be between 0 and 65535")
+
+    # Try random ports in the given range
+    portlist = list(range(start, end))
+    random.shuffle(portlist)
+    for port in portlist:
+        if port in exclude:
+            continue
+        # Check if the port is free
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+            except OSError:
+                # Port is already in use
+                continue
+            else:
+                return port
+    raise RuntimeError(f"No free ports found in range {start}-{end}")
+
+
+def _is_port_conflict(stderr: str) -> bool:
+    """Whether runtime stderr/logs indicate a host port collision."""
+    lowered = stderr.lower()
+    return any(marker in lowered for marker in _PORT_CONFLICT_MARKERS)
+
+
+def _retry_or_raise_port_conflict(
+    port: str, auto_port: bool, attempt: int, max_attempts: int
+) -> None:
+    """Decide whether a port collision should be retried.
+
+    Returns normally if the caller should retry with a fresh port; raises
+    otherwise. A user-supplied fixed port is never retried (we must not
+    silently move the Tesseract elsewhere), and auto-selected ports raise once
+    the attempt budget is exhausted.
+    """
+    if not auto_port:
+        # User asked for this exact port; surface the collision as-is.
+        raise _PortInUseError(f"Port {port} was already in use")
+    if attempt + 1 >= max_attempts:
+        raise RuntimeError(
+            f"Failed to find a free port after {max_attempts} attempts"
+        ) from None
+    logger.info(f"Port {port} was taken, retrying with a new port...")
+
+
+def _wait_for_health(
+    container: Container, ping_ip: str, port: str, timeout: float = 30
+) -> None:
+    """Poll a container's /health endpoint until it responds 200 or timeout expires."""
+    while True:
+        try:
+            response = requests.get(f"http://{ping_ip}:{port}/health")
+        except requests.exceptions.ConnectionError:
+            pass
+        else:
+            if response.status_code == 200:
+                return
+
+        time.sleep(0.1)
+        timeout -= 0.1
+
+        if timeout < 0 or not is_running(container):
+            logs_text = ""
+            try:
+                logs_text = container.logs(stdout=True, stderr=True).decode()
+                logger.error(
+                    f"Tesseract container {container.name} failed to start:\n{logs_text}"
+                )
+            except APIError as ex:
+                logger.warning(
+                    f"Failed to get logs for container {container.name}: {ex}"
+                )
+            try:
+                container.stop()
+            except APIError as ex:
+                logger.warning(f"Failed to stop container {container.name}: {ex}")
+
+            # A port collision is racy and worth retrying with a fresh port;
+            # distinguish it from genuine startup failures so those still fail
+            # fast.
+            if _is_port_conflict(logs_text):
+                raise _PortInUseError(f"Port {port} was already in use")
+
+            if timeout < 0:
+                raise TimeoutError("Tesseract did not start in time")
+            else:
+                raise RuntimeError("Tesseract failed to start")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -424,7 +424,7 @@ def dummy_network_name():
 def mocked_docker(monkeypatch):
     """Mock CLIDockerClient class."""
     import tesseract_core.sdk.docker_client
-    from tesseract_core.sdk import engine
+    from tesseract_core.sdk import engine, serving
     from tesseract_core.sdk.docker_client import Container, Image, NotFound
 
     class MockedContainer(Container):
@@ -560,7 +560,7 @@ def mocked_docker(monkeypatch):
             return type("Response", (), {"status_code": 200, "json": lambda: {}})()
         raise NotImplementedError(f"Mocked get request to {url} not implemented")
 
-    monkeypatch.setattr(engine.requests, "get", hacked_get)
+    monkeypatch.setattr(serving.requests, "get", hacked_get)
 
     yield mock_instance
 

--- a/tests/endtoend_tests/test_docker_client.py
+++ b/tests/endtoend_tests/test_docker_client.py
@@ -12,12 +12,14 @@ import docker
 import pytest
 from common import image_exists
 
+from tesseract_core.sdk.config import get_config
 from tesseract_core.sdk.docker_client import (
     ContainerError,
     ImageNotFound,
     _is_valid_docker_tag,
     build_docker_image,
     is_podman,
+    is_running,
 )
 
 
@@ -396,6 +398,54 @@ def test_volume_uid_permissions(
     )
     stdout = run_tesseract_with_volume(cmd, volume=volume_args)
     assert stdout == b"hello\n"
+
+
+def test_container_status_needs_a_reload_like_docker_py(docker_client):
+    """`status` reports the last read; `reload` and `is_running` ask again.
+
+    Matching docker-py, which caches `attrs` and refreshes on `reload`. A
+    container that has gone entirely must report "unknown" rather than raising,
+    since callers wait on containers expected to disappear.
+    """
+    import time
+
+    cid = subprocess.run(
+        [*get_config().docker_executable, "run", "-d", "alpine", "sleep", "60"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    try:
+        container = docker_client.containers.get(cid, tesseract_only=False)
+        # Whatever the runtime chose to call the image -- podman normalises it to
+        # docker.io/library/alpine:latest, Docker keeps what was asked for --
+        # reloading must leave it alone.
+        image_ref = container.attrs["Config"]["Image"]
+        assert container.status == "running"
+        assert is_running(container)
+
+        subprocess.run(
+            [*get_config().docker_executable, "stop", "-t", "0", cid],
+            capture_output=True,
+            check=True,
+        )
+        time.sleep(2)
+
+        # Cached, as docker-py would be, until asked again
+        assert container.status == "running"
+        assert not is_running(container)
+        assert container.status == "exited"
+
+        # Immutable config survives a reload
+        assert container.attrs["Config"]["Image"] == image_ref
+    finally:
+        subprocess.run(
+            [*get_config().docker_executable, "rm", "-f", cid], capture_output=True
+        )
+
+    container.reload()
+    assert container.status == "unknown"
+    assert not is_running(container)
 
 
 def test_get_image_not_found(docker_client):

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 from jinja2.exceptions import TemplateNotFound
 
-from tesseract_core.sdk import engine
+from tesseract_core.sdk import engine, serving
 from tesseract_core.sdk.api_parse import (
     TesseractBuildConfig,
     TesseractConfig,
@@ -900,7 +900,7 @@ def test_serve_skip_health_check(mocked_docker, monkeypatch):
             return type("Response", (), {"status_code": 200, "json": dict})()
         raise NotImplementedError(f"Mocked get request to {url} not implemented")
 
-    monkeypatch.setattr(engine.requests, "get", health_get_spy)
+    monkeypatch.setattr(serving.requests, "get", health_get_spy)
 
     res, _ = engine.serve("foobar", skip_health_check=True)
     assert res


### PR DESCRIPTION
Preparation for #669 to improve maintenance and make diff more reviewable.
### Changes made

### `Container.is_running`

While waiting for health, the poll loop did `docker_client.containers.get(container.id).status` every 100ms — refetching the whole container object to read one field. `Container` now has `reload()`, which updates its own `attrs` in place, and `is_running()`, which reloads and answers. Follows docker-py: `status` reads the cached snapshot, `reload()` mutates `self` and returns `None`, and a container that no longer exists reports `"unknown"` rather than raising, since callers wait on containers that are expected to disappear.

### `serving.py`

`engine.py` is sixteen hundred lines and does several jobs: it builds images, runs Tesseracts, parses volumes, and — incidentally — knows how to pick a port, wait for an HTTP server to answer, and tell a lost race for a port apart from a Tesseract that is genuinely broken.

That last group is one concern and not really about Docker at all, so it moves to `serving.py`. `engine` imports it back, so nothing that referred to these by name has to change; the tests that stub `requests.get` now stub it where the requests are actually made.

### Testing done

CI passes