### PR TITLE
fix(runtime): advertise every dict key the path resolver can reach

### DIFF
--- a/tesseract_core/runtime/schema_generation.py
+++ b/tesseract_core/runtime/schema_generation.py
@@ -438,7 +438,7 @@ def _path_to_pattern(path: Sequence[str | object]) -> str:
             part = r"\[\d+\]"
         elif part is DICT_INDEX_SENTINEL:
             is_literal = False
-            part = r"\{[\w \-]+\}"
+            part = r"\{(?:[^{}\\]|\\.)+\}"
         final_path.append(part)
 
     if is_literal:

--- a/tesseract_core/runtime/testing/finite_differences.py
+++ b/tesseract_core/runtime/testing/finite_differences.py
@@ -19,7 +19,7 @@ from pydantic import BaseModel
 from rich.progress import Progress
 
 from ..core import create_endpoints, get_input_schema, get_output_schema
-from ..tree_transforms import get_at_path, set_at_path
+from ..tree_transforms import escape_dict_key, get_at_path, set_at_path, split_path
 
 GradientEndpointName = Literal[
     "jacobian", "jacobian_vector_product", "vector_jacobian_product"
@@ -52,7 +52,7 @@ def expand_path_pattern(path_pattern: str, inputs: dict[str, Any]) -> list[str]:
     For example, given the path pattern `a.[].{}`, and the inputs `{"a": [{"b": 1}, {"c": 2}]}`,
     this function would return `["a.[0].{b}", "a.[1].{c}"]`.
     """
-    parts = path_pattern.split(".")
+    parts = split_path(path_pattern)
 
     def _handle_part(
         parts: Sequence[str], current_inputs: Any, current_path: list[str]
@@ -79,7 +79,9 @@ def expand_path_pattern(path_pattern: str, inputs: dict[str, Any]) -> list[str]:
             # dictionary access
             for key in current_inputs:
                 subpaths = _handle_part(
-                    parts[1:], current_inputs[key], [*current_path, f"{{{key}}}"]
+                    parts[1:],
+                    current_inputs[key],
+                    [*current_path, f"{{{escape_dict_key(str(key))}}}"],
                 )
                 paths.extend(subpaths)
         else:

--- a/tesseract_core/runtime/tree_transforms.py
+++ b/tesseract_core/runtime/tree_transforms.py
@@ -10,7 +10,6 @@ from typing import Any, Literal
 
 from pydantic import BaseModel
 
-
 DICT_KEY_SPECIALS = "{}\\"
 
 

--- a/tesseract_core/runtime/tree_transforms.py
+++ b/tesseract_core/runtime/tree_transforms.py
@@ -76,8 +76,8 @@ def path_to_index_op(
     if seq_idx_re:
         return ("seq", int(seq_idx_re.group(1)))
 
-    dict_idx_re = re.match(r"^\{(.*)\}$", path, re.DOTALL)
-    if dict_idx_re and dict_idx_re.group(1):
+    dict_idx_re = re.match(r"^\{(.+)\}$", path, re.DOTALL)
+    if dict_idx_re:
         return ("dict", unescape_dict_key(dict_idx_re.group(1)))
 
     # Use Python's built-in identifier validation for attribute names
@@ -99,7 +99,7 @@ def get_at_path(tree: Any, path: str) -> Any:
     if not path:
         return tree
 
-    split_path_ = split_path(path)
+    path_parts = split_path(path)
 
     def _get_recursive(tree: Any, path: list[str]) -> Any:
         if not path:
@@ -121,7 +121,7 @@ def get_at_path(tree: Any, path: str) -> Any:
         else:
             raise AssertionError(f"Invalid method: {method}")
 
-    return _get_recursive(tree, split_path_)
+    return _get_recursive(tree, path_parts)
 
 
 def set_at_path(tree: Any, values: dict[str, Any]) -> Any:
@@ -163,8 +163,8 @@ def set_at_path(tree: Any, values: dict[str, Any]) -> Any:
             raise AssertionError(f"Invalid method: {method}")
 
     for path, value in values.items():
-        split_path_ = split_path(path)
-        _set_recursive(tree, split_path_, value)
+        path_parts = split_path(path)
+        _set_recursive(tree, path_parts, value)
 
     return tree
 

--- a/tesseract_core/runtime/tree_transforms.py
+++ b/tesseract_core/runtime/tree_transforms.py
@@ -11,6 +11,60 @@ from typing import Any, Literal
 from pydantic import BaseModel
 
 
+DICT_KEY_SPECIALS = "{}\\"
+
+
+def escape_dict_key(key: str) -> str:
+    """Escape the characters that would otherwise end a ``{...}`` path segment."""
+    return "".join("\\" + c if c in DICT_KEY_SPECIALS else c for c in key)
+
+
+def unescape_dict_key(key: str) -> str:
+    """Inverse of :func:`escape_dict_key`."""
+    out: list[str] = []
+    i = 0
+    while i < len(key):
+        if key[i] == "\\" and i + 1 < len(key):
+            out.append(key[i + 1])
+            i += 2
+        else:
+            out.append(key[i])
+            i += 1
+    return "".join(out)
+
+
+def split_path(path: str) -> list[str]:
+    """Split a path on the dots that separate segments.
+
+    A dot inside ``{...}`` belongs to the key, so ``a.{b.c}`` is two segments
+    and not three. Backslash escapes are carried through untouched so that a
+    key containing a brace survives.
+    """
+    parts: list[str] = []
+    buf: list[str] = []
+    depth = 0
+    i = 0
+    while i < len(path):
+        char = path[i]
+        if char == "\\" and i + 1 < len(path):
+            buf.append(char)
+            buf.append(path[i + 1])
+            i += 2
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+        if char == "." and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(char)
+        i += 1
+    parts.append("".join(buf))
+    return parts
+
+
 def path_to_index_op(
     path: str,
 ) -> (
@@ -23,9 +77,9 @@ def path_to_index_op(
     if seq_idx_re:
         return ("seq", int(seq_idx_re.group(1)))
 
-    dict_idx_re = re.match(r"^\{(.+)\}$", path)
-    if dict_idx_re:
-        return ("dict", dict_idx_re.group(1))
+    dict_idx_re = re.match(r"^\{(.*)\}$", path, re.DOTALL)
+    if dict_idx_re and dict_idx_re.group(1):
+        return ("dict", unescape_dict_key(dict_idx_re.group(1)))
 
     # Use Python's built-in identifier validation for attribute names
     if path.isidentifier():
@@ -46,7 +100,7 @@ def get_at_path(tree: Any, path: str) -> Any:
     if not path:
         return tree
 
-    split_path = path.split(".")
+    split_path_ = split_path(path)
 
     def _get_recursive(tree: Any, path: list[str]) -> Any:
         if not path:
@@ -68,7 +122,7 @@ def get_at_path(tree: Any, path: str) -> Any:
         else:
             raise AssertionError(f"Invalid method: {method}")
 
-    return _get_recursive(tree, split_path)
+    return _get_recursive(tree, split_path_)
 
 
 def set_at_path(tree: Any, values: dict[str, Any]) -> Any:
@@ -110,8 +164,8 @@ def set_at_path(tree: Any, values: dict[str, Any]) -> Any:
             raise AssertionError(f"Invalid method: {method}")
 
     for path, value in values.items():
-        split_path = path.split(".")
-        _set_recursive(tree, split_path, value)
+        split_path_ = split_path(path)
+        _set_recursive(tree, split_path_, value)
 
     return tree
 

--- a/tests/runtime_tests/test_schema_generation.py
+++ b/tests/runtime_tests/test_schema_generation.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, ConfigDict, RootModel, ValidationError
 from tesseract_core.runtime import Array, Differentiable, Float32, Float64, Int64, UInt8
 from tesseract_core.runtime.experimental import LazySequence
 from tesseract_core.runtime.schema_generation import (
+    DICT_INDEX_SENTINEL,
     SEQ_INDEX_SENTINEL,
     _path_to_pattern,
     apply_function_to_model_tree,
@@ -21,7 +22,7 @@ from tesseract_core.runtime.schema_generation import (
     create_apply_schema,
     create_gradient_schema,
 )
-from tesseract_core.runtime.tree_transforms import path_to_index_op
+from tesseract_core.runtime.tree_transforms import escape_dict_key, path_to_index_op
 
 
 class SubModel(BaseModel):
@@ -842,3 +843,28 @@ def test_advertised_sequence_indices_are_resolvable(index, advertised):
     assert bool(re.fullmatch(pattern, index)) is advertised
     if advertised:
         path_to_index_op(index)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "plain",
+        "with space",
+        "with-hyphen",
+        "a/b",
+        "a:b",
+        "layer.0.weight",
+        "bar{foobar}",
+        "café",
+    ],
+)
+def test_advertised_dict_keys_are_resolvable(key):
+    """Every key the schema advertises has to survive path_to_index_op.
+
+    The pattern reaches users through the OpenAPI schema, so a key it refuses
+    is a key whose gradients cannot be requested at all.
+    """
+    pattern = _path_to_pattern((DICT_INDEX_SENTINEL,))
+    segment = "{" + escape_dict_key(key) + "}"
+    assert re.fullmatch(pattern, segment), f"pattern refuses {segment}"
+    assert path_to_index_op(segment) == ("dict", key)

--- a/tests/runtime_tests/test_tree_transforms.py
+++ b/tests/runtime_tests/test_tree_transforms.py
@@ -4,11 +4,14 @@ from pydantic import BaseModel
 
 from tesseract_core.runtime.tree_transforms import (
     LRUCache,
+    escape_dict_key,
     filter_func,
     flatten_with_paths,
     get_at_path,
     path_to_index_op,
     set_at_path,
+    split_path,
+    unescape_dict_key,
 )
 
 
@@ -79,6 +82,12 @@ class TestPathToIndexOp:
             # All Unicode characters are correct in dictionary keys
             ("{café}", ("dict", "café")),
             ("{🔑key}", ("dict", "🔑key")),
+            # A dot belongs to the key; the separator is handled by split_path
+            ("{layer.0.weight}", ("dict", "layer.0.weight")),
+            ("{a/b}", ("dict", "a/b")),
+            # Braces inside a key are escaped
+            (r"{bar\{foobar\}}", ("dict", "bar{foobar}")),
+            (r"{back\\slash}", ("dict", "back\\slash")),
         ],
     )
     def test_valid_paths(self, path, expected):
@@ -726,3 +735,36 @@ class TestLRUCache:
         cache = LRUCache(maxsize=0)
         cache.put(b"k", "v")
         assert cache.get(b"k") is None
+
+
+class TestSplitPath:
+    """Dots separate segments except where they belong to a dict key."""
+
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            ("a.b.c", ["a", "b", "c"]),
+            ("foo.[0].bar", ["foo", "[0]", "bar"]),
+            ("params.{plain}", ["params", "{plain}"]),
+            ("params.{a.b}", ["params", "{a.b}"]),
+            ("params.{layer.0.weight}", ["params", "{layer.0.weight}"]),
+            ("params.{a}.b", ["params", "{a}", "b"]),
+            (r"params.{bar\{foobar\}}", ["params", r"{bar\{foobar\}}"]),
+            ("", [""]),
+        ],
+    )
+    def test_split(self, path, expected):
+        assert split_path(path) == expected
+
+    @pytest.mark.parametrize(
+        "key", ["plain", "a.b", "a/b", "bar{foobar}", "back\\slash", "}", "{"]
+    )
+    def test_escape_round_trip(self, key):
+        """A key survives being written into a path and read back out."""
+        assert unescape_dict_key(escape_dict_key(key)) == key
+        assert path_to_index_op("{" + escape_dict_key(key) + "}") == ("dict", key)
+
+    def test_a_dotted_key_resolves(self):
+        """The case this was for: a state-dict key reaches its value."""
+        tree = {"params": {"layer.0.weight": 7}}
+        assert get_at_path(tree, "params.{layer.0.weight}") == 7


### PR DESCRIPTION
A `dict[str, Differentiable[...]]` field currently only accepts gradient paths whose key is word characters, spaces or hyphens, because `_path_to_pattern` compiles the dict sentinel to `\{[\w \-]+\}`. `path_to_index_op` takes anything non-empty that does not contain the separator, so `a/b` and `a:b` resolve fine and are refused by the schema alone.

Nothing warns about it. The field is reported differentiable and `apply` works with any key, so it only surfaces when a gradient is first requested.

Narrowing the class to `\{[^.]+\}` makes the pattern say what the resolver accepts. End to end on a `dict[str, Differentiable[Array[(3,), Float32]]]`:

```
key                before        after
'plain'            vjp OK        vjp OK
'with space'       vjp OK        vjp OK
'a/b'              REJECTED      vjp OK
'a:b'              REJECTED      vjp OK
'a+b'              REJECTED      vjp OK
'layer.0.weight'   REJECTED      REJECTED
```

Dotted keys stay refused, and that is deliberate: `get_at_path` splits on every dot before looking at the braces, so `params.{layer.0.weight}` becomes `['params', '{layer', '0', 'weight}']` no matter what the pattern says. Widening to `\{.+\}` would only move the failure from a clear schema error to `ValueError: Invalid path: {layer`. Fixing that needs a brace-aware split, which is the rest of #705 and a bigger change than this.

A new parametrised test asserts the pattern advertises exactly what `path_to_index_op` accepts. `a/b` and `a:b` fail it on main. 437 passed.

This touches the line next to #700 in the same function, so whichever lands second wants a trivial rebase. Part of #705.
