### PR TITLE
test(runtime): cover the gradient fallbacks with more than one key

### DIFF
--- a/tests/runtime_tests/test_gradient_fallbacks.py
+++ b/tests/runtime_tests/test_gradient_fallbacks.py
@@ -99,6 +99,97 @@ def _J2(x):
     )
 
 
+# Case 3 - two inputs and two outputs of differing rank, so the probe sweeps
+# have to keep one-hot seeds and results matched up across keys and axes:
+#   a: (2, 2), b: (3,)  ->  u: (2,), v: (2, 2)
+#   u[i]    = sum_j a[i,j]^2 + b[i]
+#   v[i,j]  = a[i,j]*b[2] + sin(b[j])
+def _f3(a, b):
+    return {
+        "u": (a**2).sum(axis=1) + b[:2],
+        "v": a * b[2] + np.sin(b[:2])[None, :],
+    }
+
+
+def _J3(a, b):
+    du_da = np.zeros((2, 2, 2))
+    du_db = np.zeros((2, 3))
+    dv_da = np.zeros((2, 2, 2, 2))
+    dv_db = np.zeros((2, 2, 3))
+    for i in range(2):
+        du_da[i, i, :] = 2 * a[i, :]
+        du_db[i, i] = 1.0
+        for j in range(2):
+            dv_da[i, j, i, j] = b[2]
+            dv_db[i, j, 2] = a[i, j]
+            dv_db[i, j, j] += np.cos(b[j])
+    return {"u": {"a": du_da, "b": du_db}, "v": {"a": dv_da, "b": dv_db}}
+
+
+def _make_multi_case():
+    """Build the same 8-tuple as _make_case for the multi-key, multi-rank case.
+
+    The endpoints only answer for the keys they are asked about, which is what
+    a Tesseract does, so a helper that probes with a seed for one key while
+    requesting another is a KeyError rather than a silent wrong answer.
+    """
+    a = np.array([[0.5, -1.2], [2.0, 0.3]])
+    b = np.array([0.7, -0.4, 1.1])
+    inputs = {"a": a, "b": b}
+    tangent = {
+        "a": np.array([[1.0, -0.5], [0.25, 2.0]]),
+        "b": np.array([1.0, -1.0, 0.5]),
+    }
+    cotangent = {"u": np.array([1.0, -2.0]), "v": np.array([[0.5, 1.5], [-1.0, 0.25]])}
+
+    def apply_fn(inputs):
+        return _f3(np.asarray(inputs["a"]), np.asarray(inputs["b"]))
+
+    def abstract_eval_fn(inputs):
+        return {
+            "u": ShapeDType(shape=(2,), dtype="float64"),
+            "v": ShapeDType(shape=(2, 2), dtype="float64"),
+        }
+
+    def jacobian_fn(inputs, jac_inputs, jac_outputs):
+        full = _J3(np.asarray(inputs["a"]), np.asarray(inputs["b"]))
+        return {dy: {dx: full[dy][dx] for dx in jac_inputs} for dy in jac_outputs}
+
+    def vjp_fn(inputs, vjp_inputs, vjp_outputs, cotangent_vector):
+        full = _J3(np.asarray(inputs["a"]), np.asarray(inputs["b"]))
+        out = {}
+        for dx in vjp_inputs:
+            total = np.zeros(np.shape(inputs[dx]))
+            for dy in vjp_outputs:
+                ct = np.asarray(cotangent_vector[dy])
+                total = total + np.tensordot(ct, full[dy][dx], axes=ct.ndim)
+            out[dx] = total
+        return out
+
+    def jvp_fn(inputs, jvp_inputs, jvp_outputs, tangent_vector):
+        full = _J3(np.asarray(inputs["a"]), np.asarray(inputs["b"]))
+        out = {}
+        for dy in jvp_outputs:
+            total = None
+            for dx in jvp_inputs:
+                t = np.asarray(tangent_vector[dx])
+                term = np.tensordot(full[dy][dx], t, axes=t.ndim)
+                total = term if total is None else total + term
+            out[dy] = total
+        return out
+
+    return (
+        inputs,
+        tangent,
+        cotangent,
+        apply_fn,
+        abstract_eval_fn,
+        jacobian_fn,
+        vjp_fn,
+        jvp_fn,
+    )
+
+
 _CASES = [
     pytest.param(
         *_make_case(
@@ -120,6 +211,7 @@ _CASES = [
         ),
         id="tall-R2-R4",
     ),
+    pytest.param(*_make_multi_case(), id="multi-key-multi-rank"),
 ]
 
 
@@ -130,8 +222,11 @@ _CASES = [
 def test_jvp_from_jacobian(
     inputs, tangent, cotangent, apply_fn, abstract_eval_fn, jacobian_fn, vjp_fn, jvp_fn
 ):
-    result = jvp_from_jacobian(jacobian_fn, inputs, {"x"}, {"y"}, tangent)
-    np.testing.assert_allclose(result["y"], jvp_fn(inputs, {"x"}, {"y"}, tangent)["y"])
+    jac_inputs, jac_outputs = set(inputs), set(cotangent)
+    result = jvp_from_jacobian(jacobian_fn, inputs, jac_inputs, jac_outputs, tangent)
+    expected = jvp_fn(inputs, jac_inputs, jac_outputs, tangent)
+    for dy in jac_outputs:
+        np.testing.assert_allclose(result[dy], expected[dy])
 
 
 @pytest.mark.parametrize(
@@ -141,10 +236,11 @@ def test_jvp_from_jacobian(
 def test_vjp_from_jacobian(
     inputs, tangent, cotangent, apply_fn, abstract_eval_fn, jacobian_fn, vjp_fn, jvp_fn
 ):
-    result = vjp_from_jacobian(jacobian_fn, inputs, {"x"}, {"y"}, cotangent)
-    np.testing.assert_allclose(
-        result["x"], vjp_fn(inputs, {"x"}, {"y"}, cotangent)["x"]
-    )
+    jac_inputs, jac_outputs = set(inputs), set(cotangent)
+    result = vjp_from_jacobian(jacobian_fn, inputs, jac_inputs, jac_outputs, cotangent)
+    expected = vjp_fn(inputs, jac_inputs, jac_outputs, cotangent)
+    for dx in jac_inputs:
+        np.testing.assert_allclose(result[dx], expected[dx])
 
 
 @pytest.mark.parametrize(
@@ -164,10 +260,12 @@ def test_jacobian_from_vjp(
     eval_fn_name,
 ):
     eval_fn = apply_fn if eval_fn_name == "apply_fn" else abstract_eval_fn
-    jac = jacobian_from_vjp(vjp_fn, eval_fn, inputs, {"x"}, {"y"})
-    np.testing.assert_allclose(
-        jac["y"]["x"], jacobian_fn(inputs, {"x"}, {"y"})["y"]["x"], rtol=1e-10
-    )
+    jac_inputs, jac_outputs = set(inputs), set(cotangent)
+    jac = jacobian_from_vjp(vjp_fn, eval_fn, inputs, jac_inputs, jac_outputs)
+    expected = jacobian_fn(inputs, jac_inputs, jac_outputs)
+    for dy in jac_outputs:
+        for dx in jac_inputs:
+            np.testing.assert_allclose(jac[dy][dx], expected[dy][dx], rtol=1e-10)
 
 
 @pytest.mark.parametrize(
@@ -177,10 +275,12 @@ def test_jacobian_from_vjp(
 def test_jacobian_from_jvp(
     inputs, tangent, cotangent, apply_fn, abstract_eval_fn, jacobian_fn, vjp_fn, jvp_fn
 ):
-    jac = jacobian_from_jvp(jvp_fn, inputs, {"x"}, {"y"})
-    np.testing.assert_allclose(
-        jac["y"]["x"], jacobian_fn(inputs, {"x"}, {"y"})["y"]["x"], rtol=1e-10
-    )
+    jac_inputs, jac_outputs = set(inputs), set(cotangent)
+    jac = jacobian_from_jvp(jvp_fn, inputs, jac_inputs, jac_outputs)
+    expected = jacobian_fn(inputs, jac_inputs, jac_outputs)
+    for dy in jac_outputs:
+        for dx in jac_inputs:
+            np.testing.assert_allclose(jac[dy][dx], expected[dy][dx], rtol=1e-10)
 
 
 @pytest.mark.parametrize(
@@ -204,10 +304,11 @@ def test_vjp_to_jvp_via_jacobian(
     jac_fn = lambda inputs, jac_inputs, jac_outputs: jacobian_from_vjp(
         vjp_fn, eval_fn, inputs, jac_inputs, jac_outputs
     )
-    result = jvp_from_jacobian(jac_fn, inputs, {"x"}, {"y"}, tangent)
-    np.testing.assert_allclose(
-        result["y"], jvp_fn(inputs, {"x"}, {"y"}, tangent)["y"], rtol=1e-10
-    )
+    jac_inputs, jac_outputs = set(inputs), set(cotangent)
+    result = jvp_from_jacobian(jac_fn, inputs, jac_inputs, jac_outputs, tangent)
+    expected = jvp_fn(inputs, jac_inputs, jac_outputs, tangent)
+    for dy in jac_outputs:
+        np.testing.assert_allclose(result[dy], expected[dy], rtol=1e-10)
 
 
 @pytest.mark.parametrize(
@@ -221,7 +322,8 @@ def test_jvp_to_vjp_via_jacobian(
     jac_fn = lambda inputs, jac_inputs, jac_outputs: jacobian_from_jvp(
         jvp_fn, inputs, jac_inputs, jac_outputs
     )
-    result = vjp_from_jacobian(jac_fn, inputs, {"x"}, {"y"}, cotangent)
-    np.testing.assert_allclose(
-        result["x"], vjp_fn(inputs, {"x"}, {"y"}, cotangent)["x"], rtol=1e-10
-    )
+    jac_inputs, jac_outputs = set(inputs), set(cotangent)
+    result = vjp_from_jacobian(jac_fn, inputs, jac_inputs, jac_outputs, cotangent)
+    expected = vjp_fn(inputs, jac_inputs, jac_outputs, cotangent)
+    for dx in jac_inputs:
+        np.testing.assert_allclose(result[dx], expected[dx], rtol=1e-10)


### PR DESCRIPTION
`test_gradient_fallbacks.py` has two cases, `wide-R4-R3` and `tall-R2-R4`. Both are nonlinear and both check the Jacobian shape, which is good, but both map one rank-1 input key to one rank-1 output key.

The one-hot sweeps in `jacobian_from_vjp` and `jacobian_from_jvp` exist precisely to keep seeds and results matched up across keys and axes. At one key and rank 1 there is nothing to match up, so that part of them is untested.

Three plausible ways to get the sweeps wrong leave the file green:

| mutation | original file | with this case |
|---|---|---|
| probe requests every output rather than the one it seeded | 16 passed | caught |
| flat indices instead of `np.ndindex` over the input shape | 16 passed | caught |
| `vjp_from_jacobian` contracts a fixed single axis | 16 passed | caught |
| `jacobian_from_jvp` writes leading axes, not trailing | caught | caught |

The first is a `KeyError` the moment there is a second key. The middle two are wrong numbers on any input of rank 2 or more, and are invisible at rank 1 because a flat index equals an `ndindex` there and a rank-1 cotangent has `ndim == 1`. The fourth was already covered, listed so the table is not just the ones that make the point.

## The case

Two inputs and two outputs of differing rank:

```
a: (2, 2)   b: (3,)   ->   u: (2,)   v: (2, 2)

u[i]   = sum_j a[i,j]**2 + b[i]
v[i,j] = a[i,j]*b[2] + sin(b[j])
```

Jacobian blocks are `(2,2,2)`, `(2,3)`, `(2,2,2,2)` and `(2,2,3)`, so a transposed or flattened write cannot pass by accident. It is written out by hand and I checked it against central differences before using it as the reference, max error 6e-10.

Its endpoints answer only for the keys they were asked about, which is what a Tesseract does. That is what turns the first mutation into an error rather than a quietly wrong answer.

## Also in the diff

The six tests hardcoded `{"x"}` and `{"y"}` as the path sets, so a new case could not flow through them. They now take the sets from the case and loop the assertions over the keys. That is the bulk of the line count and it is mechanical.

24 passed, up from 16. `tests/runtime_tests` is 430 passed.

No source change, and I did not find a live bug here. The multi-key and multi-rank paths are correct today; I checked them against an analytic reference before writing any of this.
