### PR TITLE
feat: Make json+binref usable from from_source, and measure it

### DIFF
--- a/benchmarks/test_tesseract.py
+++ b/benchmarks/test_tesseract.py
@@ -16,6 +16,12 @@ measurements of framework overhead for different interaction modes:
    experimental_binref_pool=True for warm-buffer writes and zero-copy mmap decode
 4. Containerized via CLI (`tesseract run`) - Full Docker + CLI overhead,
    using json+binref encoding with the binref directory on local disk
+5. In a dedicated subprocess via HTTP (`Tesseract.from_source`) - no container,
+   using json+base64 encoding
+6. The same, using json+binref with the scratch directories created for us (so
+   on ordinary disk), which is what you get by asking for the encoding alone
+7. The same, with the binref directory on /dev/shm and experimental_binref_pool
+   enabled - the fastest configuration available without a container
 
 All benchmarks use the same no-op Tesseract defined in tesseract_noop/.
 """
@@ -105,6 +111,61 @@ def http_shmem_tesseract_instance(noop_tesseract_image):
         yield tesseract, output_dir
 
 
+@pytest.fixture(scope="module")
+def subprocess_tesseract_instance(tmp_path_factory):
+    """Create a dedicated-process Tesseract, json+base64, reused across the module."""
+    from tesseract_core.sdk.tesseract import Tesseract
+
+    tmpdir = tmp_path_factory.mktemp("tesseract_subprocess")
+    with Tesseract.from_source(NOOP_TESSERACT_PATH, output_path=tmpdir) as tesseract:
+        tesseract.health()  # warm up: the first request pays for process startup
+        yield tesseract
+
+
+@pytest.fixture(scope="module")
+def subprocess_binref_tesseract_instance():
+    """Create a dedicated-process Tesseract using json+binref and nothing else.
+
+    Deliberately passes no directories: `from_source` creates them, and this is
+    what a user gets from asking for the encoding alone. They land in the
+    ordinary temp directory, so this measures binref without shared memory.
+    """
+    from tesseract_core.sdk.tesseract import Tesseract
+
+    with Tesseract.from_source(
+        NOOP_TESSERACT_PATH, output_format="json+binref"
+    ) as tesseract:
+        tesseract.health()
+        yield tesseract, Path(tesseract._spawn_config["output_path"])
+
+
+@pytest.fixture(scope="module")
+def subprocess_shmem_tesseract_instance():
+    """Create a dedicated-process Tesseract exchanging arrays via shared memory.
+
+    The counterpart to ``http_shmem_tesseract_instance`` with no container in the
+    way: two processes on one host share a page cache directly, so the write pool
+    needs no bind mount to be worth enabling.
+    """
+    from tesseract_core.sdk.tesseract import Tesseract
+
+    shm_dir = Path("/dev/shm")
+    if not shm_dir.is_dir():
+        pytest.skip("/dev/shm is not available on this platform")
+
+    input_dir = Path(tempfile.mkdtemp(prefix="tess_proc_in_", dir=shm_dir))
+    output_dir = Path(tempfile.mkdtemp(prefix="tess_proc_out_", dir=shm_dir))
+    with Tesseract.from_source(
+        NOOP_TESSERACT_PATH,
+        input_path=input_dir,
+        output_path=output_dir,
+        output_format="json+binref",
+        experimental_binref_pool=True,
+    ) as tesseract:
+        tesseract.health()
+        yield tesseract, output_dir
+
+
 def test_from_tesseract_api(benchmark, tesseract_api_instance, array_size):
     """Benchmark non-containerized Tesseract via from_tesseract_api()."""
     arr = create_test_array(array_size)
@@ -145,6 +206,62 @@ def test_containerized_http_shmem(benchmark, http_shmem_tesseract_instance, arra
     fast path.
     """
     tesseract, output_dir = http_shmem_tesseract_instance
+    arr = create_test_array(array_size)
+    inputs = {"data": arr}
+
+    benchmark.pedantic(
+        tesseract.apply,
+        args=(inputs,),
+        teardown=lambda *_: _purge_binref_outputs(output_dir),
+        rounds=100,
+        warmup_rounds=1,
+        iterations=1,
+    )
+
+
+def test_subprocess_http(benchmark, subprocess_tesseract_instance, array_size):
+    """Benchmark a dedicated-process Tesseract over HTTP, json+base64 encoding.
+
+    The same HTTP stack as ``test_containerized_http`` without Docker, so the
+    difference between the two is what containerization costs.
+    """
+    arr = create_test_array(array_size)
+    inputs = {"data": arr}
+
+    benchmark(subprocess_tesseract_instance.apply, inputs)
+
+
+def test_subprocess_http_binref(
+    benchmark, subprocess_binref_tesseract_instance, array_size
+):
+    """Benchmark a dedicated-process Tesseract using json+binref, no shared memory.
+
+    Asking for the encoding and nothing else, which is the configuration a user
+    is most likely to reach for. The scratch directories are on ordinary disk.
+    """
+    tesseract, output_dir = subprocess_binref_tesseract_instance
+    arr = create_test_array(array_size)
+    inputs = {"data": arr}
+
+    benchmark.pedantic(
+        tesseract.apply,
+        args=(inputs,),
+        teardown=lambda *_: _purge_binref_outputs(output_dir),
+        rounds=100,
+        warmup_rounds=1,
+        iterations=1,
+    )
+
+
+def test_subprocess_http_shmem(
+    benchmark, subprocess_shmem_tesseract_instance, array_size
+):
+    """Benchmark a dedicated-process Tesseract exchanging arrays via /dev/shm.
+
+    The fastest configuration available without a container: no array data over
+    HTTP, no data on disk, and warm pooled buffers with zero-copy decode.
+    """
+    tesseract, output_dir = subprocess_shmem_tesseract_instance
     arr = create_test_array(array_size)
     inputs = {"data": arr}
 

--- a/docs/content/how-to/debugging.md
+++ b/docs/content/how-to/debugging.md
@@ -56,6 +56,57 @@ This approach is particularly useful for:
 - Running unit tests against your Tesseract
 - Debugging with Python debuggers like `pdb` or IDE debuggers
 
+### Running in a dedicated process
+
+`from_tesseract_api()` imports your Tesseract API into the current process, so it
+shares an interpreter and all global state with your own code. Use
+`from_source()` instead to run it in a dedicated subprocess, reached over HTTP:
+
+```python
+with Tesseract.from_source("/path/to/your/tesseract_api.py") as tess:
+    result = tess.apply(inputs={"a": np.array([1.0, 2.0]), "b": np.array([3.0, 4.0])})
+```
+
+Unlike `from_tesseract_api()`, this must be used as a context manager (or served
+explicitly with `tess.serve()` and stopped with `tess.teardown()`), since there
+is a process to clean up.
+
+Use it when sharing an interpreter is the problem — for instance when the caller
+is itself a JAX program, since nesting JAX inside JAX is not safe and can
+deadlock.
+
+Since the Tesseract is no longer in your process, your own debugger cannot step
+into it. A debugger is therefore started alongside it, listening on a free
+loopback port that is logged on startup:
+
+```
+Debug mode enabled. Attach a debugger to 127.0.0.1:54321
+```
+
+Each Tesseract gets its own port, so several can be debugged at once. Attach to
+it as described under "Debug mode" below. If you are using dedicated processes
+for isolation rather than for debugging, pass `runtime_config={"debug": False}`
+to turn debug mode off altogether — as everywhere else, debug mode is what
+starts a debugger. That also drops the full tracebacks and the `test` endpoint,
+which is what you want outside development in any case.
+
+By default the Tesseract runs on the same interpreter as the caller. Point
+`python_executable` at another environment to give it dependencies that conflict
+with yours:
+
+```python
+tess = Tesseract.from_source(
+    "/path/to/your/tesseract_api.py",
+    python_executable="/path/to/venv/bin/python",
+)
+```
+
+That environment needs `tesseract-core[runtime]` and the Tesseract's own
+requirements installed; a virtual environment created with
+`uv venv` and populated from the Tesseract's `tesseract_requirements.txt` works.
+Note that this isolates Python dependencies only — for system-level packages and
+everything else a container provides, build an image instead.
+
 ## Debug mode
 
 `tesseract serve` supports a `--debug` flag; this has two effects:

--- a/docs/content/how-to/fast-local-runs.md
+++ b/docs/content/how-to/fast-local-runs.md
@@ -19,12 +19,15 @@ HTTP. Because `/dev/shm` is a `tmpfs` shared between the host and the container,
 the array data never leaves memory and is never copied through the socket.
 
 ```{note}
-This is a Linux optimization. It relies on `/dev/shm` (a shared-memory `tmpfs`)
-being available and bind-mounted into the container. This is only possible when the
-client and the Tesseract share a host; for remote Tesseracts, array data has to
-cross the network regardless, so a compact wire encoding is what matters instead
-(see {doc}`/content/reference/array-encodings`).
+This only helps when the client and the Tesseract share a host. For remote
+Tesseracts, array data has to cross the network regardless, so a compact wire
+encoding is what matters instead (see
+{doc}`/content/reference/array-encodings`).
 ```
