### PR TITLE
feat: Let a Tesseract be given longer to start, and dispose of one that never does

### DIFF
--- a/tesseract_core/sdk/cli.py
+++ b/tesseract_core/sdk/cli.py
@@ -24,7 +24,7 @@ from pydantic import ValidationError as PydanticValidationError
 from rich.console import Console as RichConsole
 from rich.table import Table as RichTable
 
-from . import engine
+from . import engine, serving
 from .api_parse import (
     EXPECTED_OBJECTS,
     ValidationError,
@@ -600,6 +600,17 @@ def serve(
             ),
         ),
     ] = False,
+    startup_timeout: Annotated[
+        float,
+        typer.Option(
+            "--startup-timeout",
+            help=(
+                "How long to wait, in seconds, for the Tesseract to answer a health "
+                "check. Raise it for one that is slow to initialize, in preference "
+                "to skipping the check altogether."
+            ),
+        ),
+    ] = serving.DEFAULT_STARTUP_TIMEOUT,
     user: Annotated[
         str | None,
         typer.Option(
@@ -699,6 +710,7 @@ def serve(
             output_format=_enum_to_val(output_format),
             docker_args=shlex.split(docker_args) if docker_args else None,
             skip_health_check=skip_health_check,
+            startup_timeout=startup_timeout,
         )
     except RuntimeError as ex:
         raise UserError(

--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -575,6 +575,14 @@ class Container:
             )
         return result.returncode, result.stdout
 
+    def __str__(self) -> str:
+        """Name this container in a message meant for a person.
+
+        `__repr__` is left to the dataclass, which spells out the constructor as
+        it should; this is what belongs in an error someone has to read.
+        """
+        return f"Tesseract container {self.name}"
+
     def stop(self) -> None:
         """Stop the container."""
         docker = _get_docker_executable()
@@ -629,11 +637,22 @@ class Container:
 
         return getattr(result, output_attr)
 
-    def wait(self) -> dict:
-        """Wait for container to finish running.
+    def wait(self, timeout: float | None = None) -> dict:
+        """Block until the container stops, then report the status it stopped with.
+
+        Params:
+            timeout: Seconds to wait before giving up. `docker wait` blocks for as
+                long as the container runs, so without this a live container waits
+                forever.
 
         Returns:
             A dict with the exit code of the container.
+
+        Raises:
+            TimeoutError: If the container is still running when `timeout` expires.
+                Note this differs from docker-py, which raises
+                `requests.exceptions.ReadTimeout`; nothing here speaks HTTP.
+            APIError: If the command fails, e.g. for a container that is gone.
         """
         docker = _get_docker_executable()
 
@@ -643,9 +662,14 @@ class Container:
                 check=True,
                 capture_output=True,
                 text=True,
+                timeout=timeout,
             )
             # Container's exit code is printed by the wait command
             return {"StatusCode": int(result.stdout)}
+        except subprocess.TimeoutExpired as ex:
+            raise TimeoutError(
+                f"Container {self.id} was still running after {timeout}s"
+            ) from ex
         except subprocess.CalledProcessError as ex:
             raise APIError(f"Cannot wait for container {self.id}: {ex}") from ex
 
@@ -691,6 +715,37 @@ def is_running(container: Container) -> bool:
     """
     container.reload()
     return container.status == "running"
+
+
+def diagnose_exit(container: Container, logs: str) -> str:
+    """Anything `docker inspect` recorded about why a container stopped.
+
+    A function rather than a method: `Container` mirrors docker-py, and docker-py
+    has nothing like this. Reads the recorded state rather than the container,
+    which by the time anything is said about a failure has been disposed of --
+    liveness is what noticed it had stopped, and reading it refreshed that state,
+    so what it holds is how it stopped.
+
+    Params:
+        container: The container that stopped.
+        logs: What it wrote, for context. Not repeated in the result.
+
+    Returns:
+        A sentence for whoever has to read the failure, or an empty string if
+        there is nothing to add beyond the exit code and the logs.
+    """
+    del logs  # a container's own output is all the other evidence there is
+    state = container.attrs.get("State", {})
+    if state.get("OOMKilled"):
+        # Nothing else can report this: the process is killed outright, so it has
+        # no chance to say anything about it in its own logs.
+        return (
+            "It was killed for exceeding its memory limit, which is why it may "
+            "have written nothing. Give it a higher `memory` limit."
+        )
+    if state.get("Error"):
+        return f"Docker reported: {state['Error']}"
+    return ""
 
 
 class Containers:

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -42,6 +42,7 @@ from .docker_client import (
 )
 from .exceptions import UserError
 from .serving import (
+    DEFAULT_STARTUP_TIMEOUT,
     _is_port_conflict,
     _PortInUseError,
     _retry_or_raise_port_conflict,
@@ -928,6 +929,7 @@ def serve(
     docker_args: list[str] | None = None,
     runtime_config: dict[str, Any] | None = None,
     skip_health_check: bool = False,
+    startup_timeout: float = DEFAULT_STARTUP_TIMEOUT,
 ) -> tuple:
     """Serve one or more Tesseract images.
 
@@ -960,6 +962,9 @@ def serve(
             Tesseracts with slow initialization (e.g., Julia runtime startup, large
             model loading). The caller is responsible for ensuring readiness,
             e.g. by polling ``/health``, before calling other endpoints.
+        startup_timeout: How long to wait for the Tesseract to answer a health
+            check, in seconds. Raise it for one that is slow to initialize, in
+            preference to skipping the check altogether.
 
     Returns:
         A tuple of the Tesseract container name and the port it is serving on.
@@ -1147,7 +1152,7 @@ def serve(
                 break
 
             logger.info("Waiting for Tesseract to start...")
-            _wait_for_health(container, ping_ip, port)
+            _wait_for_health(container, ping_ip, port, startup_timeout)
         except ContainerError as ex:
             if not _is_port_conflict(ex.stderr.decode("utf-8", errors="ignore")):
                 raise

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -43,11 +43,11 @@ from .docker_client import (
 from .exceptions import UserError
 from .serving import (
     DEFAULT_STARTUP_TIMEOUT,
-    _is_port_conflict,
-    _PortInUseError,
-    _retry_or_raise_port_conflict,
-    _wait_for_health,
+    PortInUseError,
     get_free_port,
+    is_port_conflict,
+    retry_or_raise_port_conflict,
+    wait_for_health_or_dispose,
 )
 
 if TYPE_CHECKING:
@@ -1131,7 +1131,7 @@ def serve(
         try:
             # In port-mapping mode a host-port collision fails here, when the
             # daemon tries to publish the port. In host-network mode it instead
-            # surfaces from _wait_for_health (uvicorn's own bind fails).
+            # surfaces from wait_for_health_or_dispose (uvicorn's own bind fails).
             container = docker_client.containers.run(
                 image=image_name,
                 command=["serve", *args],
@@ -1152,16 +1152,16 @@ def serve(
                 break
 
             logger.info("Waiting for Tesseract to start...")
-            _wait_for_health(container, ping_ip, port, startup_timeout)
+            wait_for_health_or_dispose(container, ping_ip, port, startup_timeout)
         except ContainerError as ex:
-            if not _is_port_conflict(ex.stderr.decode("utf-8", errors="ignore")):
+            if not is_port_conflict(ex.stderr.decode("utf-8", errors="ignore")):
                 raise
             # Publish failed; no container was created, nothing to clean up.
-            _retry_or_raise_port_conflict(port, auto_port, attempt, max_attempts)
+            retry_or_raise_port_conflict(port, auto_port, attempt, max_attempts)
             continue
-        except _PortInUseError:
+        except PortInUseError:
             container.remove(force=True)
-            _retry_or_raise_port_conflict(port, auto_port, attempt, max_attempts)
+            retry_or_raise_port_conflict(port, auto_port, attempt, max_attempts)
             continue
         break
 

--- a/tesseract_core/sdk/serving.py
+++ b/tesseract_core/sdk/serving.py
@@ -21,6 +21,9 @@ from .docker_client import APIError, Container, is_running
 
 logger = logging.getLogger("tesseract")
 
+# How long to wait for a freshly started Tesseract to answer /health.
+DEFAULT_STARTUP_TIMEOUT = 30.0
+
 
 class _PortInUseError(RuntimeError):
     """Container failed to start because its port was already bound.
@@ -95,7 +98,10 @@ def _retry_or_raise_port_conflict(
 
 
 def _wait_for_health(
-    container: Container, ping_ip: str, port: str, timeout: float = 30
+    container: Container,
+    ping_ip: str,
+    port: str,
+    timeout: float = DEFAULT_STARTUP_TIMEOUT,
 ) -> None:
     """Poll a container's /health endpoint until it responds 200 or timeout expires."""
     while True:

--- a/tesseract_core/sdk/serving.py
+++ b/tesseract_core/sdk/serving.py
@@ -11,13 +11,14 @@ knows how to run one.
 import logging
 import random
 import socket
+import subprocess
 import time
 from collections.abc import Sequence
 from contextlib import closing
 
 import requests
 
-from .docker_client import APIError, Container, is_running
+from .docker_client import APIError, Container, diagnose_exit, is_running
 
 logger = logging.getLogger("tesseract")
 
@@ -25,7 +26,7 @@ logger = logging.getLogger("tesseract")
 DEFAULT_STARTUP_TIMEOUT = 30.0
 
 
-class _PortInUseError(RuntimeError):
+class PortInUseError(RuntimeError):
     """Container failed to start because its port was already bound.
 
     Signals that a fresh port should be picked and startup retried. Only raised
@@ -36,12 +37,12 @@ class _PortInUseError(RuntimeError):
       ``containers.run`` raises ``ContainerError`` ("port is already allocated").
     - host networking: the container binds the host port directly, so the
       failure appears in the container logs as uvicorn's "address already in
-      use" and is detected in ``_wait_for_health``.
+      use" and is detected in ``wait_for_health_or_dispose``.
     """
 
 
 # Substrings container runtimes use to report a host port already being taken.
-_PORT_CONFLICT_MARKERS = ("address already in use", "port is already allocated")
+PORT_CONFLICT_MARKERS = ("address already in use", "port is already allocated")
 
 
 def get_free_port(
@@ -71,13 +72,13 @@ def get_free_port(
     raise RuntimeError(f"No free ports found in range {start}-{end}")
 
 
-def _is_port_conflict(stderr: str) -> bool:
+def is_port_conflict(stderr: str) -> bool:
     """Whether runtime stderr/logs indicate a host port collision."""
     lowered = stderr.lower()
-    return any(marker in lowered for marker in _PORT_CONFLICT_MARKERS)
+    return any(marker in lowered for marker in PORT_CONFLICT_MARKERS)
 
 
-def _retry_or_raise_port_conflict(
+def retry_or_raise_port_conflict(
     port: str, auto_port: bool, attempt: int, max_attempts: int
 ) -> None:
     """Decide whether a port collision should be retried.
@@ -89,7 +90,7 @@ def _retry_or_raise_port_conflict(
     """
     if not auto_port:
         # User asked for this exact port; surface the collision as-is.
-        raise _PortInUseError(f"Port {port} was already in use")
+        raise PortInUseError(f"Port {port} was already in use")
     if attempt + 1 >= max_attempts:
         raise RuntimeError(
             f"Failed to find a free port after {max_attempts} attempts"
@@ -97,48 +98,105 @@ def _retry_or_raise_port_conflict(
     logger.info(f"Port {port} was taken, retrying with a new port...")
 
 
-def _wait_for_health(
+# How long to give a single /health request before assuming it will not answer.
+# A published port whose target is unreachable is accepted by the proxy and then
+# dropped, so without this a poll can block indefinitely.
+_HEALTH_REQUEST_TIMEOUT = 5.0
+_HEALTH_POLL_INTERVAL = 0.1
+
+
+def wait_for_health_or_dispose(
     container: Container,
     ping_ip: str,
     port: str,
     timeout: float = DEFAULT_STARTUP_TIMEOUT,
 ) -> None:
-    """Poll a container's /health endpoint until it responds 200 or timeout expires."""
+    """Wait for a container to serve /health, and dispose of it if it never does.
+
+    Takes ``ping_ip`` rather than asking the container: one that published its
+    port on every interface is not reached at the address it reports binding to.
+
+    Raises:
+        PortInUseError: if it failed because its port was taken, which the caller
+            may want to retry on a fresh one.
+        TimeoutError: if it never answered in time.
+        RuntimeError: if it stopped running before it could.
+    """
+    deadline = time.monotonic() + timeout
+    timed_out = False
+
     while True:
         try:
-            response = requests.get(f"http://{ping_ip}:{port}/health")
-        except requests.exceptions.ConnectionError:
+            response = requests.get(
+                f"http://{ping_ip}:{port}/health", timeout=_HEALTH_REQUEST_TIMEOUT
+            )
+        except requests.exceptions.RequestException:
             pass
         else:
             if response.status_code == 200:
                 return
 
-        time.sleep(0.1)
-        timeout -= 0.1
+        # /health did not answer, so we check for dead containers first, timeouts second
+        if not is_running(container):
+            break
+        if time.monotonic() > deadline:
+            timed_out = True
+            break
 
-        if timeout < 0 or not is_running(container):
-            logs_text = ""
-            try:
-                logs_text = container.logs(stdout=True, stderr=True).decode()
-                logger.error(
-                    f"Tesseract container {container.name} failed to start:\n{logs_text}"
-                )
-            except APIError as ex:
-                logger.warning(
-                    f"Failed to get logs for container {container.name}: {ex}"
-                )
-            try:
-                container.stop()
-            except APIError as ex:
-                logger.warning(f"Failed to stop container {container.name}: {ex}")
+        time.sleep(_HEALTH_POLL_INTERVAL)
 
-            # A port collision is racy and worth retrying with a fresh port;
-            # distinguish it from genuine startup failures so those still fail
-            # fast.
-            if _is_port_conflict(logs_text):
-                raise _PortInUseError(f"Port {port} was already in use")
+    # Read the logs before disposing of what wrote them. Neither reading nor
+    # disposing may raise: they are how we report the failure, not the failure
+    # itself, and an error here would replace it with a less useful one.
+    try:
+        logs = container.logs(stdout=True, stderr=True).decode(errors="replace")
+    except APIError as ex:
+        logger.warning(f"Failed to get logs for {container}: {ex}")
+        logs = ""
 
-            if timeout < 0:
-                raise TimeoutError("Tesseract did not start in time")
-            else:
-                raise RuntimeError("Tesseract failed to start")
+    # Only worth asking about one that stopped, and only before it is removed: a
+    # container that is merely slow would block `wait` for as long as it runs.
+    exit_code = None
+    if not timed_out:
+        try:
+            exit_code = container.wait(timeout=_HEALTH_REQUEST_TIMEOUT)["StatusCode"]
+        except APIError as ex:
+            logger.warning(f"Failed to read the exit code of {container}: {ex}")
+
+    # Everything the container knew has now been read, so it can go -- in a
+    # `finally`, because every path out of here raises and none of them should
+    # leave it behind. The port-collision one especially: it is retried, so a
+    # container per attempt would pile up.
+    try:
+        # A port collision is racy and worth retrying with a fresh port;
+        # distinguish it from genuine startup failures so those still fail fast.
+        if is_port_conflict(logs):
+            raise PortInUseError(f"Port {port} was already in use")
+
+        if timed_out:
+            headline = f"{container} did not respond to a health check in time."
+            diagnosis = (
+                "If it is simply slow to initialize (e.g. loading a large model), "
+                "increase `startup_timeout`."
+            )
+        else:
+            exited = "" if exit_code is None else f" (exit code {exit_code})"
+            headline = f"{container} stopped running during startup{exited}."
+            diagnosis = diagnose_exit(container, logs)
+        output = (
+            f"Output from the Tesseract:\n{logs.strip()}"
+            if logs.strip()
+            else "The Tesseract produced no output."
+        )
+        paragraphs = [headline, diagnosis, output]
+        message = "\n\n".join(p for p in paragraphs if p)
+        raise TimeoutError(message) if timed_out else RuntimeError(message)
+    finally:
+        try:
+            # Forced: it may still be running, and an unforced remove would refuse.
+            container.remove(force=True)
+        except (APIError, subprocess.CalledProcessError) as ex:
+            # `Container.remove` raises `APIError` only when it recognises the
+            # stderr as Docker's, and passes the raw error through otherwise;
+            # either way it must not replace the failure we are reporting.
+            logger.warning(f"Failed to remove {container}: {ex}")

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -160,6 +160,7 @@ class Tesseract:
         runtime_config: dict[str, Any] | None = None,
         stream_logs: BoolOrCallable = False,
         skip_health_check: bool = False,
+        startup_timeout: float = engine.DEFAULT_STARTUP_TIMEOUT,
         timeout: float | tuple[float, float] | None = None,
         experimental_binref_pool: bool = False,
     ) -> Tesseract:
@@ -205,6 +206,9 @@ class Tesseract:
                 model loading). The caller is responsible for ensuring
                 readiness, e.g. by calling :meth:`health`, before calling
                 other endpoints.
+            startup_timeout: How long to wait, in seconds, for the Tesseract to
+                answer a health check. Raise it for one that is slow to
+                initialize, in preference to skipping the check altogether.
             timeout: Request timeout in seconds for HTTP calls to the Tesseract.
                 Can be a float for both connect and read timeouts, or a
                 ``(connect, read)`` tuple for separate control. ``None`` (the default)
@@ -274,6 +278,7 @@ class Tesseract:
             debug=True,
             docker_args=docker_args,
             skip_health_check=skip_health_check,
+            startup_timeout=startup_timeout,
         )
         return obj
 

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -10,17 +10,18 @@ from contextlib import closing
 from pathlib import Path
 
 import pytest
+import requests
 import yaml
 from jinja2.exceptions import TemplateNotFound
 
-from tesseract_core.sdk import engine, serving
+from tesseract_core.sdk import docker_client, engine, serving
 from tesseract_core.sdk.api_parse import (
     TesseractBuildConfig,
     TesseractConfig,
     validate_tesseract_api,
 )
 from tesseract_core.sdk.cli import AVAILABLE_RECIPES
-from tesseract_core.sdk.docker_client import Container, Image, NotFound
+from tesseract_core.sdk.docker_client import APIError, Container, Image, NotFound
 from tesseract_core.sdk.exceptions import UserError
 
 
@@ -1190,13 +1191,13 @@ def test_serve_retries_on_port_in_use(mocked_docker, monkeypatch):
     seen_ports = []
     fail_times = 2  # fail the first two attempts, succeed on the third
 
-    def flaky_health(container, ping_ip, port, timeout=30):
+    def flaky_health(container, ping_ip, port, timeout):
         seen_ports.append(port)
         if len(seen_ports) <= fail_times:
-            raise engine._PortInUseError(f"Port {port} was already in use")
+            raise engine.PortInUseError(f"Port {port} was already in use")
         # success -> return normally
 
-    monkeypatch.setattr(engine, "_wait_for_health", flaky_health)
+    monkeypatch.setattr(engine, "wait_for_health_or_dispose", flaky_health)
 
     res, _ = engine.serve("foobar")
     assert res
@@ -1253,13 +1254,142 @@ def test_serve_reraises_non_port_container_error(mocked_docker, monkeypatch):
         engine.serve("foobar")
 
 
+# `docker inspect` state, as recorded for a container that has stopped. Verified
+# against Docker: an OOM kill reports both the flag and code 137.
+_OOM_KILLED = {"Running": False, "OOMKilled": True, "ExitCode": 137, "Error": ""}
+_EXITED = {"Running": False, "OOMKilled": False, "ExitCode": 1, "Error": ""}
+_DAEMON_ERROR = {
+    "Running": False,
+    "OOMKilled": False,
+    "ExitCode": 127,
+    "Error": 'exec: "tesseract-runtime": not found',
+}
+
+
+@pytest.mark.parametrize(
+    "state,expected",
+    [
+        (_OOM_KILLED, "exceeding its memory limit"),
+        (_DAEMON_ERROR, 'Docker reported: exec: "tesseract-runtime": not found'),
+        (_EXITED, ""),
+    ],
+)
+def test_container_diagnoses_its_own_exit(state, expected):
+    """A stopped container can say things its logs cannot -- an OOM kill writes nothing."""
+    container = Container(
+        id="abc123", short_id="abc123", name="vectoradd", attrs={"State": state}
+    )
+    assert expected in docker_client.diagnose_exit(container, logs="")
+
+
+def _stopped_container(logs=b"", state=None, **overrides):
+    """A Container wired up to answer without a daemon behind it.
+
+    `is_running` is a module function now, so callers patch `serving.is_running`
+    rather than the container.
+    """
+    container = Container(
+        id="abc123",
+        short_id="abc123",
+        name="vectoradd",
+        attrs={"State": state if state is not None else dict(_EXITED)},
+    )
+    container.wait = lambda timeout=None: {"StatusCode": 1}
+    container.logs = lambda **kwargs: logs
+    container.remove = lambda **kwargs: None
+    for name, value in overrides.items():
+        setattr(container, name, value)
+    return container
+
+
+# Nothing listens on port 1, so /health fails immediately and the wait gives up
+# on the first pass rather than sleeping.
+_DEAD = ("127.0.0.1", "1")
+
+
+def test_wait_for_health_reports_a_container_that_never_answers(monkeypatch):
+    """A container still running when time runs out is a timeout, not a crash."""
+    monkeypatch.setattr(serving, "is_running", lambda container: True)
+    container = _stopped_container()
+
+    with pytest.raises(TimeoutError) as excinfo:
+        serving.wait_for_health_or_dispose(container, *_DEAD, timeout=0.05)
+
+    message = str(excinfo.value)
+    assert "did not respond to a health check in time" in message
+    assert "increase `startup_timeout`" in message
+
+
+def test_wait_for_health_singles_out_a_port_collision(monkeypatch):
+    """A collision is racy and retriable, so it must not look like a crash."""
+    monkeypatch.setattr(serving, "is_running", lambda container: False)
+    container = _stopped_container(logs=b"Error: address already in use")
+
+    with pytest.raises(engine.PortInUseError):
+        serving.wait_for_health_or_dispose(container, *_DEAD, timeout=0.05)
+
+
+def test_unreadable_logs_do_not_mask_the_startup_failure(monkeypatch):
+    """Failing to read the logs is not the failure we are trying to report."""
+
+    def cannot_read(**kwargs):
+        raise APIError("daemon went away")
+
+    monkeypatch.setattr(serving, "is_running", lambda container: False)
+    container = _stopped_container()
+    container.logs = cannot_read
+
+    with pytest.raises(RuntimeError) as excinfo:
+        serving.wait_for_health_or_dispose(container, *_DEAD, timeout=0.05)
+
+    assert "stopped running during startup" in str(excinfo.value)
+
+
+def test_failure_to_dispose_does_not_mask_the_startup_failure(monkeypatch):
+    """Nor is failing to remove the container."""
+
+    def cannot_remove(**kwargs):
+        raise APIError("daemon went away")
+
+    monkeypatch.setattr(serving, "is_running", lambda container: False)
+    container = _stopped_container(remove=cannot_remove)
+
+    with pytest.raises(RuntimeError, match="stopped running during startup"):
+        serving.wait_for_health_or_dispose(container, *_DEAD, timeout=0.05)
+
+
+def test_serve_disposes_of_a_container_that_never_starts(mocked_docker, monkeypatch):
+    """A container that fails to become healthy is removed, not left lying around.
+
+    Everything it knew goes into the error before it goes, and the port-conflict
+    retry path would otherwise leave one behind per attempt.
+    """
+    torn_down = []
+
+    def unreachable(*args, **kwargs):
+        raise requests.exceptions.ConnectionError("nothing listening")
+
+    # The fixture answers /health with a 200; this container never will, and is
+    # not running, so waiting gives up on it immediately.
+    monkeypatch.setattr(serving.requests, "get", unreachable)
+    monkeypatch.setattr(serving, "is_running", lambda container: False)
+    # The fixture's container overrides `remove`, so patch the class it actually is
+    mocked_cls = type(mocked_docker.containers.run(detach=True))
+    monkeypatch.setattr(mocked_cls, "remove", lambda self, **kw: torn_down.append(kw))
+
+    with pytest.raises(RuntimeError, match="stopped running during startup"):
+        engine.serve("foobar")
+
+    assert torn_down == [{"force": True}]
+
+
 def test_serve_gives_up_after_max_port_attempts(mocked_docker, monkeypatch):
     """If every attempt loses the port race, serve raises rather than looping forever."""
 
-    def always_in_use(container, ping_ip, port, timeout=30):
-        raise engine._PortInUseError(f"Port {port} was already in use")
+    def always_in_use(container, ping_ip, port, timeout):
+        raise engine.PortInUseError(f"Port {port} was already in use")
 
-    monkeypatch.setattr(engine, "_wait_for_health", always_in_use)
+    monkeypatch.setattr(engine, "wait_for_health_or_dispose", always_in_use)
 
     with pytest.raises(RuntimeError, match="Failed to find a free port"):
         engine.serve("foobar")
@@ -1273,13 +1403,13 @@ def test_serve_does_not_retry_user_supplied_port(mocked_docker, monkeypatch):
     """
     attempts = []
 
-    def always_in_use(container, ping_ip, port, timeout=30):
+    def always_in_use(container, ping_ip, port, timeout):
         attempts.append(port)
-        raise engine._PortInUseError(f"Port {port} was already in use")
+        raise engine.PortInUseError(f"Port {port} was already in use")
 
-    monkeypatch.setattr(engine, "_wait_for_health", always_in_use)
+    monkeypatch.setattr(engine, "wait_for_health_or_dispose", always_in_use)
 
-    with pytest.raises(engine._PortInUseError):
+    with pytest.raises(engine.PortInUseError):
         engine.serve("foobar", port="12345")
 
     # Exactly one attempt, on the exact port requested.
@@ -1519,7 +1649,7 @@ def _stub_serve_docker(monkeypatch):
         return Container(id="cid", short_id="cid", name="test-container", attrs={})
 
     monkeypatch.setattr(engine.docker_client.containers, "run", fake_run)
-    monkeypatch.setattr(engine, "_wait_for_health", lambda *a, **k: None)
+    monkeypatch.setattr(engine, "wait_for_health_or_dispose", lambda *a, **k: None)
     monkeypatch.setattr(engine, "is_podman", lambda: False)
     return captured
 

--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -9,6 +9,7 @@ import requests
 from pydantic import ValidationError
 
 from tesseract_core import Tesseract
+from tesseract_core.sdk import engine
 from tesseract_core.sdk.docker_client import Container
 from tesseract_core.sdk.tesseract import (
     HTTPClient,
@@ -229,6 +230,7 @@ def test_serve_lifecycle(mock_serving, mock_clients):
         "docker_args": None,
         "runtime_config": None,
         "skip_health_check": False,
+        "startup_timeout": engine.DEFAULT_STARTUP_TIMEOUT,
     }
 
     for key, expected_value in expected_kwargs.items():


### PR DESCRIPTION
I had introduced similar checks and guards in #669 and the lack of consistency increased the diff unecessarily, it turns out we can offer something similar for containers.Stacked on #693.

### Changes made

### `startup_timeout`

Waiting for a container to answer `/health` was fixed at 30 seconds, so a Tesseract slow to initialize — one loading a large model, or starting a Julia runtime — could only be served by skipping the health check altogether and taking on the job of establishing readiness. `serve` and `from_image` now take a `startup_timeout`, defaulting to 30s.

### Failed containers are disposed of, and inspected to diagnose failure

A container that failed to become healthy was stopped but not removed, leaving one behind per attempt at a port that turned out to be taken — and `Containers.list` does not report stopped containers, so `tesseract teardown --all` would not collect them either (we could decide to fix that if you prefer).

Removing it means `docker logs` is no longer available afterwards, so the error now carries everything the container knew: which container, whether it ran out of time or stopped, the code it stopped with, and its output.

`Container` reports that and the daemon's own error for an image that cannot exec, since a serving primitive has no business parsing Docker's JSON.

Also fixed: a single health request had no timeout, so a published port whose target is unreachable — accepted by the proxy, then dropped — could block the poll indefinitely.

### Testing done

Added some unit tests