+
+A containerized Tesseract needs `/dev/shm` bind-mounted into it, which means a
+Linux host. A Tesseract served in a dedicated process needs nothing of the sort
+-- see [Without a container](#without-a-container) below.
 
 ## Basic usage
 
@@ -110,8 +113,61 @@ Two things to keep in mind when opting in:
 - **The pool holds some resident memory** until the Tesseract is torn down, and
   each result you keep pins its backing pages until it is dropped.
 
-The pool is Linux-only (it raises on other platforms) and has no effect for
-output formats other than `json+binref`.
+The pool needs the binref directory to be **memory-backed**. That is what makes
+its memory-mapped writes free; on an ordinary disk-backed directory the mapping
+machinery costs more than it saves, and the pool is measurably _slower_ than
+plain `json+binref`. It has no effect for output formats other than
+`json+binref`.
+
+For a containerized Tesseract the pool additionally requires a Linux host, and
+raises elsewhere: on macOS and Windows the container runs inside a Linux VM, so
+bind mounts cross the VM boundary and the client and the container never share a
+page cache. A Tesseract served in a dedicated process has no VM to cross, so the
+pool is available on any platform.
+
+## Without a container
+
+`Tesseract.from_source()` serves a `tesseract_api.py` in a dedicated subprocess
+rather than a container (see {doc}`/content/how-to/debugging`). Client and server
+are then two ordinary processes on one host, which removes both of the
+constraints above -- and you do not have to name any directories, because
+scratch directories are created and cleaned up for you:
+
+```python
+with Tesseract.from_source(
+    "/path/to/tesseract_api.py", output_format="json+binref"
+) as t:
+    result = t.apply({"x": x})
+```
+
+This is enough to get most of the benefit. Measured on an Apple silicon laptop,
+a 40 MB `float64` round trip takes ~26 ms this way against ~168 ms for the
+default `json+base64`.
+
+Note that a directory in `/tmp` is not memory-backed, even though it performs as
+if it were: writeback happens asynchronously and the reader is served from the
+page cache, so the call never waits for the disk. The bytes do reach the disk
+eventually. In one measurement, moving 720 MB of arrays produced 687 MB of
+device writes. If that matters -- for SSD wear, or to enable the pool -- put the
+scratch directories on a memory-backed filesystem and pass them explicitly.
+
+On Linux that is `/dev/shm`, as above. macOS has no `/dev/shm`, but it does have
+a `tmpfs`:
+
+```bash
+mkdir -p /tmp/tess-shm
+sudo mount_tmpfs -s 1g /tmp/tess-shm   # a cap, not a reservation
+```
+
+```{warning}
+Do not use `hdiutil attach ram://` for this. That allocates **wired** memory,
+which the memory compressor cannot reclaim, and a large one can wedge the
+machine. A `tmpfs` mounted with `-s` is a ceiling on pages that are allocated on
+demand and stay reclaimable.
+```
+
+With the scratch directories on that mount and the pool enabled, the same 40 MB
+round trip takes ~20 ms.
 
 ## When this helps
 
@@ -137,6 +193,11 @@ overhead again.
 If your arrays are small, or your Tesseract runs remotely, stay with the default
 `json+base64`. Reach for shared-memory binref when you are passing large arrays
 to a Tesseract on the same machine and per-call overhead is limiting you.
+
+The crossover is low: 64 kB is 8192 `float64` elements, so anything much larger
+than a short vector is already on the binref side of it. Below the crossover the
+penalty is a fixed fraction of a millisecond -- the cost of handling a file per
+call -- which is the same order as the HTTP round trip you are paying anyway.
 
 For the broader picture of where overhead comes from and how to reason about it,
 see {doc}`/content/concepts/performance`. For encoding-format details, see

--- a/examples/_multi-tesseract/multi-helloworld/run_example.py
+++ b/examples/_multi-tesseract/multi-helloworld/run_example.py
@@ -8,7 +8,7 @@ with Tesseract.from_image(
     ) as helloworld_tess:
         payload = {
             "name": "YOU",
-            "helloworld_tesseract_url": f"http://helloworld:{helloworld_tess._serve_context['port']}",
+            "helloworld_tesseract_url": f"http://helloworld:{helloworld_tess.container_info().host_port}",
         }
         result = multi_helloworld_tess.apply(inputs=payload)
         print(result["greeting"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,9 @@ addopts = ["--typeguard-packages=tesseract_core", "--durations=10"]
 testpaths = ["tests"]
 markers = [
     "gpu: requires a physical CUDA GPU (plus CuPy) and is skipped on GPU-less CI runners",
+    # Builds a throwaway virtualenv with uv; needs network on a cold uv cache.
+    # Deselect with: -m "not foreign_venv"
+    "foreign_venv: test that runs a Tesseract in a separate Python environment",
 ]
 filterwarnings = [
     "error",

--- a/tesseract_core/runtime/__init__.py
+++ b/tesseract_core/runtime/__init__.py
@@ -14,6 +14,10 @@ try:
         if path.stem.startswith("app_"):
             # Instantiated versions of apps for testing and CLI that have side effects at import time.
             continue
+        if path.stem == "__main__":
+            # Importing this as a side effect of importing the package makes
+            # `python -m tesseract_core.runtime` warn about a double import.
+            continue
         if path.stem in ("jax_recipes",):
             # Recipes typically have optional dependencies that we don't want to require
             # for the core runtime.

--- a/tesseract_core/runtime/__main__.py
+++ b/tesseract_core/runtime/__main__.py
@@ -1,0 +1,12 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Entrypoint for ``python -m tesseract_core.runtime``.
+
+Equivalent to the ``tesseract-runtime`` console script, but reachable via an
+interpreter path alone, without knowing where its scripts directory is.
+"""
+
+from tesseract_core.runtime.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/tesseract_core/sdk/binref.py
+++ b/tesseract_core/sdk/binref.py
@@ -16,9 +16,9 @@ This module holds the client-side machinery for that path:
 - :func:`read_binref_array` / :func:`mmap_binref_array` decode a binref buffer
   eagerly (portable) or as a zero-copy mmap view (POSIX only).
 
-The pool and the lazy mmap decode are gated on Linux via
-:data:`SUPPORTS_BINREF_POOL`; see the note there for why other platforms do not
-qualify.
+The pool and the lazy mmap decode are opt-in, and only pay off when the binref
+directory is memory-backed. A containerized Tesseract can additionally only meet
+the premise on Linux -- see :data:`CONTAINERS_SUPPORT_BINREF_POOL`.
 """
 
 from __future__ import annotations
@@ -208,14 +208,16 @@ def encode_array_binref_pooled(
 
 
 # The binref write pool is a fast same-machine IPC path: the client writes binref
-# inputs into a directory the server container reads directly, ideally a shared-
-# memory tmpfs (/dev/shm), and decodes outputs as zero-copy mmap views. That only
-# pays off when client and server share a page cache, i.e. a native Linux host
-# running Linux containers. On macOS (and Windows) the container runs inside a
-# Linux VM, so bind mounts cross the VM boundary and there is no host tmpfs the
-# container sees as the same memory -- the premise does not hold. So the pool
-# (and, with it, the lazy zero-copy decode) is offered on Linux only.
-SUPPORTS_BINREF_POOL = sys.platform.startswith("linux")
+# inputs into a directory the server reads directly, and decodes outputs as
+# zero-copy mmap views. It only pays off when the two share a page cache and the
+# directory is memory-backed; on a disk-backed filesystem the mmap machinery
+# costs more than it saves, so it is opt-in and never chosen for you.
+#
+# A *containerized* Tesseract can only meet that condition on a native Linux
+# host: elsewhere the container runs inside a Linux VM, so bind mounts cross the
+# VM boundary and there is no host tmpfs the container sees as the same memory.
+# A Tesseract served as a subprocess has no VM to cross and so is unrestricted.
+CONTAINERS_SUPPORT_BINREF_POOL = sys.platform.startswith("linux")
 
 
 def read_binref_array(

--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -21,6 +21,7 @@ from typing import Any, TypeAlias
 from typing import List as list_  # noqa: UP035
 
 from tesseract_core.sdk.config import get_config
+from tesseract_core.sdk.served_client import ServedTesseract
 
 logger = logging.getLogger("tesseract")
 
@@ -442,7 +443,7 @@ class Images:
 
 
 @dataclass
-class Container:
+class Container(ServedTesseract):
     """Container class to wrap Docker container details.
 
     Container class has additional member variables `host_port` and `host_ip` that

--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -573,6 +573,45 @@ class Container:
             )
         return result.returncode, result.stdout
 
+    def __repr__(self) -> str:
+        return f"Tesseract container {self.name}"
+
+    def exit_code(self) -> int | None:
+        """The code this container exited with, from the last state read of it."""
+        state = self.attrs.get("State", {})
+        if state.get("Running"):
+            return None
+        return state.get("ExitCode")
+
+    def diagnose_exit(self, logs: str) -> str:
+        """Report what `docker inspect` recorded and the logs cannot say.
+
+        Reads the recorded state rather than the container, which by now has been
+        disposed of: liveness is what noticed it had stopped, and reading it
+        refreshed that state, so what it holds is how it stopped.
+        """
+        del logs  # a container's own output is all the other evidence there is
+        state = self.attrs.get("State", {})
+        if state.get("OOMKilled"):
+            # Nothing else can report this: the process is killed outright, so it
+            # has no chance to say anything about it in its own logs.
+            return (
+                "It was killed for exceeding its memory limit, which is why it "
+                "may have written nothing. Give it a higher `memory` limit."
+            )
+        if state.get("Error"):
+            return f"Docker reported: {state['Error']}"
+        return ""
+
+    def teardown(self) -> None:
+        """Stop this container and remove it, leaving nothing behind.
+
+        Neither `stop` nor `remove` will do on its own: the first leaves a stopped
+        container in place, and the second refuses to touch a running one unless
+        forced. Named for what `tesseract teardown` already means.
+        """
+        self.remove(force=True)
+
     def stop(self) -> None:
         """Stop the container."""
         docker = _get_docker_executable()

--- a/tesseract_core/sdk/docker_client.py
+++ b/tesseract_core/sdk/docker_client.py
@@ -525,8 +525,31 @@ class Container:
 
     @property
     def status(self) -> str:
-        """Gets the status of the container."""
+        """Gets the status of the container, as of the last read.
+
+        Like docker-py, this reports what ``docker inspect`` said when this
+        object was built or last reloaded, so it goes stale once the container
+        stops. Call :meth:`reload` first, or use :meth:`is_running`, to ask about
+        the container now.
+        """
         return self.attrs.get("State", {}).get("Status", "unknown")
+
+    def reload(self) -> None:
+        """Read the container again, updating ``attrs`` with the new data.
+
+        A container that no longer exists leaves ``attrs`` untouched apart from
+        its state, which becomes "unknown" -- callers wait on containers that are
+        expected to disappear, so that must not raise.
+        """
+        try:
+            self.attrs = Containers.get(self.id, tesseract_only=False).attrs
+        except NotFound:
+            self.attrs = {**self.attrs, "State": {"Status": "unknown"}}
+
+    def is_running(self) -> bool:
+        """Whether the container is running now, reading it again to find out."""
+        self.reload()
+        return self.status == "running"
 
     def exec_run(self, command: list) -> tuple[int, bytes]:
         """Run a command in this container.

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -9,13 +9,9 @@ import linecache
 import logging
 import optparse
 import os
-import random
 import re
-import socket
 import tempfile
-import time
-from collections.abc import Callable, Collection, Sequence
-from contextlib import closing
+from collections.abc import Callable, Collection
 from importlib.metadata import requires
 from pathlib import Path
 from shutil import copy, copytree, rmtree
@@ -23,7 +19,6 @@ from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 from urllib.parse import urlparse
 from urllib.request import url2pathname
 
-import requests
 import yaml
 from jinja2 import Environment, PackageLoader, StrictUndefined
 from packaging.requirements import Requirement
@@ -42,6 +37,13 @@ from .docker_client import (
     is_podman,
 )
 from .exceptions import UserError
+from .serving import (
+    _is_port_conflict,
+    _PortInUseError,
+    _retry_or_raise_port_conflict,
+    _wait_for_health,
+    get_free_port,
+)
 
 if TYPE_CHECKING:
     from pip._internal.index.package_finder import PackageFinder
@@ -89,33 +91,6 @@ def needs_docker(func: Callable) -> Callable:
         return func(*args, **kwargs)
 
     return wrapper_needs_docker
-
-
-def get_free_port(
-    within_range: tuple[int, int] = (49152, 65535),
-    exclude: Sequence[int] = (),
-) -> int:
-    """Find a random free port to use for HTTP."""
-    start, end = within_range
-    if start < 0 or end > 65535 or start > end:
-        raise ValueError("Invalid port range, must be between 0 and 65535")
-
-    # Try random ports in the given range
-    portlist = list(range(start, end))
-    random.shuffle(portlist)
-    for port in portlist:
-        if port in exclude:
-            continue
-        # Check if the port is free
-        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
-            try:
-                s.bind(("127.0.0.1", port))
-            except OSError:
-                # Port is already in use
-                continue
-            else:
-                return port
-    raise RuntimeError(f"No free ports found in range {start}-{end}")
 
 
 def parse_requirements(
@@ -776,25 +751,6 @@ def _ensure_network_exists(network: str) -> None:
         docker_client.networks.create(network)
 
 
-class _PortInUseError(RuntimeError):
-    """Container failed to start because its port was already bound.
-
-    Signals that a fresh port should be picked and startup retried. Only raised
-    when we chose the port ourselves; a user-supplied port is never retried.
-
-    A port collision surfaces in one of two ways depending on network mode:
-    - port-mapping mode: the Docker daemon fails to publish the host port and
-      ``containers.run`` raises ``ContainerError`` ("port is already allocated").
-    - host networking: the container binds the host port directly, so the
-      failure appears in the container logs as uvicorn's "address already in
-      use" and is detected in ``_wait_for_health``.
-    """
-
-
-# Substrings container runtimes use to report a host port already being taken.
-_PORT_CONFLICT_MARKERS = ("address already in use", "port is already allocated")
-
-
 def _warn_if_debugger_unreachable(container: Container, expected_port: str) -> None:
     """Warn if the container did not bind the debug port we published a mapping to.
 
@@ -884,76 +840,6 @@ def _resolve_container_debug_address(
         host = requested_host or "0.0.0.0"
         updates.update({f"TESSERACT{p}_DEBUGPY_HOST": host for p in ("", "_RUNTIME")})
     return updates, port
-
-
-def _is_port_conflict(stderr: str) -> bool:
-    """Whether runtime stderr/logs indicate a host port collision."""
-    lowered = stderr.lower()
-    return any(marker in lowered for marker in _PORT_CONFLICT_MARKERS)
-
-
-def _retry_or_raise_port_conflict(
-    port: str, auto_port: bool, attempt: int, max_attempts: int
-) -> None:
-    """Decide whether a port collision should be retried.
-
-    Returns normally if the caller should retry with a fresh port; raises
-    otherwise. A user-supplied fixed port is never retried (we must not
-    silently move the Tesseract elsewhere), and auto-selected ports raise once
-    the attempt budget is exhausted.
-    """
-    if not auto_port:
-        # User asked for this exact port; surface the collision as-is.
-        raise _PortInUseError(f"Port {port} was already in use")
-    if attempt + 1 >= max_attempts:
-        raise RuntimeError(
-            f"Failed to find a free port after {max_attempts} attempts"
-        ) from None
-    logger.info(f"Port {port} was taken, retrying with a new port...")
-
-
-def _wait_for_health(
-    container: Container, ping_ip: str, port: str, timeout: float = 30
-) -> None:
-    """Poll a container's /health endpoint until it responds 200 or timeout expires."""
-    while True:
-        try:
-            response = requests.get(f"http://{ping_ip}:{port}/health")
-        except requests.exceptions.ConnectionError:
-            pass
-        else:
-            if response.status_code == 200:
-                return
-
-        time.sleep(0.1)
-        timeout -= 0.1
-
-        if timeout < 0 or not container.is_running():
-            logs_text = ""
-            try:
-                logs_text = container.logs(stdout=True, stderr=True).decode()
-                logger.error(
-                    f"Tesseract container {container.name} failed to start:\n{logs_text}"
-                )
-            except APIError as ex:
-                logger.warning(
-                    f"Failed to get logs for container {container.name}: {ex}"
-                )
-            try:
-                container.stop()
-            except APIError as ex:
-                logger.warning(f"Failed to stop container {container.name}: {ex}")
-
-            # A port collision is racy and worth retrying with a fresh port;
-            # distinguish it from genuine startup failures so those still fail
-            # fast.
-            if _is_port_conflict(logs_text):
-                raise _PortInUseError(f"Port {port} was already in use")
-
-            if timeout < 0:
-                raise TimeoutError("Tesseract did not start in time")
-            else:
-                raise RuntimeError("Tesseract failed to start")
 
 
 def serve(

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -928,9 +928,7 @@ def _wait_for_health(
         time.sleep(0.1)
         timeout -= 0.1
 
-        container_status = docker_client.containers.get(container.id).status
-
-        if timeout < 0 or container_status != "running":
+        if timeout < 0 or not container.is_running():
             logs_text = ""
             try:
                 logs_text = container.logs(stdout=True, stderr=True).decode()

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -44,6 +44,7 @@ from .serving import (
     _retry_or_raise_port_conflict,
     _wait_for_health,
     get_free_port,
+    runtime_config_env,
 )
 
 if TYPE_CHECKING:
@@ -932,15 +933,7 @@ def serve(
         environment = {}
     environment.update(volume_environment)
 
-    # Convert runtime_config to TESSERACT_* environment variables
-    if runtime_config is not None:
-        for key, value in runtime_config.items():
-            env_key = f"TESSERACT_{key.upper()}"
-            if isinstance(value, bool):
-                env_value = "1" if value else "0"
-            else:
-                env_value = str(value)
-            environment[env_key] = env_value
+    environment.update(runtime_config_env(runtime_config))
 
     if output_format:
         environment["TESSERACT_OUTPUT_FORMAT"] = output_format
@@ -1086,7 +1079,7 @@ def serve(
                 break
 
             logger.info("Waiting for Tesseract to start...")
-            _wait_for_health(container, ping_ip, port, startup_timeout)
+            _wait_for_health(container, f"http://{ping_ip}:{port}", startup_timeout)
         except ContainerError as ex:
             if not _is_port_conflict(ex.stderr.decode("utf-8", errors="ignore")):
                 raise
@@ -1423,16 +1416,3 @@ def _resolve_file_path(path: str | Path, make_dir: bool = False) -> Path:
         raise RuntimeError(f"Path {local_path} provided is not a directory")
 
     return local_path
-
-
-def logs(container_id: str) -> str:
-    """Get logs from a container.
-
-    Args:
-        container_id: the ID of the container.
-
-    Returns:
-        The logs of the container.
-    """
-    container = docker_client.containers.get(container_id)
-    return container.logs().decode("utf-8")

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -715,7 +715,7 @@ def teardown(
     }
 
     for container_id, container in containers.items():
-        container.remove(force=True)
+        container.teardown()
         logger.info(f"Tesseract is shutdown for Docker container ID: {container_id}")
 
 

--- a/tesseract_core/sdk/engine.py
+++ b/tesseract_core/sdk/engine.py
@@ -38,6 +38,7 @@ from .docker_client import (
 )
 from .exceptions import UserError
 from .serving import (
+    DEFAULT_STARTUP_TIMEOUT,
     _is_port_conflict,
     _PortInUseError,
     _retry_or_raise_port_conflict,
@@ -862,6 +863,7 @@ def serve(
     docker_args: list[str] | None = None,
     runtime_config: dict[str, Any] | None = None,
     skip_health_check: bool = False,
+    startup_timeout: float = DEFAULT_STARTUP_TIMEOUT,
 ) -> tuple:
     """Serve one or more Tesseract images.
 
@@ -894,6 +896,9 @@ def serve(
             Tesseracts with slow initialization (e.g., Julia runtime startup, large
             model loading). The caller is responsible for ensuring readiness,
             e.g. by polling ``/health``, before calling other endpoints.
+        startup_timeout: How long to wait for the Tesseract to answer a health
+            check, in seconds. Raise it for one that is slow to initialize, in
+            preference to skipping the check altogether.
 
     Returns:
         A tuple of the Tesseract container name and the port it is serving on.
@@ -1081,7 +1086,7 @@ def serve(
                 break
 
             logger.info("Waiting for Tesseract to start...")
-            _wait_for_health(container, ping_ip, port)
+            _wait_for_health(container, ping_ip, port, startup_timeout)
         except ContainerError as ex:
             if not _is_port_conflict(ex.stderr.decode("utf-8", errors="ignore")):
                 raise

--- a/tesseract_core/sdk/local_client.py
+++ b/tesseract_core/sdk/local_client.py
@@ -1,0 +1,156 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""A handle on a Tesseract served as a local subprocess.
+
+The process counterpart to :mod:`tesseract_core.sdk.docker_client`: what a
+started Tesseract is, and how to talk to it, read it and dispose of it. Deciding
+to start one is :mod:`tesseract_core.sdk.local_engine`'s job, so nothing here
+imports from either engine.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .served_client import ServedTesseract
+
+logger = logging.getLogger("tesseract")
+
+# How long to give a child process to exit on SIGTERM before escalating.
+_TERMINATE_TIMEOUT = 10.0
+
+
+def popen_kwargs() -> dict[str, Any]:
+    """Platform-specific options to isolate a child in its own process group.
+
+    Two reasons to do this: a Ctrl-C in the parent's terminal must not race us to
+    the child (we want to shut it down in an orderly way ourselves), and on
+    teardown we need to be able to kill uvicorn's worker processes along with the
+    parent it spawned them from. Paired with :func:`_stop_process`, which relies
+    on the group existing.
+    """
+    if os.name == "nt":
+        return {"creationflags": subprocess.CREATE_NEW_PROCESS_GROUP}
+    return {"start_new_session": True}
+
+
+def _stop_process(process: subprocess.Popen, *, force: bool) -> None:
+    """Ask a child and everything it spawned to exit, or force it to.
+
+    ``signal.SIGKILL`` does not exist on Windows, so it must not be named outside
+    the POSIX branch -- not even to compare against.
+    """
+    if os.name == "nt":
+        # No process groups in the POSIX sense; these map to the Windows APIs
+        # for asking a process to stop and for terminating it outright.
+        process.kill() if force else process.terminate()
+        return
+
+    sig = signal.SIGKILL if force else signal.SIGTERM
+    try:
+        # The group, so uvicorn's workers go down with the parent that spawned them.
+        os.killpg(os.getpgid(process.pid), sig)
+    except ProcessLookupError:
+        # Group is gone; fall back to the process in case it outlived it.
+        process.send_signal(sig)
+
+
+@dataclass
+class TesseractProcess(ServedTesseract):
+    """A ``tesseract-runtime serve`` process running on the local host.
+
+    The process counterpart to :class:`~tesseract_core.sdk.docker_client.Container`.
+    """
+
+    process: subprocess.Popen
+    host_ip: str
+    port: int
+    log_path: Path
+    python_executable: str
+    api_path: Path
+
+    def __repr__(self) -> str:
+        return f"Tesseract at {self.api_path}"
+
+    @property
+    def host_port(self) -> str:
+        """Port the Tesseract can be reached on."""
+        return str(self.port)
+
+    def reload(self) -> None:
+        """Nothing to do: this handle holds the process, not a copy of its state."""
+
+    def exit_code(self) -> int | None:
+        """The code the child exited with, if it has."""
+        return self.process.poll()
+
+    def is_running(self) -> bool:
+        """Whether the child process is still alive."""
+        return self.process.poll() is None
+
+    def teardown(self) -> None:
+        """Stop the process, forcing it if it does not go quietly, and clean up.
+
+        Safe to call more than once, and on a process that has already exited.
+        """
+        self._stop()
+        try:
+            self.log_path.unlink(missing_ok=True)
+        except OSError:
+            # Windows refuses to delete a file another process still holds open,
+            # and a just-killed child may not have released it yet. Harmless to
+            # leave: it is in a temp directory.
+            logger.debug("Could not remove log file %s", self.log_path)
+
+    def logs(self) -> bytes:
+        """Everything the process has written to stdout and stderr so far.
+
+        Bytes, matching what a container's logs give us, so callers holding the
+        interface need not care which they have. The file is created before the
+        process is, so a read that fails is a real one, not an empty Tesseract.
+        """
+        return self.log_path.read_bytes()
+
+    def diagnose_exit(self, logs: str) -> str:
+        """Name the interpreter that ran it, which nothing else can see."""
+        if "No module named 'tesseract_core'" in logs:
+            return (
+                f"The environment running it ({self.python_executable}) does not "
+                "have Tesseract installed. Install it there with "
+                "`uv pip install tesseract-core[runtime]`."
+            )
+        return (
+            "This usually means `tesseract_api.py` raised at import time, or a "
+            "dependency it needs is missing from the environment running it "
+            f"({self.python_executable})."
+        )
+
+    def _stop(self) -> None:
+        """Terminate the child, escalating to a kill if it outlasts the grace period."""
+        if self.process.poll() is not None:
+            return
+
+        try:
+            _stop_process(self.process, force=False)
+            try:
+                self.process.wait(timeout=_TERMINATE_TIMEOUT)
+                return
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    "Tesseract process %s did not exit within %ss, killing it",
+                    self.process.pid,
+                    _TERMINATE_TIMEOUT,
+                )
+            _stop_process(self.process, force=True)
+            self.process.wait(timeout=_TERMINATE_TIMEOUT)
+        except (ProcessLookupError, PermissionError):
+            # Already gone, or not ours to signal anymore (pid reuse).
+            pass
+        except subprocess.TimeoutExpired:
+            logger.warning("Tesseract process %s could not be killed", self.process.pid)

--- a/tesseract_core/sdk/local_engine.py
+++ b/tesseract_core/sdk/local_engine.py
@@ -1,0 +1,282 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Serve Tesseracts as local subprocesses, without containerization.
+
+This is the non-containerized counterpart to :mod:`tesseract_core.sdk.engine`:
+instead of running ``tesseract-runtime serve`` inside a Docker container, it runs
+it as a child process of the current interpreter. The Tesseract is still reached
+over HTTP, so the client side is identical to the containerized case.
+
+Compared to importing ``tesseract_api.py`` in-process, this buys process
+isolation (the Tesseract gets its own interpreter, its own global state, and its
+own signal handlers) at the cost of HTTP round-trips. It does *not* provide any
+of the other isolation a container gives you: the child inherits the parent's
+environment, working directory, filesystem access, and user.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Literal
+
+from .local_client import TesseractProcess, popen_kwargs
+from .serving import (
+    DEFAULT_STARTUP_TIMEOUT,
+    _PortInUseError,
+    _retry_or_raise_port_conflict,
+    _wait_for_health,
+    get_free_port,
+    runtime_config_env,
+)
+
+logger = logging.getLogger("tesseract")
+
+# Number of times to retry startup with a fresh port when the one we picked was
+# taken between selection and bind. Mirrors the containerized serve path.
+_MAX_PORT_ATTEMPTS = 3
+
+
+def _runtime_env(
+    api_path: Path,
+    *,
+    input_path: str | Path | None,
+    output_path: str | Path | None,
+    output_format: str | None,
+    runtime_config: dict[str, Any] | None,
+    environment: dict[str, str] | None,
+    foreign_interpreter: bool,
+) -> dict[str, str]:
+    """Build the child's environment.
+
+    Runtime configuration is passed as ``TESSERACT_*`` environment variables
+    rather than by mutating this process's runtime config, which is what makes
+    it possible to run several differently-configured Tesseracts side by side.
+    """
+    env = dict(os.environ)
+
+    if foreign_interpreter:
+        # Our own interpreter's import paths are meaningless (at best) and
+        # actively harmful (at worst) to a different one: they would put this
+        # environment's site-packages ahead of the Tesseract's own, defeating
+        # the point of running it elsewhere. Note that importing a
+        # tesseract_api.py in-process sets PYTHONPATH as a side effect, so this
+        # is not a hypothetical.
+        for var in ("PYTHONPATH", "PYTHONHOME", "VIRTUAL_ENV"):
+            env.pop(var, None)
+
+    # Applied after the scrub above, so an explicit request always wins.
+    if environment:
+        env.update(environment)
+
+    env["TESSERACT_API_PATH"] = str(api_path)
+
+    def mirror(key: str, value: str) -> None:
+        """Write a setting under both names the runtime accepts.
+
+        Unlike a container, the child inherits this process's environment, so a
+        setting exported by the caller is already there. Writing only
+        ``TESSERACT_*`` would leave an inherited ``TESSERACT_RUNTIME_*`` in place,
+        and typer resolves that as a CLI option, which wins -- so an exported
+        TESSERACT_RUNTIME_DEBUGPY_PORT would put every Tesseract on the same debug
+        port and the second would fail to start.
+        """
+        env[key] = value
+        env[key.replace("TESSERACT_", "TESSERACT_RUNTIME_", 1)] = value
+
+    for key, value in runtime_config_env(runtime_config).items():
+        mirror(key, value)
+
+    if input_path is not None:
+        mirror("TESSERACT_INPUT_PATH", str(Path(input_path).resolve()))
+    if output_path is not None:
+        mirror("TESSERACT_OUTPUT_PATH", str(Path(output_path).resolve()))
+    if output_format is not None:
+        mirror("TESSERACT_OUTPUT_FORMAT", output_format)
+
+    # Without this the child's logs arrive in chunks, which makes streaming them
+    # useless and startup failures look like hangs.
+    env["PYTHONUNBUFFERED"] = "1"
+
+    return env
+
+
+def serve(
+    api_path: str | Path,
+    *,
+    host_ip: str = "127.0.0.1",
+    port: int | str | None = None,
+    num_workers: int = 1,
+    environment: dict[str, str] | None = None,
+    input_path: str | Path | None = None,
+    output_path: str | Path | None = None,
+    output_format: Literal["json", "json+base64", "json+binref"] | None = None,
+    runtime_config: dict[str, Any] | None = None,
+    python_executable: str | Path | None = None,
+    skip_health_check: bool = False,
+    startup_timeout: float = DEFAULT_STARTUP_TIMEOUT,
+) -> TesseractProcess:
+    """Serve a ``tesseract_api.py`` in a dedicated subprocess.
+
+    Args:
+        api_path: Path to the ``tesseract_api.py`` to serve.
+        host_ip: IP address to bind to.
+        port: Port to bind to. If None, a free port is picked automatically
+            (and re-picked if it gets taken before the server binds it).
+        num_workers: Number of uvicorn worker processes.
+        environment: Extra environment variables for the child process. These are
+            layered on top of the parent's environment, not a replacement for it.
+        input_path: Value for ``TESSERACT_INPUT_PATH``.
+        output_path: Value for ``TESSERACT_OUTPUT_PATH``.
+        output_format: Value for ``TESSERACT_OUTPUT_FORMAT``.
+        runtime_config: Runtime configuration options, converted to
+            ``TESSERACT_*`` environment variables just as in the containerized
+            path.
+        python_executable: Interpreter used to run the Tesseract. Defaults to the
+            one running this process; pointing it at another environment's
+            ``python`` is what allows a Tesseract to have dependencies that
+            conflict with the caller's.
+        skip_health_check: If True, return as soon as the process is spawned
+            without waiting for it to answer /health. The caller is then
+            responsible for establishing readiness.
+        startup_timeout: How long to wait for the health check, in seconds.
+
+    Returns:
+        The served Tesseract, to be passed to :func:`teardown` when done.
+    """
+    api_path = Path(api_path).resolve()
+    if not api_path.is_file():
+        raise FileNotFoundError(f"Tesseract API path {api_path} is not a file.")
+
+    if python_executable is None:
+        python_executable = sys.executable
+    python_executable = str(python_executable)
+
+    foreign_interpreter = os.path.realpath(python_executable) != os.path.realpath(
+        sys.executable
+    )
+    if foreign_interpreter and not os.path.isfile(python_executable):
+        raise FileNotFoundError(
+            f"Python interpreter {python_executable} does not exist."
+        )
+
+    if output_format == "json+binref" and output_path is None:
+        raise ValueError(
+            "output_path is required when using the 'json+binref' output format."
+        )
+
+    auto_port = port is None
+
+    for attempt in range(_MAX_PORT_ATTEMPTS):
+        chosen_port = int(get_free_port()) if auto_port else int(port)
+
+        # Debug mode always starts a debugger, so give each Tesseract its own
+        # port: host processes share a network namespace, unlike containers, so
+        # the default would collide on the second Tesseract. The host it binds
+        # is left to the runtime, which already defaults to loopback. Opt out of
+        # debug mode entirely with `runtime_config={"debug": False}`.
+        attempt_config = dict(runtime_config or {})
+        if attempt_config.get("debug"):
+            attempt_config.setdefault(
+                "debugpy_port", get_free_port(exclude=(chosen_port,))
+            )
+
+        env = _runtime_env(
+            api_path,
+            input_path=input_path,
+            output_path=output_path,
+            output_format=output_format,
+            runtime_config=attempt_config,
+            environment=environment,
+            foreign_interpreter=foreign_interpreter,
+        )
+
+        if attempt_config.get("debug"):
+            # The runtime reports this too, but into the captured log file, which
+            # nobody sees unless they go looking. Read the host back out of the
+            # environment, since it may be the runtime's default rather than
+            # something we set.
+            debugpy_host = env.get("TESSERACT_DEBUGPY_HOST", "127.0.0.1")
+            logger.info(
+                "Debug mode enabled. Attach a debugger to "
+                f"{debugpy_host}:{attempt_config['debugpy_port']}"
+            )
+
+        # A dedicated file rather than a pipe: nothing has to keep draining it to
+        # stop a chatty Tesseract from filling the pipe buffer and blocking, and
+        # it gives `server_logs()` something to read after teardown.
+        log_fd, log_name = tempfile.mkstemp(prefix="tesseract_serve_", suffix=".log")
+        log_path = Path(log_name)
+
+        command = [
+            python_executable,
+            "-m",
+            "tesseract_core.runtime",
+            "serve",
+            "--host",
+            host_ip,
+            "--port",
+            str(chosen_port),
+            "--num-workers",
+            str(num_workers),
+        ]
+
+        logger.debug("Serving Tesseract %s on port %s", api_path, chosen_port)
+
+        try:
+            process = subprocess.Popen(
+                command,
+                env=env,
+                stdout=log_fd,
+                stderr=subprocess.STDOUT,
+                stdin=subprocess.DEVNULL,
+                **popen_kwargs(),
+            )
+        finally:
+            # The child holds its own duplicate of the descriptor.
+            os.close(log_fd)
+
+        served = TesseractProcess(
+            process=process,
+            host_ip=host_ip,
+            port=chosen_port,
+            log_path=log_path,
+            python_executable=python_executable,
+            api_path=api_path,
+        )
+
+        if skip_health_check:
+            return served
+
+        try:
+            _wait_for_health(served, served.url, startup_timeout)
+        except _PortInUseError:
+            # Retry as long as at least one of the ports was ours to pick. The
+            # logs say a port was taken but not which, and the debug port is
+            # chosen automatically even when the caller pins the API port, so
+            # keying the decision on the API port alone would refuse to retry a
+            # collision we caused and can trivially resolve.
+            debugpy_port = attempt_config.get("debugpy_port")
+            we_chose_debugpy_port = debugpy_port is not None and "debugpy_port" not in (
+                runtime_config or {}
+            )
+            retriable = auto_port or we_chose_debugpy_port
+            conflicting = (
+                f"{chosen_port} or {debugpy_port}"
+                if debugpy_port is not None
+                else str(chosen_port)
+            )
+            _retry_or_raise_port_conflict(
+                conflicting, retriable, attempt, _MAX_PORT_ATTEMPTS
+            )
+            continue
+
+        return served
+
+    raise RuntimeError(
+        f"Failed to find a free port after {_MAX_PORT_ATTEMPTS} attempts"
+    )

--- a/tesseract_core/sdk/served_client.py
+++ b/tesseract_core/sdk/served_client.py
@@ -1,0 +1,77 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The interface a running Tesseract presents, however it is being served.
+
+Implemented by :mod:`tesseract_core.sdk.docker_client` for containers and by
+:mod:`tesseract_core.sdk.local_client` for subprocesses. Kept apart from both so
+that neither client has to import the other to get its base class, and so the
+interface stays free of anything either transport needs.
+"""
+
+from __future__ import annotations
+
+import abc
+
+
+class ServedTesseract(abc.ABC):
+    """A Tesseract that has been started and can be reached, inspected and stopped.
+
+    Implemented by :class:`~tesseract_core.sdk.docker_client.Container` and by
+    :class:`~tesseract_core.sdk.local_client.TesseractProcess`, so callers that
+    only need to talk to a Tesseract, read its output or shut it down need not
+    know which of the two they hold.
+
+    Deliberately narrow: it promises nothing about separating stdout from stderr,
+    since a Tesseract served as a bare process writes both to one file.
+    """
+
+    # Provided by subclasses, as a field or a property. Not abstract: a dataclass
+    # field without a default does not satisfy an abstract property, and
+    # requiring one would force every subclass to wrap its own attribute.
+    host_ip: str | None
+    host_port: str | None
+
+    @property
+    def url(self) -> str:
+        """Base URL the Tesseract is serving on."""
+        return f"http://{self.host_ip}:{self.host_port}"
+
+    @abc.abstractmethod
+    def reload(self) -> None:
+        """Read the Tesseract's state again."""
+
+    @abc.abstractmethod
+    def is_running(self) -> bool:
+        """Whether the Tesseract is running now."""
+
+    @abc.abstractmethod
+    def teardown(self) -> None:
+        """Stop the Tesseract and dispose of it, leaving nothing behind.
+
+        Neither ``stop`` nor ``remove`` would do: the first leaves a stopped
+        container in place, and the second refuses to touch a running one unless
+        forced. Named for what `tesseract teardown` already means.
+        """
+
+    @abc.abstractmethod
+    def exit_code(self) -> int | None:
+        """The status it exited with, or None if it has not exited.
+
+        A snapshot, like ``is_running``: read after the Tesseract is disposed of,
+        it still reports what it stopped with.
+        """
+
+    @abc.abstractmethod
+    def logs(self) -> bytes:
+        """Everything the Tesseract has written so far."""
+
+    def diagnose_exit(self, logs: str) -> str:
+        """Anything this Tesseract can add about why it stopped running.
+
+        The code it exited with and what it wrote are reported by whoever noticed.
+        This is for what remains: a cause the transport can name and the logs
+        cannot. Empty by default, for a Tesseract with nothing to add. Takes the
+        logs as evidence, not to repeat them.
+        """
+        del logs
+        return ""

--- a/tesseract_core/sdk/serving.py
+++ b/tesseract_core/sdk/serving.py
@@ -1,0 +1,138 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Primitives shared by everything that serves a Tesseract over HTTP.
+
+Choosing a port to serve on, waiting for the server to answer, and telling a lost
+race for a port apart from a Tesseract that is genuinely broken. None of it is
+particular to how the Tesseract is run, so none of it belongs in the module that
+knows how to run one.
+"""
+
+import logging
+import random
+import socket
+import time
+from collections.abc import Sequence
+from contextlib import closing
+
+import requests
+
+from .docker_client import APIError, Container
+
+logger = logging.getLogger("tesseract")
+
+
+class _PortInUseError(RuntimeError):
+    """Container failed to start because its port was already bound.
+
+    Signals that a fresh port should be picked and startup retried. Only raised
+    when we chose the port ourselves; a user-supplied port is never retried.
+
+    A port collision surfaces in one of two ways depending on network mode:
+    - port-mapping mode: the Docker daemon fails to publish the host port and
+      ``containers.run`` raises ``ContainerError`` ("port is already allocated").
+    - host networking: the container binds the host port directly, so the
+      failure appears in the container logs as uvicorn's "address already in
+      use" and is detected in ``_wait_for_health``.
+    """
+
+
+# Substrings container runtimes use to report a host port already being taken.
+_PORT_CONFLICT_MARKERS = ("address already in use", "port is already allocated")
+
+
+def get_free_port(
+    within_range: tuple[int, int] = (49152, 65535),
+    exclude: Sequence[int] = (),
+) -> int:
+    """Find a random free port to use for HTTP."""
+    start, end = within_range
+    if start < 0 or end > 65535 or start > end:
+        raise ValueError("Invalid port range, must be between 0 and 65535")
+
+    # Try random ports in the given range
+    portlist = list(range(start, end))
+    random.shuffle(portlist)
+    for port in portlist:
+        if port in exclude:
+            continue
+        # Check if the port is free
+        with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+            except OSError:
+                # Port is already in use
+                continue
+            else:
+                return port
+    raise RuntimeError(f"No free ports found in range {start}-{end}")
+
+
+def _is_port_conflict(stderr: str) -> bool:
+    """Whether runtime stderr/logs indicate a host port collision."""
+    lowered = stderr.lower()
+    return any(marker in lowered for marker in _PORT_CONFLICT_MARKERS)
+
+
+def _retry_or_raise_port_conflict(
+    port: str, auto_port: bool, attempt: int, max_attempts: int
+) -> None:
+    """Decide whether a port collision should be retried.
+
+    Returns normally if the caller should retry with a fresh port; raises
+    otherwise. A user-supplied fixed port is never retried (we must not
+    silently move the Tesseract elsewhere), and auto-selected ports raise once
+    the attempt budget is exhausted.
+    """
+    if not auto_port:
+        # User asked for this exact port; surface the collision as-is.
+        raise _PortInUseError(f"Port {port} was already in use")
+    if attempt + 1 >= max_attempts:
+        raise RuntimeError(
+            f"Failed to find a free port after {max_attempts} attempts"
+        ) from None
+    logger.info(f"Port {port} was taken, retrying with a new port...")
+
+
+def _wait_for_health(
+    container: Container, ping_ip: str, port: str, timeout: float = 30
+) -> None:
+    """Poll a container's /health endpoint until it responds 200 or timeout expires."""
+    while True:
+        try:
+            response = requests.get(f"http://{ping_ip}:{port}/health")
+        except requests.exceptions.ConnectionError:
+            pass
+        else:
+            if response.status_code == 200:
+                return
+
+        time.sleep(0.1)
+        timeout -= 0.1
+
+        if timeout < 0 or not container.is_running():
+            logs_text = ""
+            try:
+                logs_text = container.logs(stdout=True, stderr=True).decode()
+                logger.error(
+                    f"Tesseract container {container.name} failed to start:\n{logs_text}"
+                )
+            except APIError as ex:
+                logger.warning(
+                    f"Failed to get logs for container {container.name}: {ex}"
+                )
+            try:
+                container.stop()
+            except APIError as ex:
+                logger.warning(f"Failed to stop container {container.name}: {ex}")
+
+            # A port collision is racy and worth retrying with a fresh port;
+            # distinguish it from genuine startup failures so those still fail
+            # fast.
+            if _is_port_conflict(logs_text):
+                raise _PortInUseError(f"Port {port} was already in use")
+
+            if timeout < 0:
+                raise TimeoutError("Tesseract did not start in time")
+            else:
+                raise RuntimeError("Tesseract failed to start")

--- a/tesseract_core/sdk/serving.py
+++ b/tesseract_core/sdk/serving.py
@@ -2,22 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 """Primitives shared by everything that serves a Tesseract over HTTP.
 
-Choosing a port to serve on, waiting for the server to answer, and telling a lost
-race for a port apart from a Tesseract that is genuinely broken. None of it is
-particular to how the Tesseract is run, so none of it belongs in the module that
-knows how to run one.
+Choosing a port to serve on, telling the Tesseract how it is configured, waiting
+for it to answer, and telling a lost race for a port apart from a Tesseract that
+is genuinely broken. None of it is particular to how the Tesseract is run, so none
+of it belongs in a module that knows how to run one.
 """
 
 import logging
 import random
 import socket
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from contextlib import closing
+from typing import Any
 
 import requests
 
-from .docker_client import APIError, Container
+from .docker_client import APIError
+from .served_client import ServedTesseract
 
 logger = logging.getLogger("tesseract")
 
@@ -43,7 +45,12 @@ class _PortInUseError(RuntimeError):
 
 
 # Substrings container runtimes use to report a host port already being taken.
-_PORT_CONFLICT_MARKERS = ("address already in use", "port is already allocated")
+_PORT_CONFLICT_MARKERS = (
+    "address already in use",
+    "port is already allocated",
+    # Windows' wording for the same condition (WSAEADDRINUSE / WinError 10048)
+    "only one usage of each socket address",
+)
 
 
 def get_free_port(
@@ -73,9 +80,30 @@ def get_free_port(
     raise RuntimeError(f"No free ports found in range {start}-{end}")
 
 
+def runtime_config_env(runtime_config: Mapping[str, Any] | None) -> dict[str, str]:
+    """Convert runtime configuration to the variables the Tesseract runtime reads.
+
+    Shared so that ``runtime_config`` means the same thing however a Tesseract is
+    served; booleans in particular have to be spelled the way the config parser
+    expects.
+    """
+
+    def encode(value: Any) -> str:
+        return ("1" if value else "0") if isinstance(value, bool) else str(value)
+
+    return {
+        f"TESSERACT_{key.upper()}": encode(value)
+        for key, value in (runtime_config or {}).items()
+    }
+
+
 def _is_port_conflict(stderr: str) -> bool:
     """Whether runtime stderr/logs indicate a host port collision."""
-    lowered = stderr.lower()
+    # Collapse whitespace before matching. An uncaught error in the runtime is
+    # rendered by rich into a fixed-width box, which wraps long lines -- and
+    # debugpy's "Address already in use" is long enough to be split across two,
+    # so a naive substring search silently misses a genuine conflict.
+    lowered = " ".join(stderr.split()).lower()
     return any(marker in lowered for marker in _PORT_CONFLICT_MARKERS)
 
 
@@ -106,15 +134,10 @@ _HEALTH_REQUEST_TIMEOUT = 5.0
 _HEALTH_POLL_INTERVAL = 0.1
 
 
-def _wait_for_health(
-    container: Container,
-    ping_ip: str,
-    port: str,
-    timeout: float = DEFAULT_STARTUP_TIMEOUT,
-) -> None:
-    """Wait for a container to serve /health, and dispose of it if it never does.
+def _wait_for_health(served: ServedTesseract, url: str, timeout: float) -> None:
+    """Wait for a Tesseract to serve /health, and dispose of it if it never does.
 
-    Takes ``ping_ip`` rather than asking the container: one that published its
+    Takes ``url`` rather than using ``served.url``: a container that published its
     port on every interface is not reached at the address it reports binding to.
 
     Raises:
@@ -127,9 +150,7 @@ def _wait_for_health(
 
     while True:
         try:
-            response = requests.get(
-                f"http://{ping_ip}:{port}/health", timeout=_HEALTH_REQUEST_TIMEOUT
-            )
+            response = requests.get(f"{url}/health", timeout=_HEALTH_REQUEST_TIMEOUT)
         except requests.exceptions.RequestException:
             pass
         else:
@@ -137,12 +158,11 @@ def _wait_for_health(
                 return
 
         # Liveness is only asked once /health has failed to answer, so a healthy
-        # container never pays for it -- worth having, as it is a `docker inspect`
-        # every poll. Checked before the deadline: "it exited" tells whoever asked
-        # more than "it did not answer in time", and a container that has exited
-        # is never going to answer. Reading it also leaves the state it stopped in
-        # on the container, for the message below to use.
-        if not container.is_running():
+        # Tesseract never pays for it -- worth having, as for a container it is a
+        # `docker inspect` every poll. Checked before the deadline: "it exited"
+        # tells whoever asked more than "it did not answer in time", and a
+        # Tesseract that has exited is never going to answer.
+        if not served.is_running():
             timed_out = False
             break
         if time.monotonic() > deadline:
@@ -153,34 +173,39 @@ def _wait_for_health(
 
     # Read the logs before disposing of what wrote them. Neither reading nor
     # disposing may raise: they are how we report the failure, not the failure
-    # itself, and an error here would replace it with a less useful one.
+    # itself, and an error here would replace it with a less useful one. Both
+    # implementations raise `APIError` and nothing else, but a handle holding an
+    # operating system resource is entitled to an `OSError`.
     try:
-        logs = container.logs(stdout=True, stderr=True).decode(errors="replace")
-    except APIError as ex:
-        logger.warning(f"Failed to get logs for {container}: {ex}")
+        logs = served.logs().decode(errors="replace")
+    except (APIError, OSError) as ex:
+        logger.warning(f"Failed to get logs for {served}: {ex}")
         logs = ""
 
     try:
-        container.teardown()
-    except APIError as ex:
-        logger.warning(f"Failed to tear down {container}: {ex}")
+        served.teardown()
+    except (APIError, OSError) as ex:
+        logger.warning(f"Failed to tear down {served}: {ex}")
 
     # A port collision is racy and worth retrying with a fresh port; distinguish
     # it from genuine startup failures so those still fail fast.
     if _is_port_conflict(logs):
-        raise _PortInUseError(f"Port {port} was already in use")
+        raise _PortInUseError(f"Port {served.host_port} was already in use")
 
+    # Only what the Tesseract itself can add differs between transports; naming
+    # it, saying which of the two ways it failed, and quoting its output do not.
     if timed_out:
-        headline = f"{container} did not respond to a health check in time."
+        headline = f"{served} did not respond to a health check in time."
+        # Advice neither transport can improve on: both take the same argument.
         diagnosis = (
             "If it is simply slow to initialize (e.g. loading a large model), "
             "increase `startup_timeout`."
         )
     else:
-        exit_code = container.exit_code()
+        exit_code = served.exit_code()
         exited = "" if exit_code is None else f" (exit code {exit_code})"
-        headline = f"{container} stopped running during startup{exited}."
-        diagnosis = container.diagnose_exit(logs)
+        headline = f"{served} stopped running during startup{exited}."
+        diagnosis = served.diagnose_exit(logs)
     output = (
         f"Output from the Tesseract:\n{logs.strip()}"
         if logs.strip()

--- a/tesseract_core/sdk/serving.py
+++ b/tesseract_core/sdk/serving.py
@@ -99,48 +99,93 @@ def _retry_or_raise_port_conflict(
     logger.info(f"Port {port} was taken, retrying with a new port...")
 
 
+# How long to give a single /health request before assuming it will not answer.
+# A published port whose target is unreachable is accepted by the proxy and then
+# dropped, so without this a poll can block indefinitely.
+_HEALTH_REQUEST_TIMEOUT = 5.0
+_HEALTH_POLL_INTERVAL = 0.1
+
+
 def _wait_for_health(
     container: Container,
     ping_ip: str,
     port: str,
     timeout: float = DEFAULT_STARTUP_TIMEOUT,
 ) -> None:
-    """Poll a container's /health endpoint until it responds 200 or timeout expires."""
+    """Wait for a container to serve /health, and dispose of it if it never does.
+
+    Takes ``ping_ip`` rather than asking the container: one that published its
+    port on every interface is not reached at the address it reports binding to.
+
+    Raises:
+        _PortInUseError: if it failed because its port was taken, which the caller
+            may want to retry on a fresh one.
+        TimeoutError: if it never answered in time.
+        RuntimeError: if it stopped running before it could.
+    """
+    deadline = time.monotonic() + timeout
+
     while True:
         try:
-            response = requests.get(f"http://{ping_ip}:{port}/health")
-        except requests.exceptions.ConnectionError:
+            response = requests.get(
+                f"http://{ping_ip}:{port}/health", timeout=_HEALTH_REQUEST_TIMEOUT
+            )
+        except requests.exceptions.RequestException:
             pass
         else:
             if response.status_code == 200:
                 return
 
-        time.sleep(0.1)
-        timeout -= 0.1
+        # Liveness is only asked once /health has failed to answer, so a healthy
+        # container never pays for it -- worth having, as it is a `docker inspect`
+        # every poll. Checked before the deadline: "it exited" tells whoever asked
+        # more than "it did not answer in time", and a container that has exited
+        # is never going to answer. Reading it also leaves the state it stopped in
+        # on the container, for the message below to use.
+        if not container.is_running():
+            timed_out = False
+            break
+        if time.monotonic() > deadline:
+            timed_out = True
+            break
 
-        if timeout < 0 or not container.is_running():
-            logs_text = ""
-            try:
-                logs_text = container.logs(stdout=True, stderr=True).decode()
-                logger.error(
-                    f"Tesseract container {container.name} failed to start:\n{logs_text}"
-                )
-            except APIError as ex:
-                logger.warning(
-                    f"Failed to get logs for container {container.name}: {ex}"
-                )
-            try:
-                container.stop()
-            except APIError as ex:
-                logger.warning(f"Failed to stop container {container.name}: {ex}")
+        time.sleep(_HEALTH_POLL_INTERVAL)
 
-            # A port collision is racy and worth retrying with a fresh port;
-            # distinguish it from genuine startup failures so those still fail
-            # fast.
-            if _is_port_conflict(logs_text):
-                raise _PortInUseError(f"Port {port} was already in use")
+    # Read the logs before disposing of what wrote them. Neither reading nor
+    # disposing may raise: they are how we report the failure, not the failure
+    # itself, and an error here would replace it with a less useful one.
+    try:
+        logs = container.logs(stdout=True, stderr=True).decode(errors="replace")
+    except APIError as ex:
+        logger.warning(f"Failed to get logs for {container}: {ex}")
+        logs = ""
 
-            if timeout < 0:
-                raise TimeoutError("Tesseract did not start in time")
-            else:
-                raise RuntimeError("Tesseract failed to start")
+    try:
+        container.teardown()
+    except APIError as ex:
+        logger.warning(f"Failed to tear down {container}: {ex}")
+
+    # A port collision is racy and worth retrying with a fresh port; distinguish
+    # it from genuine startup failures so those still fail fast.
+    if _is_port_conflict(logs):
+        raise _PortInUseError(f"Port {port} was already in use")
+
+    if timed_out:
+        headline = f"{container} did not respond to a health check in time."
+        diagnosis = (
+            "If it is simply slow to initialize (e.g. loading a large model), "
+            "increase `startup_timeout`."
+        )
+    else:
+        exit_code = container.exit_code()
+        exited = "" if exit_code is None else f" (exit code {exit_code})"
+        headline = f"{container} stopped running during startup{exited}."
+        diagnosis = container.diagnose_exit(logs)
+    output = (
+        f"Output from the Tesseract:\n{logs.strip()}"
+        if logs.strip()
+        else "The Tesseract produced no output."
+    )
+    paragraphs = [headline, diagnosis, output]
+    message = "\n\n".join(p for p in paragraphs if p)
+    raise TimeoutError(message) if timed_out else RuntimeError(message)

--- a/tesseract_core/sdk/serving.py
+++ b/tesseract_core/sdk/serving.py
@@ -21,6 +21,11 @@ from .docker_client import APIError, Container
 
 logger = logging.getLogger("tesseract")
 
+# How long to wait for a freshly started Tesseract to answer /health. Generous,
+# because the cost of being wrong is asymmetric: a Tesseract that crashes is
+# reported the moment it stops running, so this only bounds one that hangs.
+DEFAULT_STARTUP_TIMEOUT = 60.0
+
 
 class _PortInUseError(RuntimeError):
     """Container failed to start because its port was already bound.
@@ -95,7 +100,10 @@ def _retry_or_raise_port_conflict(
 
 
 def _wait_for_health(
-    container: Container, ping_ip: str, port: str, timeout: float = 30
+    container: Container,
+    ping_ip: str,
+    port: str,
+    timeout: float = DEFAULT_STARTUP_TIMEOUT,
 ) -> None:
     """Poll a container's /health endpoint until it responds 200 or timeout expires."""
     while True:

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -24,7 +24,7 @@ import requests
 from pydantic import BaseModel, TypeAdapter, ValidationError
 from pydantic_core import InitErrorDetails, PydanticCustomError, from_json
 
-from . import engine
+from . import engine, local_engine, serving
 from .binref import (
     SUPPORTS_BINREF_POOL,
     BinrefSlot,
@@ -35,8 +35,9 @@ from .binref import (
     mmap_binref_array,
     read_binref_array,
 )
-from .docker_client import Container, Containers
+from .docker_client import Container
 from .logs import LogStreamer
+from .served_client import ServedTesseract
 
 if TYPE_CHECKING:
     # Imported for type hints only. `from __future__ import annotations` makes
@@ -66,8 +67,12 @@ def requires_client(func: Callable) -> Callable:
     @wraps(func)
     def wrapper(self: Tesseract, *args: Any, **kwargs: Any) -> Any:
         if not self._client:
+            if self._spawn_backend == "subprocess":
+                constructor = "from_source"
+            else:
+                constructor = "from_image"
             raise RuntimeError(
-                f"When creating a {self.__class__.__name__} via `from_image`, "
+                f"When creating a {self.__class__.__name__} via `{constructor}`, "
                 "you must either use it as a context manager or call .serve() before use."
             )
         return func(self, *args, **kwargs)
@@ -86,7 +91,11 @@ class Tesseract:
     """
 
     _spawn_config: dict | None = None
-    _serve_context: dict | None = None
+    # Which engine `serve()` should hand `_spawn_config` to. "container" rather
+    # than "docker" because any docker-compatible CLI works here (see
+    # `is_podman`), matching how `container_info` and `Container` are named.
+    _spawn_backend: Literal["container", "subprocess"] | None = None
+    _serve_context: ServedTesseract | None = None
     _lastlog: str | None = None
     _client: HTTPClient | LocalClient | None = None
     _stream_logs: BoolOrCallable = False
@@ -160,7 +169,7 @@ class Tesseract:
         runtime_config: dict[str, Any] | None = None,
         stream_logs: BoolOrCallable = False,
         skip_health_check: bool = False,
-        startup_timeout: float = engine.DEFAULT_STARTUP_TIMEOUT,
+        startup_timeout: float = serving.DEFAULT_STARTUP_TIMEOUT,
         timeout: float | tuple[float, float] | None = None,
         experimental_binref_pool: bool = False,
     ) -> Tesseract:
@@ -280,6 +289,7 @@ class Tesseract:
             skip_health_check=skip_health_check,
             startup_timeout=startup_timeout,
         )
+        obj._spawn_backend = "container"
         return obj
 
     @classmethod
@@ -353,6 +363,76 @@ class Tesseract:
         obj._client = LocalClient(tesseract_api, output_path=resolved_output_path)
         return obj
 
+    @classmethod
+    def from_source(
+        cls,
+        tesseract_api: str | Path,
+        input_path: Path | None = None,
+        output_path: Path | None = None,
+        output_format: Literal["json", "json+base64", "json+binref"] = "json+base64",
+        runtime_config: dict[str, Any] | None = None,
+        stream_logs: BoolOrCallable = False,
+        python_executable: str | Path | None = None,
+        startup_timeout: float = serving.DEFAULT_STARTUP_TIMEOUT,
+    ) -> Tesseract:
+        """Create a Tesseract instance from a Tesseract API file, in its own process.
+
+        The Tesseract is served by a dedicated ``tesseract-runtime serve``
+        subprocess and reached over HTTP, so it does not share an interpreter,
+        global state or signal handlers with the caller. That matters when
+        sharing them is unsafe -- nesting JAX inside JAX can deadlock -- and it
+        lets the Tesseract run in a different environment than the caller.
+
+        Unlike :meth:`from_tesseract_api`, which imports the API into this
+        process, this must be used as a context manager or served explicitly,
+        since there is a process to clean up:
+
+            >>> with Tesseract.from_source("tesseract_api.py") as tess:
+            ...     tess.apply({"a": 1})
+
+        This is not a substitute for a container: the Tesseract inherits this
+        process's environment, working directory, filesystem access and user.
+
+        Args:
+            tesseract_api: Path to the `tesseract_api.py` file. Unlike
+                :meth:`from_tesseract_api`, an already imported module cannot be
+                used, since it cannot be shared with another process.
+            input_path: Path of input directory. All paths in the tesseract
+                payload have to be relative to this path.
+            output_path: Path of output directory. All paths in the tesseract
+                result with be given relative to this path. Required when using json+binref.
+            output_format: Format to use for the output data. json+binref requires output_path.
+                This has no impact on what is returned to Python and only affects the format that is used internally.
+            runtime_config: Dictionary of runtime configuration options to pass to the Tesseract.
+                For example, `{"profiling": True}` enables profiling.
+            stream_logs: If True, stream logs to stdout while endpoints run.
+                If a callable, stream logs to that callable instead.
+            python_executable: Interpreter used to run the Tesseract. Defaults to
+                the one running this process; point it at another environment's
+                ``python`` (for example one created with ``uv venv``) to give the
+                Tesseract dependencies that conflict with the caller's. That
+                environment must have ``tesseract-core[runtime]`` and the
+                Tesseract's own requirements installed.
+            startup_timeout: How long to wait, in seconds, for the Tesseract to
+                become healthy before giving up.
+
+        Returns:
+            A Tesseract instance.
+        """
+        obj = cls.__new__(cls)
+        obj._stream_logs = stream_logs
+        obj._spawn_backend = "subprocess"
+        obj._spawn_config = _subprocess_spawn_config(
+            tesseract_api,
+            input_path=input_path,
+            output_path=output_path,
+            output_format=output_format,
+            runtime_config=runtime_config,
+            python_executable=python_executable,
+            startup_timeout=startup_timeout,
+        )
+        return obj
+
     def __enter__(self) -> Tesseract:
         """Enter the Tesseract context.
 
@@ -386,32 +466,48 @@ class Tesseract:
         """
         if self._spawn_config is None:
             raise RuntimeError(
-                "Can only retrieve logs for a Tesseract created via from_image."
+                "Can only retrieve logs for a Tesseract created via `from_image` "
+                "or `from_source`."
             )
         if self._serve_context is None:
             return self._lastlog or ""
-        return engine.logs(self._serve_context["container_name"])
+        return self._serve_context.logs().decode("utf-8", errors="replace")
 
     def serve(self) -> None:
         """Serve the Tesseract until it is stopped."""
         if self._spawn_config is None:
-            raise RuntimeError("Can only serve a Tesseract created via from_image.")
+            raise RuntimeError(
+                "Can only serve a Tesseract created via `from_image` or `from_source`."
+            )
         if self._serve_context is not None:
             raise RuntimeError("Tesseract is already being served.")
-        container_name, container = engine.serve(**self._spawn_config)
-        self._serve_context = dict(
-            container_name=container_name,
-            port=container.host_port,
-            network=self._spawn_config["network"],
-            network_alias=self._spawn_config["network_alias"],
-        )
-        host_ip = self._spawn_config["host_ip"]
+
+        # The only part that has to know which backend it is: what to start.
+        if self._spawn_backend == "subprocess":
+            self._serve_context = local_engine.serve(**self._spawn_config)
+        else:
+            _, self._serve_context = engine.serve(**self._spawn_config)
+
+        # Ensure that the Tesseract is torn down once the object is garbage
+        # collected, to avoid orphaned containers or processes if the user
+        # forgets to call .teardown()
+        def _silent_teardown(handle: ServedTesseract) -> None:
+            from tesseract_core.sdk.docker_client import NotFound
+
+            try:
+                handle.teardown()
+            except NotFound:
+                pass
+
+        reap = (_silent_teardown, self._serve_context)
+        url = self._serve_context.url
+
         self._lastlog = None
         output_path = self._spawn_config.get("output_path")
         input_path = self._spawn_config.get("input_path")
         output_format = self._spawn_config.get("output_format", "json+base64")
         self._client = HTTPClient(
-            f"http://{host_ip}:{container.host_port}",
+            url,
             output_path=Path(output_path) if output_path else None,
             output_format=output_format,
             timeout=self._timeout,
@@ -419,29 +515,18 @@ class Tesseract:
             experimental_binref_pool=self._binref_pool_enabled,
         )
 
-        # Ensure that the Tesseract is torn down once the object is garbage collected,
-        # to avoid orphaned containers if the user forgets to call .teardown()
-        def _silent_teardown(name: str) -> None:
-            from tesseract_core.sdk.docker_client import NotFound
-
-            try:
-                engine.teardown(name)
-            except NotFound:
-                pass
-
-        self._atexit_finalizer = weakref.finalize(
-            self, _silent_teardown, container_name
-        )
+        self._atexit_finalizer = weakref.finalize(self, *reap)
 
     def teardown(self) -> None:
         """Teardown the Tesseract.
 
-        This will stop and remove the Tesseract container.
+        This will stop and remove the Tesseract container, or stop the dedicated
+        process serving it.
         """
         if self._serve_context is None:
             raise RuntimeError("Tesseract is not being served.")
         self._lastlog = self.server_logs()
-        engine.teardown(self._serve_context["container_name"])
+        self._serve_context.teardown()
         if self._client is not None:
             self._client.close()
         self._client = None
@@ -483,7 +568,7 @@ class Tesseract:
             tesseract_core.sdk.docker_client.NotFound: if the container
                 disappeared between :meth:`serve` and this call.
         """
-        if self._spawn_config is None:
+        if self._spawn_backend != "container":
             raise RuntimeError(
                 "`container_info` is only available when using "
                 "`Tesseract.from_image(...)`."
@@ -493,7 +578,7 @@ class Tesseract:
                 "`container_info` is only available for served Tesseracts. "
                 "Use `tess.serve()` or `with tess:` first."
             )
-        return Containers.get(self._serve_context["container_name"])
+        return self._serve_context
 
     @requires_client
     def apply(
@@ -686,6 +771,66 @@ class Tesseract:
             raise AssertionError(result["message"])
         elif result["status"] == "error":
             raise RuntimeError(result["message"])
+
+
+def _subprocess_spawn_config(
+    tesseract_api: str | Path | ModuleType,
+    *,
+    input_path: Path | None,
+    output_path: Path | None,
+    output_format: Literal["json", "json+base64", "json+binref"],
+    runtime_config: dict[str, Any] | None,
+    python_executable: str | Path | None,
+    startup_timeout: float,
+) -> dict[str, Any]:
+    """Validate arguments for a dedicated-process Tesseract and build its config.
+
+    Unlike the in-process path, nothing here touches this process's runtime
+    config: it all reaches the child as environment variables, so several
+    Tesseracts can be configured independently.
+    """
+    if not isinstance(tesseract_api, str | Path):
+        raise ValueError(
+            "`from_source` requires a path to a `tesseract_api.py` file, but an "
+            f"already imported module was given "
+            f"({getattr(tesseract_api, '__name__', tesseract_api)!r}). A module "
+            "cannot be shared with another process; pass `module.__file__`, or "
+            "use `from_tesseract_api` to run it in this one."
+        )
+
+    tesseract_api_path = Path(tesseract_api).resolve(strict=True)
+    if not tesseract_api_path.is_file():
+        raise RuntimeError(f"Tesseract API path {tesseract_api_path} is not a file.")
+
+    if output_path is not None:
+        resolved_output_path = engine._resolve_file_path(output_path, make_dir=True)
+    elif output_format == "json+binref":
+        raise ValueError(
+            "output_path is required when using the 'json+binref' output format."
+        )
+    else:
+        # Same as `from_image` and the in-process path: an output directory
+        # always exists, which is what makes `stream_logs` work without the
+        # caller having to specify one.
+        resolved_output_path = Path(tempfile.mkdtemp(prefix="tesseract_output_"))
+
+    # Debug mode gives full tracebacks from the child and enables the `test`
+    # endpoint, matching what the in-process path configures. The debugpy
+    # listener it would normally imply is disabled separately, in
+    # `local_engine.serve`.
+    config_kwargs: dict[str, Any] = {"debug": True}
+    if runtime_config is not None:
+        config_kwargs.update(runtime_config)
+
+    return dict(
+        api_path=tesseract_api_path,
+        input_path=input_path.resolve() if input_path is not None else None,
+        output_path=resolved_output_path,
+        output_format=output_format,
+        runtime_config=config_kwargs,
+        python_executable=python_executable,
+        startup_timeout=startup_timeout,
+    )
 
 
 def _tree_map(func: Callable, tree: Any, is_leaf: Callable | None = None) -> Any:

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -160,6 +160,7 @@ class Tesseract:
         runtime_config: dict[str, Any] | None = None,
         stream_logs: BoolOrCallable = False,
         skip_health_check: bool = False,
+        startup_timeout: float = engine.DEFAULT_STARTUP_TIMEOUT,
         timeout: float | tuple[float, float] | None = None,
         experimental_binref_pool: bool = False,
     ) -> Tesseract:
@@ -205,6 +206,9 @@ class Tesseract:
                 model loading). The caller is responsible for ensuring
                 readiness, e.g. by calling :meth:`health`, before calling
                 other endpoints.
+            startup_timeout: How long to wait, in seconds, for the Tesseract to
+                answer a health check. Raise it for one that is slow to
+                initialize, in preference to skipping the check altogether.
             timeout: Request timeout in seconds for HTTP calls to the Tesseract.
                 Can be a float for both connect and read timeouts, or a
                 ``(connect, read)`` tuple for separate control. ``None`` (the default)
@@ -274,6 +278,7 @@ class Tesseract:
             debug=True,
             docker_args=docker_args,
             skip_health_check=skip_health_check,
+            startup_timeout=startup_timeout,
         )
         return obj
 

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -26,7 +26,7 @@ from pydantic_core import InitErrorDetails, PydanticCustomError, from_json
 
 from . import engine, local_engine, serving
 from .binref import (
-    SUPPORTS_BINREF_POOL,
+    CONTAINERS_SUPPORT_BINREF_POOL,
     BinrefSlot,
     BinrefWritePool,
     _fast_tobytes,
@@ -261,6 +261,14 @@ class Tesseract:
 
         obj._stream_logs = stream_logs
         obj._timeout = timeout
+        if experimental_binref_pool and not CONTAINERS_SUPPORT_BINREF_POOL:
+            raise RuntimeError(
+                "experimental_binref_pool=True is only supported for containerized "
+                "Tesseracts on Linux, since it relies on the client and the "
+                "container sharing a page cache. Elsewhere the container runs "
+                "inside a VM, so bind mounts cross the VM boundary and the premise "
+                "does not hold. `from_source` has no VM to cross and is unrestricted."
+            )
         obj._binref_pool_enabled = experimental_binref_pool
         # Purge auto-created tempdirs when the object is garbage collected.
         # User-supplied paths are left untouched.
@@ -374,6 +382,7 @@ class Tesseract:
         stream_logs: BoolOrCallable = False,
         python_executable: str | Path | None = None,
         startup_timeout: float = serving.DEFAULT_STARTUP_TIMEOUT,
+        experimental_binref_pool: bool = False,
     ) -> Tesseract:
         """Create a Tesseract instance from a Tesseract API file, in its own process.
 
@@ -415,6 +424,12 @@ class Tesseract:
                 Tesseract's own requirements installed.
             startup_timeout: How long to wait, in seconds, for the Tesseract to
                 become healthy before giving up.
+            experimental_binref_pool: Opt-in fast path for ``json+binref`` that
+                reuses warm memory-mapped buffers instead of allocating a file
+                per call. Only pays off when the binref directory is
+                memory-backed (a ``tmpfs``); on an ordinary disk-backed
+                filesystem it is several times *slower* than plain
+                ``json+binref``. See :doc:`/content/how-to/fast-local-runs`.
 
         Returns:
             A Tesseract instance.
@@ -422,6 +437,7 @@ class Tesseract:
         obj = cls.__new__(cls)
         obj._stream_logs = stream_logs
         obj._spawn_backend = "subprocess"
+        obj._binref_pool_enabled = experimental_binref_pool
         auto_dirs, obj._spawn_config = _subprocess_spawn_config(
             tesseract_api,
             input_path=input_path,
@@ -1099,14 +1115,10 @@ class HTTPClient:
         # Opt-in warm-buffer pool for binref inputs. Only meaningful when passing
         # inputs as binref into a mounted (ideally shared-memory) input dir.
         self._binref_pool: BinrefWritePool | None = None
+        # Whether the pool can work at all depends on how the Tesseract is
+        # served, which is not something a client reached over HTTP can know.
+        # Whoever served it decides; this honours the decision.
         if experimental_binref_pool and self._input_path is not None:
-            if not SUPPORTS_BINREF_POOL:
-                raise RuntimeError(
-                    "experimental_binref_pool=True is only supported on Linux, "
-                    "since it relies on the client and server container sharing a "
-                    "page cache via a shared-memory tmpfs. On other platforms the "
-                    "container runs inside a VM, so this premise does not hold."
-                )
             self._binref_pool = BinrefWritePool(self._input_path)
 
     def close(self) -> None:

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -422,7 +422,7 @@ class Tesseract:
         obj = cls.__new__(cls)
         obj._stream_logs = stream_logs
         obj._spawn_backend = "subprocess"
-        obj._spawn_config = _subprocess_spawn_config(
+        auto_dirs, obj._spawn_config = _subprocess_spawn_config(
             tesseract_api,
             input_path=input_path,
             output_path=output_path,
@@ -431,6 +431,9 @@ class Tesseract:
             python_executable=python_executable,
             startup_timeout=startup_timeout,
         )
+        # Purge auto-created scratch dirs when the object is garbage collected.
+        for scratch in auto_dirs:
+            weakref.finalize(obj, _purge_tempdir, str(scratch))
         return obj
 
     def __enter__(self) -> Tesseract:
@@ -782,7 +785,7 @@ def _subprocess_spawn_config(
     runtime_config: dict[str, Any] | None,
     python_executable: str | Path | None,
     startup_timeout: float,
-) -> dict[str, Any]:
+) -> tuple[list[Path], dict[str, Any]]:
     """Validate arguments for a dedicated-process Tesseract and build its config.
 
     Unlike the in-process path, nothing here touches this process's runtime
@@ -802,17 +805,24 @@ def _subprocess_spawn_config(
     if not tesseract_api_path.is_file():
         raise RuntimeError(f"Tesseract API path {tesseract_api_path} is not a file.")
 
+    # Scratch directories, as `from_image` does it: an output directory always
+    # exists, which is what makes `stream_logs` work without the caller
+    # specifying one, and binref additionally needs somewhere to put its inputs.
+    # Auto-created ones are purged with the Tesseract; given ones are left alone.
+    auto_dirs = []
     if output_path is not None:
         resolved_output_path = engine._resolve_file_path(output_path, make_dir=True)
-    elif output_format == "json+binref":
-        raise ValueError(
-            "output_path is required when using the 'json+binref' output format."
-        )
     else:
-        # Same as `from_image` and the in-process path: an output directory
-        # always exists, which is what makes `stream_logs` work without the
-        # caller having to specify one.
         resolved_output_path = Path(tempfile.mkdtemp(prefix="tesseract_output_"))
+        auto_dirs.append(resolved_output_path)
+
+    if input_path is not None:
+        resolved_input_path = Path(input_path).resolve()
+    elif output_format == "json+binref":
+        resolved_input_path = Path(tempfile.mkdtemp(prefix="tesseract_input_"))
+        auto_dirs.append(resolved_input_path)
+    else:
+        resolved_input_path = None
 
     # Debug mode gives full tracebacks from the child and enables the `test`
     # endpoint, matching what the in-process path configures. The debugpy
@@ -822,9 +832,9 @@ def _subprocess_spawn_config(
     if runtime_config is not None:
         config_kwargs.update(runtime_config)
 
-    return dict(
+    return auto_dirs, dict(
         api_path=tesseract_api_path,
-        input_path=input_path.resolve() if input_path is not None else None,
+        input_path=resolved_input_path,
         output_path=resolved_output_path,
         output_format=output_format,
         runtime_config=config_kwargs,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -424,7 +424,7 @@ def dummy_network_name():
 def mocked_docker(monkeypatch):
     """Mock CLIDockerClient class."""
     import tesseract_core.sdk.docker_client
-    from tesseract_core.sdk import engine
+    from tesseract_core.sdk import engine, serving
     from tesseract_core.sdk.docker_client import Container, Image, NotFound
 
     class MockedContainer(Container):
@@ -560,7 +560,7 @@ def mocked_docker(monkeypatch):
             return type("Response", (), {"status_code": 200, "json": lambda: {}})()
         raise NotImplementedError(f"Mocked get request to {url} not implemented")
 
-    monkeypatch.setattr(engine.requests, "get", hacked_get)
+    monkeypatch.setattr(serving.requests, "get", hacked_get)
 
     yield mock_instance
 

--- a/tests/endtoend_tests/test_docker_client.py
+++ b/tests/endtoend_tests/test_docker_client.py
@@ -12,6 +12,7 @@ import docker
 import pytest
 from common import image_exists
 
+from tesseract_core.sdk.config import get_config
 from tesseract_core.sdk.docker_client import (
     ContainerError,
     ImageNotFound,
@@ -396,6 +397,50 @@ def test_volume_uid_permissions(
     )
     stdout = run_tesseract_with_volume(cmd, volume=volume_args)
     assert stdout == b"hello\n"
+
+
+def test_container_status_needs_a_reload_like_docker_py(docker_client):
+    """`status` reports the last read; `reload` and `is_running` ask again.
+
+    Matching docker-py, which caches `attrs` and refreshes on `reload`. A
+    container that has gone entirely must report "unknown" rather than raising,
+    since callers wait on containers expected to disappear.
+    """
+    import time
+
+    cid = subprocess.run(
+        [*get_config().docker_executable, "run", "-d", "alpine", "sleep", "60"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    try:
+        container = docker_client.containers.get(cid, tesseract_only=False)
+        assert container.status == "running"
+        assert container.is_running()
+
+        subprocess.run(
+            [*get_config().docker_executable, "stop", "-t", "0", cid],
+            capture_output=True,
+            check=True,
+        )
+        time.sleep(2)
+
+        # Cached, as docker-py would be, until asked again
+        assert container.status == "running"
+        assert not container.is_running()
+        assert container.status == "exited"
+
+        # Immutable config survives a reload
+        assert container.attrs["Config"]["Image"] == "alpine"
+    finally:
+        subprocess.run(
+            [*get_config().docker_executable, "rm", "-f", cid], capture_output=True
+        )
+
+    container.reload()
+    assert container.status == "unknown"
+    assert not container.is_running()
 
 
 def test_get_image_not_found(docker_client):

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -10,6 +10,7 @@ from contextlib import closing
 from pathlib import Path
 
 import pytest
+import requests
 import yaml
 from jinja2.exceptions import TemplateNotFound
 
@@ -1088,7 +1089,7 @@ def test_serve_retries_on_port_in_use(mocked_docker, monkeypatch):
     seen_ports = []
     fail_times = 2  # fail the first two attempts, succeed on the third
 
-    def flaky_health(container, ping_ip, port, timeout=30):
+    def flaky_health(container, ping_ip, port, timeout):
         seen_ports.append(port)
         if len(seen_ports) <= fail_times:
             raise engine._PortInUseError(f"Port {port} was already in use")
@@ -1151,10 +1152,62 @@ def test_serve_reraises_non_port_container_error(mocked_docker, monkeypatch):
         engine.serve("foobar")
 
 
+# `docker inspect` state, as recorded for a container that has stopped. Verified
+# against Docker: an OOM kill reports both the flag and code 137.
+_OOM_KILLED = {"Running": False, "OOMKilled": True, "ExitCode": 137, "Error": ""}
+_EXITED = {"Running": False, "OOMKilled": False, "ExitCode": 1, "Error": ""}
+_DAEMON_ERROR = {
+    "Running": False,
+    "OOMKilled": False,
+    "ExitCode": 127,
+    "Error": 'exec: "tesseract-runtime": not found',
+}
+
+
+@pytest.mark.parametrize(
+    "state,expected",
+    [
+        (_OOM_KILLED, "exceeding its memory limit"),
+        (_DAEMON_ERROR, 'Docker reported: exec: "tesseract-runtime": not found'),
+        (_EXITED, ""),
+    ],
+)
+def test_container_diagnoses_its_own_exit(state, expected):
+    """A stopped container can say things its logs cannot -- an OOM kill writes nothing."""
+    container = Container(
+        id="abc123", short_id="abc123", name="vectoradd", attrs={"State": state}
+    )
+    assert expected in container.diagnose_exit(logs="")
+    assert container.exit_code() == state["ExitCode"]
+
+
+def test_serve_disposes_of_a_container_that_never_starts(mocked_docker, monkeypatch):
+    """A container that fails to become healthy is removed, not left lying around.
+
+    Everything it knew goes into the error before it goes, and the port-conflict
+    retry path would otherwise leave one behind per attempt.
+    """
+    torn_down = []
+
+    def unreachable(*args, **kwargs):
+        raise requests.exceptions.ConnectionError("nothing listening")
+
+    # The fixture answers /health with a 200; this container never will, and is
+    # not running, so waiting gives up on it immediately.
+    monkeypatch.setattr(serving.requests, "get", unreachable)
+    monkeypatch.setattr(Container, "is_running", lambda self: False)
+    monkeypatch.setattr(Container, "teardown", lambda self: torn_down.append(self))
+
+    with pytest.raises(RuntimeError, match="stopped running during startup"):
+        engine.serve("foobar")
+
+    assert len(torn_down) == 1
+
+
 def test_serve_gives_up_after_max_port_attempts(mocked_docker, monkeypatch):
     """If every attempt loses the port race, serve raises rather than looping forever."""
 
-    def always_in_use(container, ping_ip, port, timeout=30):
+    def always_in_use(container, ping_ip, port, timeout):
         raise engine._PortInUseError(f"Port {port} was already in use")
 
     monkeypatch.setattr(engine, "_wait_for_health", always_in_use)
@@ -1171,7 +1224,7 @@ def test_serve_does_not_retry_user_supplied_port(mocked_docker, monkeypatch):
     """
     attempts = []
 
-    def always_in_use(container, ping_ip, port, timeout=30):
+    def always_in_use(container, ping_ip, port, timeout):
         attempts.append(port)
         raise engine._PortInUseError(f"Port {port} was already in use")
 

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -13,7 +13,7 @@ import pytest
 import yaml
 from jinja2.exceptions import TemplateNotFound
 
-from tesseract_core.sdk import engine
+from tesseract_core.sdk import engine, serving
 from tesseract_core.sdk.api_parse import (
     TesseractBuildConfig,
     TesseractConfig,
@@ -798,7 +798,7 @@ def test_serve_skip_health_check(mocked_docker, monkeypatch):
             return type("Response", (), {"status_code": 200, "json": dict})()
         raise NotImplementedError(f"Mocked get request to {url} not implemented")
 
-    monkeypatch.setattr(engine.requests, "get", health_get_spy)
+    monkeypatch.setattr(serving.requests, "get", health_get_spy)
 
     res, _ = engine.serve("foobar", skip_health_check=True)
     assert res

--- a/tests/sdk_tests/test_engine.py
+++ b/tests/sdk_tests/test_engine.py
@@ -1062,6 +1062,33 @@ def test_container_debugpy_host_defaults_to_all_interfaces(mocked_docker):
     assert json.loads(res)["environment"]["TESSERACT_DEBUGPY_HOST"] == "0.0.0.0"
 
 
+def test_port_conflict_detected_in_wrapped_traceback():
+    """A conflict must be recognised even when rich has wrapped the message.
+
+    An uncaught error in the runtime is rendered into a fixed-width box, and
+    debugpy's message is long enough to be split across two lines. Matching the
+    raw text misses it, so a real port collision is reported as an unexplained
+    startup failure instead of being retried.
+    """
+    # Verbatim from a real debugpy bind failure captured through the runtime CLI
+    wrapped = (
+        "RuntimeError: Can't listen for client connections: [Errno 48] Address "
+        "already in\nuse"
+    )
+
+    assert engine._is_port_conflict(wrapped)
+    # Unwrapped forms must keep working
+    assert engine._is_port_conflict("[Errno 98] Address already in use")
+    assert engine._is_port_conflict("port is already allocated")
+    # Windows words it entirely differently for the same condition
+    assert engine._is_port_conflict(
+        "RuntimeError: Can't listen for client connections: [WinError 10048] Only "
+        "one usage of each socket address (protocol/network address/port) is "
+        "normally permitted"
+    )
+    assert not engine._is_port_conflict("some unrelated failure")
+
+
 def test_serve_container_port_decoupled_from_host_port(mocked_docker):
     """The container-side API port is fixed and independent of the host port.
 
@@ -1086,13 +1113,13 @@ def test_serve_retries_on_port_in_use(mocked_docker, monkeypatch):
     fails to bind it) should cause serve to pick a fresh port and try again,
     rather than surfacing the failure to the caller.
     """
-    seen_ports = []
+    seen_urls = []
     fail_times = 2  # fail the first two attempts, succeed on the third
 
-    def flaky_health(container, ping_ip, port, timeout):
-        seen_ports.append(port)
-        if len(seen_ports) <= fail_times:
-            raise engine._PortInUseError(f"Port {port} was already in use")
+    def flaky_health(served, url, timeout):
+        seen_urls.append(url)
+        if len(seen_urls) <= fail_times:
+            raise engine._PortInUseError(f"{url} was already in use")
         # success -> return normally
 
     monkeypatch.setattr(engine, "_wait_for_health", flaky_health)
@@ -1100,10 +1127,8 @@ def test_serve_retries_on_port_in_use(mocked_docker, monkeypatch):
     res, _ = engine.serve("foobar")
     assert res
     # It retried until success and used a distinct port each time.
-    assert len(seen_ports) == fail_times + 1
-    assert len(set(seen_ports)) == len(seen_ports), (
-        f"retries reused a port: {seen_ports}"
-    )
+    assert len(seen_urls) == fail_times + 1
+    assert len(set(seen_urls)) == len(seen_urls), f"retries reused a port: {seen_urls}"
 
 
 def test_serve_retries_on_docker_publish_conflict(mocked_docker, monkeypatch):
@@ -1152,6 +1177,29 @@ def test_serve_reraises_non_port_container_error(mocked_docker, monkeypatch):
         engine.serve("foobar")
 
 
+def test_serve_disposes_of_a_container_that_never_starts(mocked_docker, monkeypatch):
+    """A container that fails to become healthy is removed, not left lying around.
+
+    Its logs are reported before it goes, so nothing is lost by removing it -- and
+    the port-conflict retry path would otherwise leave one behind per attempt.
+    """
+    torn_down = []
+
+    def unreachable(*args, **kwargs):
+        raise requests.exceptions.ConnectionError("nothing listening")
+
+    # The fixture answers /health with a 200; this container never will, and is
+    # not running, so waiting gives up on it immediately.
+    monkeypatch.setattr(serving.requests, "get", unreachable)
+    monkeypatch.setattr(Container, "is_running", lambda self: False)
+    monkeypatch.setattr(Container, "teardown", lambda self: torn_down.append(self))
+
+    with pytest.raises(RuntimeError, match="stopped running during startup"):
+        engine.serve("foobar")
+
+    assert len(torn_down) == 1
+
+
 # `docker inspect` state, as recorded for a container that has stopped. Verified
 # against Docker: an OOM kill reports both the flag and code 137.
 _OOM_KILLED = {"Running": False, "OOMKilled": True, "ExitCode": 137, "Error": ""}
@@ -1172,7 +1220,7 @@ _DAEMON_ERROR = {
         (_EXITED, ""),
     ],
 )
-def test_container_diagnoses_its_own_exit(state, expected):
+def test_container_diagnoses_its_own_failure(state, expected):
     """A stopped container can say things its logs cannot -- an OOM kill writes nothing."""
     container = Container(
         id="abc123", short_id="abc123", name="vectoradd", attrs={"State": state}
@@ -1181,34 +1229,11 @@ def test_container_diagnoses_its_own_exit(state, expected):
     assert container.exit_code() == state["ExitCode"]
 
 
-def test_serve_disposes_of_a_container_that_never_starts(mocked_docker, monkeypatch):
-    """A container that fails to become healthy is removed, not left lying around.
-
-    Everything it knew goes into the error before it goes, and the port-conflict
-    retry path would otherwise leave one behind per attempt.
-    """
-    torn_down = []
-
-    def unreachable(*args, **kwargs):
-        raise requests.exceptions.ConnectionError("nothing listening")
-
-    # The fixture answers /health with a 200; this container never will, and is
-    # not running, so waiting gives up on it immediately.
-    monkeypatch.setattr(serving.requests, "get", unreachable)
-    monkeypatch.setattr(Container, "is_running", lambda self: False)
-    monkeypatch.setattr(Container, "teardown", lambda self: torn_down.append(self))
-
-    with pytest.raises(RuntimeError, match="stopped running during startup"):
-        engine.serve("foobar")
-
-    assert len(torn_down) == 1
-
-
 def test_serve_gives_up_after_max_port_attempts(mocked_docker, monkeypatch):
     """If every attempt loses the port race, serve raises rather than looping forever."""
 
-    def always_in_use(container, ping_ip, port, timeout):
-        raise engine._PortInUseError(f"Port {port} was already in use")
+    def always_in_use(served, url, timeout):
+        raise engine._PortInUseError(f"{url} was already in use")
 
     monkeypatch.setattr(engine, "_wait_for_health", always_in_use)
 
@@ -1224,9 +1249,9 @@ def test_serve_does_not_retry_user_supplied_port(mocked_docker, monkeypatch):
     """
     attempts = []
 
-    def always_in_use(container, ping_ip, port, timeout):
-        attempts.append(port)
-        raise engine._PortInUseError(f"Port {port} was already in use")
+    def always_in_use(served, url, timeout):
+        attempts.append(url)
+        raise engine._PortInUseError(f"{url} was already in use")
 
     monkeypatch.setattr(engine, "_wait_for_health", always_in_use)
 
@@ -1234,7 +1259,7 @@ def test_serve_does_not_retry_user_supplied_port(mocked_docker, monkeypatch):
         engine.serve("foobar", port="12345")
 
     # Exactly one attempt, on the exact port requested.
-    assert attempts == ["12345"]
+    assert attempts == ["http://127.0.0.1:12345"]
 
 
 def test_needs_docker(mocked_docker, monkeypatch):

--- a/tests/sdk_tests/test_local_engine.py
+++ b/tests/sdk_tests/test_local_engine.py
@@ -6,6 +6,7 @@ These spawn real ``tesseract-runtime serve`` processes (but no containers), so
 they exercise the actual startup / health-check / teardown path.
 """
 
+import gc
 import os
 import re
 import shutil
@@ -341,12 +342,48 @@ def test_rejects_imported_module(dummy_tesseract_module):
         )
 
 
-def test_rejects_binref_without_output_path(dummy_api_path):
-    with pytest.raises(ValueError, match="output_path is required"):
-        Tesseract.from_source(
-            dummy_api_path,
-            output_format="json+binref",
-        )
+def test_binref_works_without_being_given_directories(dummy_api_path, sample_inputs):
+    """Binref needs scratch dirs; not being told about them is not the user's problem."""
+    with Tesseract.from_source(dummy_api_path, output_format="json+binref") as tess:
+        result = tess.apply(sample_inputs)
+
+    assert result["result"].shape == sample_inputs["a"].shape
+
+
+def test_auto_created_scratch_dirs_are_purged(dummy_api_path, sample_inputs):
+    """What we made, we clean up -- unlike directories the caller passed in."""
+    tess = Tesseract.from_source(dummy_api_path, output_format="json+binref")
+    scratch = [
+        Path(tess._spawn_config["input_path"]),
+        Path(tess._spawn_config["output_path"]),
+    ]
+    assert all(d.exists() for d in scratch)
+
+    with tess:
+        tess.apply(sample_inputs)
+    del tess
+    gc.collect()
+
+    assert not any(d.exists() for d in scratch)
+
+
+def test_given_scratch_dirs_are_left_alone(dummy_api_path, sample_inputs, tmp_path):
+    given_in, given_out = tmp_path / "in", tmp_path / "out"
+    given_in.mkdir()
+    given_out.mkdir()
+
+    tess = Tesseract.from_source(
+        dummy_api_path,
+        input_path=given_in,
+        output_path=given_out,
+        output_format="json+binref",
+    )
+    with tess:
+        tess.apply(sample_inputs)
+    del tess
+    gc.collect()
+
+    assert given_in.exists() and given_out.exists()
 
 
 def test_container_info_unavailable(dummy_api_path):

--- a/tests/sdk_tests/test_local_engine.py
+++ b/tests/sdk_tests/test_local_engine.py
@@ -1,0 +1,540 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for serving Tesseracts in dedicated subprocesses.
+
+These spawn real ``tesseract-runtime serve`` processes (but no containers), so
+they exercise the actual startup / health-check / teardown path.
+"""
+
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+import requests
+
+from tesseract_core import Tesseract
+from tesseract_core.sdk import local_client, local_engine
+
+pytestmark = pytest.mark.timeout(120)
+
+
+def _env_without_pythonpath() -> dict[str, str]:
+    """Environment safe to hand to a different interpreter.
+
+    Importing a tesseract_api.py in-process puts this interpreter's sys.path on
+    PYTHONPATH as a side effect, and any earlier test in the session may have
+    done so. A 3.11 interpreter that inherits it picks up 3.13 packages.
+    """
+    return {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+
+
+@pytest.fixture
+def dummy_api_path(dummy_tesseract_package):
+    return dummy_tesseract_package / "tesseract_api.py"
+
+
+@pytest.fixture
+def sample_inputs():
+    return {
+        "a": np.array([1.0, 2.0], dtype=np.float32),
+        "b": np.array([3.0, 4.0], dtype=np.float32),
+        "s": 2,
+    }
+
+
+def test_serve_and_teardown(dummy_api_path):
+    served = local_engine.serve(dummy_api_path)
+    try:
+        assert served.is_running()
+        assert served.port != 0
+    finally:
+        logs = served.logs().decode()
+        served.teardown()
+
+    assert not served.is_running()
+    if os.name != "nt":
+        # Windows refuses to delete a file a just-killed child may still hold, so
+        # teardown tolerates that and leaves it in the temp directory.
+        assert not served.log_path.exists()
+    # uvicorn announces itself on startup; if we captured nothing, log capture
+    # is broken even though the health check passed.
+    assert logs.strip()
+
+
+def test_teardown_is_idempotent(dummy_api_path):
+    served = local_engine.serve(dummy_api_path)
+    served.teardown()
+    # Must not raise, even though the process and its log file are gone
+    served.teardown()
+    # The logs, though, really are gone -- as they are for a removed container.
+    with pytest.raises(FileNotFoundError):
+        served.logs()
+
+
+def test_serve_rejects_missing_api():
+    with pytest.raises(FileNotFoundError, match="is not a file"):
+        local_engine.serve("/nonexistent/tesseract_api.py")
+
+
+def test_serve_on_explicit_port(dummy_api_path):
+    from tesseract_core.sdk.engine import get_free_port
+
+    port = get_free_port()
+    served = local_engine.serve(dummy_api_path, port=port)
+    try:
+        assert served.port == port
+        assert served.url.endswith(f":{port}")
+    finally:
+        served.teardown()
+
+
+def test_endpoints_over_subprocess(dummy_api_path, sample_inputs):
+    with Tesseract.from_source(dummy_api_path) as tess:
+        result = tess.apply(sample_inputs)
+        np.testing.assert_allclose(result["result"], [5.0, 8.0])
+
+        assert tess.health()["status"] == "ok"
+
+        # debug mode is on by default, mirroring the in-process path, so the
+        # test endpoint must be available
+        assert "test" in tess.available_endpoints
+
+
+def test_runs_in_a_different_process(dummy_tesseract_package, sample_inputs):
+    """The whole point: the Tesseract must not share our interpreter."""
+    api_path = dummy_tesseract_package / "tesseract_api.py"
+    api_path.write_text(
+        api_path.read_text()
+        + textwrap.dedent(
+            """
+
+            def _pid_check(inputs):
+                import os
+                return os.getpid()
+            """
+        )
+    )
+
+    tess = Tesseract.from_source(api_path)
+    with tess:
+        process = tess._serve_context.process
+        assert process.pid != os.getpid()
+        assert process.poll() is None
+
+    assert process.poll() is not None
+
+
+def test_teardown_stops_the_process(dummy_api_path):
+    tess = Tesseract.from_source(dummy_api_path)
+    tess.serve()
+    served = tess._serve_context
+    assert served.is_running()
+
+    tess.teardown()
+
+    assert not served.is_running()
+    assert tess._client is None
+    assert tess._serve_context is None
+
+
+def test_garbage_collection_reaps_process(dummy_api_path):
+    """A forgotten Tesseract must not leave an orphaned process behind."""
+    import gc
+
+    tess = Tesseract.from_source(dummy_api_path)
+    tess.serve()
+    # Hold the process, not the Tesseract, so it can still be collected.
+    process = tess._serve_context.process
+
+    del tess
+    gc.collect()
+
+    assert process.poll() is not None
+
+
+def test_logs_are_captured(dummy_api_path):
+    tess = Tesseract.from_source(dummy_api_path)
+    with tess:
+        assert "Uvicorn running" in tess.server_logs()
+
+    # Logs remain available after teardown
+    assert "Uvicorn running" in tess.server_logs()
+
+
+def test_stream_logs_without_output_path(dummy_api_path, sample_inputs):
+    """Streaming must work without the caller specifying an output directory."""
+    lines = []
+
+    with Tesseract.from_source(dummy_api_path, stream_logs=lines.append) as tess:
+        tess.apply(sample_inputs)
+
+    # The dummy Tesseract logs nothing itself, so assert on the mechanism having
+    # run rather than on content: a missing output path would have raised.
+    assert isinstance(lines, list)
+
+
+def _debug_address(served):
+    """Read the debug address a served Tesseract reported binding."""
+    match = re.search(r"Debugger listening on ([\d.]+):(\d+)", served.logs().decode())
+    return (match.group(1), int(match.group(2))) if match else None
+
+
+def test_debugger_listens_on_loopback_by_default(dummy_api_path):
+    """Debugging is the point of a non-containerized Tesseract, so it's on...
+
+    ...but on loopback: unlike a container, there is no network namespace here,
+    and debugpy is unauthenticated code execution.
+    """
+    served = local_engine.serve(dummy_api_path, runtime_config={"debug": True})
+    try:
+        host, port = _debug_address(served)
+        assert host == "127.0.0.1"
+        assert port != served.port, "Debugger must not share the API port"
+    finally:
+        served.teardown()
+
+
+def test_two_tesseracts_get_distinct_debugpy_ports(dummy_api_path):
+    """The whole reason the address is configurable: both must be debuggable."""
+    first = local_engine.serve(dummy_api_path, runtime_config={"debug": True})
+    second = local_engine.serve(dummy_api_path, runtime_config={"debug": True})
+    try:
+        assert _debug_address(first) != _debug_address(second)
+    finally:
+        first.teardown()
+        second.teardown()
+
+
+def test_debugpy_port_collision_recovers_even_with_a_pinned_api_port(
+    dummy_api_path, monkeypatch
+):
+    """A collision on a port we chose must be retried, not surfaced.
+
+    The API port can be pinned by the caller while the debug port is still
+    picked automatically. Deciding retriability from the API port alone would
+    refuse to recover from a collision of our own making.
+    """
+    import socket
+    from contextlib import closing
+
+    from tesseract_core.sdk.engine import get_free_port
+
+    api_port = get_free_port()
+    taken = get_free_port(exclude=(api_port,))
+    calls = []
+
+    def fake_get_free_port(within_range=None, exclude=()):
+        # Hand out an already-bound port first, a usable one afterwards.
+        calls.append(1)
+        return taken if len(calls) == 1 else get_free_port(exclude=(api_port, taken))
+
+    monkeypatch.setattr(local_engine, "get_free_port", fake_get_free_port)
+
+    with closing(socket.socket()) as occupied:
+        occupied.bind(("127.0.0.1", taken))
+        occupied.listen(1)
+
+        served = local_engine.serve(
+            dummy_api_path, port=api_port, runtime_config={"debug": True}
+        )
+        try:
+            assert served.is_running()
+            _, port = _debug_address(served)
+            assert port != taken, "retried onto the port that was already in use"
+            assert served.port == api_port, "pinned API port must be honoured"
+        finally:
+            served.teardown()
+
+
+def test_inherited_runtime_override_cannot_hijack_the_debugpy_port(
+    dummy_api_path, monkeypatch
+):
+    """An exported setting must not override the port we picked per Tesseract.
+
+    The child inherits our environment, so a TESSERACT_RUNTIME_DEBUGPY_PORT the
+    caller exported is already there -- and typer resolves it as a CLI option,
+    which beats the TESSERACT_DEBUGPY_PORT we set. Every Tesseract would land on
+    the same port and the second would fail to start.
+    """
+    monkeypatch.setenv("TESSERACT_RUNTIME_DEBUGPY_PORT", "47777")
+
+    with (
+        Tesseract.from_source(dummy_api_path) as first,
+        Tesseract.from_source(dummy_api_path) as second,
+    ):
+        ports = {_debug_address(t._serve_context)[1] for t in (first, second)}
+
+    assert len(ports) == 2, "both Tesseracts used the inherited port"
+    assert 47777 not in ports
+
+
+def test_debugger_can_be_opted_out(dummy_api_path):
+    """Turning off debug mode must also mean no debugger.
+
+    Debug mode is what starts a debugger, here as everywhere else, so there is
+    no separate knob to disable one -- which is what someone running dedicated
+    processes for isolation rather than debugging wants anyway, since debug mode
+    also exposes tracebacks and the `test` endpoint.
+    """
+    served = local_engine.serve(dummy_api_path, runtime_config={"debug": False})
+    try:
+        assert _debug_address(served) is None
+    finally:
+        logs = served.logs().decode()
+        served.teardown()
+
+    assert "Debugger listening" not in logs
+
+
+def test_two_tesseracts_get_distinct_ports(dummy_api_path, sample_inputs):
+    with (
+        Tesseract.from_source(dummy_api_path) as first,
+        Tesseract.from_source(dummy_api_path) as second,
+    ):
+        assert first._client.url != second._client.url
+        np.testing.assert_allclose(first.apply(sample_inputs)["result"], [5.0, 8.0])
+        np.testing.assert_allclose(second.apply(sample_inputs)["result"], [5.0, 8.0])
+
+
+def test_runtime_config_does_not_leak_into_parent(dummy_api_path):
+    """Config goes to the child as env vars, not into our own runtime config."""
+    from tesseract_core.runtime.config import get_config
+
+    before = get_config().output_format
+
+    with Tesseract.from_source(dummy_api_path, output_format="json"):
+        assert get_config().output_format == before
+
+
+def test_requires_context_manager(dummy_api_path, sample_inputs):
+    tess = Tesseract.from_source(dummy_api_path)
+    with pytest.raises(RuntimeError, match="from_source"):
+        tess.apply(sample_inputs)
+
+
+def test_rejects_imported_module(dummy_tesseract_module):
+    """A module cannot be handed to another process, so say so clearly.
+
+    Tested against the helper rather than `from_source`, whose annotation lets
+    typeguard reject it first under the test suite -- but nothing enforces
+    annotations at runtime, so the check still has to exist.
+    """
+    from tesseract_core.sdk.tesseract import _subprocess_spawn_config
+
+    with pytest.raises(ValueError, match="already imported module was given"):
+        _subprocess_spawn_config(
+            dummy_tesseract_module,
+            input_path=None,
+            output_path=None,
+            output_format="json+base64",
+            runtime_config=None,
+            python_executable=None,
+            startup_timeout=1.0,
+        )
+
+
+def test_rejects_binref_without_output_path(dummy_api_path):
+    with pytest.raises(ValueError, match="output_path is required"):
+        Tesseract.from_source(
+            dummy_api_path,
+            output_format="json+binref",
+        )
+
+
+def test_container_info_unavailable(dummy_api_path):
+    tess = Tesseract.from_source(dummy_api_path)
+    with pytest.raises(RuntimeError, match="from_image"):
+        tess.container_info()
+
+
+def test_startup_failure_surfaces_child_traceback(tmp_path):
+    api_path = tmp_path / "tesseract_api.py"
+    api_path.write_text("raise RuntimeError('kaboom at import time')\n")
+
+    tess = Tesseract.from_source(api_path)
+    with pytest.raises(RuntimeError) as excinfo:
+        tess.serve()
+
+    message = str(excinfo.value)
+    assert "stopped running during startup (exit code 1)" in message
+    assert "kaboom at import time" in message
+
+
+def test_failed_startup_leaves_no_log_file(tmp_path):
+    """The captured output is read into the error, so its file has served its purpose."""
+    api_path = tmp_path / "tesseract_api.py"
+    api_path.write_text("raise RuntimeError('kaboom at import time')\n")
+
+    temp_dir = Path(tempfile.gettempdir())
+    before = set(temp_dir.glob("tesseract_serve_*.log"))
+
+    with pytest.raises(RuntimeError):
+        local_engine.serve(api_path)
+
+    assert not set(temp_dir.glob("tesseract_serve_*.log")) - before
+
+
+def test_startup_timeout_is_reported(dummy_api_path, monkeypatch):
+    """A Tesseract that never becomes healthy reports a timeout, not a crash."""
+
+    def never_healthy(*args, **kwargs):
+        raise requests.exceptions.ConnectionError("nope")
+
+    monkeypatch.setattr(requests, "get", never_healthy)
+
+    with pytest.raises(TimeoutError, match="did not respond to a health check"):
+        local_engine.serve(dummy_api_path, startup_timeout=1.0)
+
+
+def test_skip_health_check_returns_immediately(dummy_api_path):
+    served = local_engine.serve(dummy_api_path, skip_health_check=True)
+    try:
+        assert served.is_running()
+    finally:
+        served.teardown()
+
+
+@pytest.fixture(scope="session")
+def foreign_venv(tmp_path_factory):
+    """A separate environment running a different Python from this one.
+
+    This is what makes subprocess isolation worth more than a nicety: the
+    Tesseract need not be installable alongside the caller. Deliberately no
+    version pins beyond the interpreter -- CI rewrites the runtime extras to
+    exact pins on its oldest-dependency axis, so anything we add here can
+    conflict with them.
+    """
+    uv = shutil.which("uv")
+    if uv is None:
+        pytest.skip("uv is required to build a foreign environment")
+
+    # Any supported version that is not the one running the tests.
+    ours = f"{sys.version_info.major}.{sys.version_info.minor}"
+    foreign = next(v for v in ("3.12", "3.11", "3.13") if v != ours)
+
+    venv_dir = tmp_path_factory.mktemp("foreign_venv") / "env"
+    repo_root = Path(__file__).parents[2]
+    env = _env_without_pythonpath()
+
+    def run(*args):
+        result = subprocess.run(args, capture_output=True, text=True, env=env)
+        if result.returncode != 0:
+            pytest.skip(
+                f"could not build a Python {foreign} environment: "
+                f"{result.stderr.strip()[-300:]}"
+            )
+
+    run(uv, "venv", str(venv_dir), "--python", foreign)
+    run(uv, "pip", "install", "--python", str(venv_dir), f"{repo_root}[runtime]")
+
+    scripts, exe = ("Scripts", "python.exe") if os.name == "nt" else ("bin", "python")
+    return venv_dir / scripts / exe, foreign
+
+
+def test_foreign_interpreter_does_not_inherit_our_import_paths(monkeypatch):
+    """Our sys.path must not follow a Tesseract into a different environment."""
+    monkeypatch.setenv("PYTHONPATH", "/some/other/site-packages")
+    monkeypatch.setenv("VIRTUAL_ENV", "/some/other/env")
+
+    same = local_engine._runtime_env(
+        Path("tesseract_api.py"),
+        input_path=None,
+        output_path=None,
+        output_format=None,
+        runtime_config=None,
+        environment=None,
+        foreign_interpreter=False,
+    )
+    assert same["PYTHONPATH"] == "/some/other/site-packages"
+
+    foreign = local_engine._runtime_env(
+        Path("tesseract_api.py"),
+        input_path=None,
+        output_path=None,
+        output_format=None,
+        runtime_config=None,
+        environment=None,
+        foreign_interpreter=True,
+    )
+    assert "PYTHONPATH" not in foreign
+    assert "VIRTUAL_ENV" not in foreign
+
+    # ...unless the caller insists
+    explicit = local_engine._runtime_env(
+        Path("tesseract_api.py"),
+        input_path=None,
+        output_path=None,
+        output_format=None,
+        runtime_config=None,
+        environment={"PYTHONPATH": "/deliberate"},
+        foreign_interpreter=True,
+    )
+    assert explicit["PYTHONPATH"] == "/deliberate"
+
+
+def test_missing_interpreter_is_reported(dummy_api_path):
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        local_engine.serve(dummy_api_path, python_executable="/nonexistent/bin/python")
+
+
+@pytest.mark.foreign_venv
+def test_tesseract_in_foreign_environment(foreign_venv, dummy_api_path, sample_inputs):
+    """A Tesseract runs under an interpreter the caller could not have used."""
+    interpreter, foreign_version = foreign_venv
+
+    reported = subprocess.run(
+        [str(interpreter), "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_env_without_pythonpath(),
+    ).stdout.strip()
+
+    # Guard the premise: same interpreter would prove nothing
+    assert reported == foreign_version
+    assert reported != f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    with Tesseract.from_source(
+        dummy_api_path,
+        python_executable=interpreter,
+    ) as tess:
+        result = tess.apply(sample_inputs)
+
+    np.testing.assert_allclose(result["result"], [5.0, 8.0])
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX process groups")
+def test_child_runs_in_its_own_process_group(dummy_api_path):
+    """So that a Ctrl-C in the parent's terminal doesn't race us to the child."""
+    served = local_engine.serve(dummy_api_path)
+    try:
+        assert os.getpgid(served.process.pid) != os.getpgid(os.getpid())
+    finally:
+        served.teardown()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX signals")
+def test_teardown_escalates_to_sigkill(dummy_api_path):
+    """A Tesseract that ignores SIGTERM still gets cleaned up."""
+    served = local_engine.serve(dummy_api_path)
+
+    # Make the child ignore SIGTERM by shortening our patience instead of
+    # modifying the child: escalation must happen either way.
+    monkeypatched_timeout = 0.5
+    original = local_client._TERMINATE_TIMEOUT
+    local_client._TERMINATE_TIMEOUT = monkeypatched_timeout
+    try:
+        os.killpg(os.getpgid(served.process.pid), signal.SIGSTOP)  # ignores SIGTERM
+        served.teardown()
+    finally:
+        local_client._TERMINATE_TIMEOUT = original
+
+    assert served.process.poll() is not None

--- a/tests/sdk_tests/test_local_engine.py
+++ b/tests/sdk_tests/test_local_engine.py
@@ -386,6 +386,22 @@ def test_given_scratch_dirs_are_left_alone(dummy_api_path, sample_inputs, tmp_pa
     assert given_in.exists() and given_out.exists()
 
 
+def test_binref_pool_is_available_without_a_linux_host(dummy_api_path, sample_inputs):
+    """The pool is barred for containers off Linux, not for a plain subprocess.
+
+    A container elsewhere runs in a VM, so bind mounts cross the VM boundary and
+    client and server never share a page cache. Two processes on one host do.
+    """
+    tess = Tesseract.from_source(
+        dummy_api_path, output_format="json+binref", experimental_binref_pool=True
+    )
+    with tess:
+        assert tess._client._binref_pool is not None
+        result = tess.apply(sample_inputs)
+
+    assert result["result"].shape == sample_inputs["a"].shape
+
+
 def test_container_info_unavailable(dummy_api_path):
     tess = Tesseract.from_source(dummy_api_path)
     with pytest.raises(RuntimeError, match="from_image"):

--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -9,6 +9,7 @@ import requests
 from pydantic import ValidationError
 
 from tesseract_core import Tesseract
+from tesseract_core.sdk import engine
 from tesseract_core.sdk.docker_client import Container
 from tesseract_core.sdk.tesseract import (
     HTTPClient,
@@ -229,6 +230,7 @@ def test_serve_lifecycle(mock_serving, mock_clients):
         "docker_args": None,
         "runtime_config": None,
         "skip_health_check": False,
+        "startup_timeout": engine.DEFAULT_STARTUP_TIMEOUT,
     }
 
     for key, expected_value in expected_kwargs.items():

--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -1,3 +1,4 @@
+import os
 from unittest.mock import MagicMock, Mock
 
 import numpy as np
@@ -647,13 +648,12 @@ def testencode_array_binref_pooled_falls_back_and_decodes_correctly(tmp_path):
 
 def test_binref_pool_lazy_decode_is_readonly_view(tmp_path):
     from tesseract_core.sdk.binref import (
-        SUPPORTS_BINREF_POOL,
         BinrefWritePool,
         encode_array_binref_pooled,
     )
 
-    if not SUPPORTS_BINREF_POOL:
-        pytest.skip("binref pool / lazy decode is Linux-only")
+    if os.name != "posix":
+        pytest.skip("the pool and its mmap decode are POSIX-only")
 
     pool = BinrefWritePool(tmp_path, max_slots=4)
     try:
@@ -673,13 +673,12 @@ def test_binref_pool_lazy_decode_is_readonly_view(tmp_path):
 
 def test_binref_pool_lazy_decode_survives_unlink(tmp_path):
     from tesseract_core.sdk.binref import (
-        SUPPORTS_BINREF_POOL,
         BinrefWritePool,
         encode_array_binref_pooled,
     )
 
-    if not SUPPORTS_BINREF_POOL:
-        pytest.skip("binref pool / lazy decode is Linux-only")
+    if os.name != "posix":
+        pytest.skip("the pool and its mmap decode are POSIX-only")
 
     pool = BinrefWritePool(tmp_path, max_slots=4)
     try:
@@ -708,11 +707,7 @@ def test_binref_pool_lazy_decode_survives_unlink(tmp_path):
 
 
 def test_HTTPClient_binref_pool_only_created_with_input_path(tmp_path):
-    from tesseract_core.sdk.binref import SUPPORTS_BINREF_POOL
     from tesseract_core.sdk.tesseract import HTTPClient
-
-    if not SUPPORTS_BINREF_POOL:
-        pytest.skip("experimental_binref_pool is Linux-only")
 
     # experimental_binref_pool=True without an input_path is meaningless (no
     # mounted dir to put pooled files in), so no pool should be created.
@@ -728,11 +723,7 @@ def test_HTTPClient_binref_pool_only_created_with_input_path(tmp_path):
 
 
 def test_HTTPClient_close_is_idempotent(tmp_path):
-    from tesseract_core.sdk.binref import SUPPORTS_BINREF_POOL
     from tesseract_core.sdk.tesseract import HTTPClient
-
-    if not SUPPORTS_BINREF_POOL:
-        pytest.skip("experimental_binref_pool is Linux-only")
 
     client = HTTPClient("localhost", input_path=tmp_path, experimental_binref_pool=True)
     client.close()

--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock
 
 import numpy as np
@@ -19,21 +18,50 @@ from tesseract_core.sdk.tesseract import (
 )
 
 
+class FakeContainer(Container):
+    """Stands in for a served container, without touching docker.
+
+    A real `Container` subclass rather than a bare stub, so it satisfies both the
+    `ServedTesseract` interface and the `Container` that `container_info` returns
+    -- a member added to either without one here is an error, not a surprise in
+    production.
+    """
+
+    host_ip = "127.0.0.1"
+    host_port = "1234"
+
+    def __init__(self):
+        super().__init__(
+            id="container-id-123",
+            short_id="container-id",
+            name="container-id-123",
+            attrs={},
+        )
+        self.teardown_calls = 0
+
+    def reload(self) -> None:
+        pass
+
+    def is_running(self) -> bool:
+        return True
+
+    def teardown(self) -> None:
+        self.teardown_calls += 1
+
+    def logs(self) -> bytes:
+        return b"fake container logs"
+
+
 @pytest.fixture
 def mock_serving(mocker):
-    fake_container = SimpleNamespace()
-    fake_container.host_port = 1234
-    fake_container.id = "container-id-123"
+    fake_container = FakeContainer()
 
     serve_mock = mocker.patch("tesseract_core.sdk.engine.serve")
     serve_mock.return_value = fake_container.id, fake_container
 
-    teardown_mock = mocker.patch("tesseract_core.sdk.engine.teardown")
-    logs_mock = mocker.patch("tesseract_core.sdk.engine.logs")
     return {
         "serve_mock": serve_mock,
-        "teardown_mock": teardown_mock,
-        "logs_mock": logs_mock,
+        "container": fake_container,
     }
 
 
@@ -107,27 +135,14 @@ def test_Tesseract_from_image(mock_serving, mock_clients):
         t.teardown()
 
 
-def test_container_info_returns_container_during_serve(
-    mock_serving, mock_clients, mocker
-):
-    """``container_info()`` returns a fresh ``Container`` while served.
+def test_container_info_returns_container_during_serve(mock_serving, mock_clients):
+    """``container_info()`` returns the container being served.
 
     Each call delegates to ``Containers.get(container_name)``, so we
     patch that lookup and verify the call site forwards the running
     container's name through unchanged. Outside the serve window the
     call must raise.
     """
-    fake_container = Container(
-        id="container-id-123",
-        short_id="container-id",
-        name="container-id-123",
-        attrs={},
-    )
-    get_mock = mocker.patch(
-        "tesseract_core.sdk.tesseract.Containers.get",
-        return_value=fake_container,
-    )
-
     t = Tesseract.from_image("sometesseract:0.2.3")
 
     # Pre-serve: not yet running, so the call raises.
@@ -135,9 +150,8 @@ def test_container_info_returns_container_during_serve(
         t.container_info()
 
     with t:
-        info = t.container_info()
-        assert info is fake_container
-        get_mock.assert_called_with("container-id-123")
+        # The container we are already holding, rather than a fresh lookup
+        assert t.container_info() is mock_serving["container"]
 
     # Post-teardown: container is gone, so the call raises again.
     with pytest.raises(RuntimeError, match="only available for served Tesseracts"):
@@ -157,15 +171,14 @@ def test_del_tesseract_triggers_teardown(mock_serving):
     """Deleting a served Tesseract must tear down its container via weakref.finalize."""
     import gc
 
-    teardown_mock = mock_serving["teardown_mock"]
-
+    container = mock_serving["container"]
     t = Tesseract.from_image("sometesseract:0.2.3")
     t.serve()
-    assert teardown_mock.call_count == 0
+    assert container.teardown_calls == 0
 
     del t
     gc.collect()
-    assert teardown_mock.call_count == 1
+    assert container.teardown_calls == 1
 
 
 def test_del_tesseract_purges_auto_tempdir(mock_serving):
@@ -241,7 +254,7 @@ def test_serve_lifecycle(mock_serving, mock_clients):
     # Check that no unexpected kwargs were passed
     assert call_kwargs.keys() == expected_kwargs.keys() | {"output_path"}
 
-    mock_serving["teardown_mock"].assert_called_with("container-id-123")
+    assert mock_serving["container"].teardown_calls == 1
 
     # check that the same Tesseract obj cannot be used to instantiate two containers
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
Stacked on #669.

`from_source` refused `json+binref` unless you passed `output_path` yourself, and the write pool was gated to Linux — so the fastest transport a dedicated-process Tesseract has was the one thing you could not simply ask for.

### Scratch directories

`from_image` creates an input and an output directory when none are given. `from_source` raised instead. It now creates both, and purges them with the Tesseract — which the output directory it *already* created silently was never doing.

```python
with Tesseract.from_source(api, output_format="json+binref") as t:
    result = t.apply({"x": x})   # nothing else to configure
```

### The write pool

The gate was `sys.platform.startswith("linux")`, for a reason its own comment gives: a container elsewhere runs inside a Linux VM, so bind mounts cross the VM boundary and client and server never share a page cache. That is a fact about *containers*. Two processes on one host share a page cache on any platform.

The check moves to where the knowledge is: `HTTPClient` cannot know how the Tesseract it talks to was started, so it now honours the flag and `Tesseract` decides. Containers still require Linux. Four tests previously skipped off Linux now run, since the pool machinery only needs POSIX.

### Measured (macOS, Apple silicon, 40 MB float64 round trip)

| transport | ms/call |
| --- | --- |
| `json+base64` (default) | 168 |
| `json+binref`, no directories given | 26 |
| `json+binref` + pool, no directories given | 38 |
| `json+binref` + pool on tmpfs | **20** |

Crossover with base64 is ~64 kB — 8192 `float64` elements.

Two findings that shaped this:

- **binref does not need shared memory to be fast.** On APFS it matches tmpfs at every size, because writeback is asynchronous and the reader is served from the page cache. What it costs is disk writes: moving 720 MB of arrays produced 687 MB of device writes.
- **The pool does need it.** On a disk-backed directory it is several times slower than plain binref. So it stays opt-in and is never chosen for you.

Auto-detecting a memory-backed directory and enabling the pool accordingly is the obvious follow-up, deliberately not here.

### Benchmarks

Three `from_source` modes added to the suite so Linux numbers come from CI rather than one laptop: base64, binref with auto-created directories, and binref on `/dev/shm` with the pool. None need Docker; the `/dev/shm` one skips where there is none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)