### PR TITLE
fix(runtime): find wheel-installed libcudart for cuda_ipc decode

### DIFF
--- a/tesseract_core/runtime/cuda_ipc.py
+++ b/tesseract_core/runtime/cuda_ipc.py
@@ -20,6 +20,12 @@ runtime machinery. The public entry points used by :mod:`array_encoding` are:
   encode/decode pair,
 * :func:`release_pinned_ipc_exports` -- keepalive cleanup, called once per
   request by both the server (for its outputs) and the client (for its inputs).
+
+:func:`iter_cudart_candidates` is also public, but for a different audience:
+out-of-process consumers that ``dlopen`` libcudart themselves (e.g. the
+``tesseract_jax`` C++ FFI shim) can reuse this module's discovery -- including
+the pip-wheel fallback and forward-compatible version range -- instead of
+maintaining their own soname list.
 """
 
 import ctypes
@@ -250,39 +256,67 @@ def _iter_wheel_cudart_paths() -> Iterator[str]:
             yield str(candidate)
 
 
-def _find_cudart() -> Any:
-    """Locate and load libcudart (a ``ctypes.CDLL``), or ``None`` if not found.
+def iter_cudart_candidates() -> Iterator[str]:
+    """Yield libcudart names/paths to try loading, most-preferred first.
 
-    Search order: the system loader (``find_library`` then bare sonames), then
-    pip-wheel CUDA installs (see :func:`_iter_wheel_cudart_paths`).
+    Each item is an argument suitable for ``ctypes.CDLL`` **and** for a raw
+    ``dlopen``/``LoadLibrary``: either a bare soname the system loader resolves
+    (e.g. ``"libcudart.so.12"``) or an absolute path to a wheel-shipped runtime.
+    The order encodes the search strategy:
+
+    1. ``ctypes.util.find_library`` results (honours ``LD_LIBRARY_PATH`` and the
+       ``ldconfig`` cache), unversioned name first then generated per-major
+       Windows stems;
+    2. bare sonames, for systems where ``find_library`` misses the versioned name
+       but the loader can still resolve it (e.g. an already-loaded copy);
+    3. absolute paths to pip-wheel CUDA installs (see
+       :func:`_iter_wheel_cudart_paths`).
+
+    This is the public discovery surface: non-Python consumers (e.g. the
+    ``tesseract_jax`` C++ FFI shim, which ``dlopen``s libcudart itself) can use
+    it to locate the same runtime this module loads, so both agree on the wheel
+    fallback and stay forward-compatible with new CUDA majors without their own
+    hardcoded soname list. Discovery only -- the caller does the actual load.
+
+    Items are de-duplicated preserving order; existence is not guaranteed (a
+    candidate may still fail to load), so callers should try each in turn.
     """
-    # System loader: honours LD_LIBRARY_PATH and the ldconfig cache. Try the
-    # unversioned name first, then generated per-major Windows names (find_library
-    # wants a stem, not a full soname).
+    seen: set[str] = set()
+
+    def _fresh(candidate: str) -> bool:
+        if candidate in seen:
+            return False
+        seen.add(candidate)
+        return True
+
+    # find_library wants a stem (not a full soname): the unversioned name first,
+    # then generated per-major Windows stems.
     find_library_names = ["cudart"] + [f"cudart64_{major}" for major in _CUDART_MAJORS]
     for name in find_library_names:
         path = ctypes.util.find_library(name)
-        if path:
-            try:
-                return ctypes.CDLL(path)
-            except OSError:
-                pass
+        if path and _fresh(path):
+            yield path
 
-    # Bare sonames: covers systems where find_library misses the versioned name
-    # but the loader can still resolve it (e.g. an already-loaded copy).
     for soname in _cudart_sonames():
-        try:
-            return ctypes.CDLL(soname)
-        except OSError:
-            continue
+        if _fresh(soname):
+            yield soname
 
-    # pip-wheel CUDA: load by absolute path from the wheel's lib directory.
     for path in _iter_wheel_cudart_paths():
+        if _fresh(path):
+            yield path
+
+
+def _find_cudart() -> Any:
+    """Locate and load libcudart (a ``ctypes.CDLL``), or ``None`` if not found.
+
+    Tries each candidate from :func:`iter_cudart_candidates` in order and
+    returns the first that loads.
+    """
+    for candidate in iter_cudart_candidates():
         try:
-            return ctypes.CDLL(path)
+            return ctypes.CDLL(candidate)
         except OSError:
             continue
-
     return None
 
 

--- a/tesseract_core/runtime/cuda_ipc.py
+++ b/tesseract_core/runtime/cuda_ipc.py
@@ -142,16 +142,60 @@ class _CudaIpcMemHandle(ctypes.Structure):
     _fields_ = [("reserved", ctypes.c_byte * _CUDA_IPC_HANDLE_SIZE)]
 
 
-# Library filenames for the CUDA runtime, per platform, newest major first.
-_CUDART_SONAMES = (
-    "libcudart.so",
-    "libcudart.so.13",
-    "libcudart.so.12",
-    "libcudart.so.11",
-    "libcudart.dylib",
-    "cudart64_13.dll",
-    "cudart64_12.dll",
-)
+# CUDA runtime major versions we probe for by number, newest first. cuda_ipc
+# only calls a handful of long-stable runtime symbols (cudaIpc*, cudaMemcpy,
+# cudaMalloc, cudaSetDevice, cudaDeviceSynchronize), so a newer major than any
+# listed here is very likely to work -- the range is generous and open-ended at
+# the top precisely so a freshly released CUDA does not need a code change. The
+# floor is the oldest major whose ABI we still expect to encounter in the wild.
+_CUDART_MAJOR_NEWEST = 20
+_CUDART_MAJOR_OLDEST = 11
+_CUDART_MAJORS = tuple(range(_CUDART_MAJOR_NEWEST, _CUDART_MAJOR_OLDEST - 1, -1))
+
+
+def _cudart_sonames() -> tuple[str, ...]:
+    """Candidate CUDA runtime library filenames, most-preferred first.
+
+    Unversioned names come first: on a system with a CUDA toolkit the loader
+    resolves ``libcudart.so`` / ``libcudart.dylib`` via the dev symlink to
+    whatever major is installed, so we never have to know the number. The
+    versioned names that follow are generated over :data:`_CUDART_MAJORS`
+    (newest first) rather than hand-enumerated, so a new CUDA major is picked up
+    without editing this file.
+    """
+    names = ["libcudart.so", "libcudart.dylib"]
+    names += [f"libcudart.so.{major}" for major in _CUDART_MAJORS]
+    names += [f"cudart64_{major}.dll" for major in _CUDART_MAJORS]
+    return tuple(names)
+
+
+# Glob patterns for locating a wheel-shipped runtime by filename in a known lib
+# directory. Unlike the loader-name list above, here we have a concrete
+# directory to scan, so we can match *any* version present rather than probe a
+# fixed set -- fully forward-compatible for the wheel case.
+_CUDART_GLOBS = ("libcudart.so.*", "libcudart.so", "libcudart.dylib", "cudart64_*.dll")
+
+
+def _cudart_soname_sort_key(path: Path) -> tuple[int, int]:
+    """Sort key placing higher CUDA majors first among wheel candidates.
+
+    Returns ``(-major, tiebreak)`` so ``sorted`` yields newest-major-first. The
+    major is parsed from ``libcudart.so.<major>`` / ``cudart64_<major>.dll``;
+    names without a parseable version (e.g. an unversioned ``libcudart.so``
+    symlink) sort after all versioned ones so a concrete version wins.
+    """
+    name = path.name
+    major = -1
+    if name.startswith("libcudart.so."):
+        tail = name[len("libcudart.so.") :].split(".", 1)[0]
+        if tail.isdigit():
+            major = int(tail)
+    elif name.startswith("cudart64_") and name.endswith(".dll"):
+        tail = name[len("cudart64_") : -len(".dll")]
+        if tail.isdigit():
+            major = int(tail)
+    # Versioned first (-major ascending == major descending); unversioned last.
+    return (0 if major >= 0 else 1, -major)
 
 
 def _iter_wheel_cudart_paths() -> Iterator[str]:
@@ -197,10 +241,13 @@ def _iter_wheel_cudart_paths() -> Iterator[str]:
             _add(lib)
 
     for lib_dir in lib_dirs:
-        for soname in _CUDART_SONAMES:
-            candidate = lib_dir / soname
-            if candidate.exists():
-                yield str(candidate)
+        candidates: set[Path] = set()
+        for pattern in _CUDART_GLOBS:
+            candidates.update(p for p in lib_dir.glob(pattern) if p.is_file())
+        # Newest major first, so a wheel dir that somehow holds several runtimes
+        # (or a dev symlink alongside a versioned .so) prefers the highest one.
+        for candidate in sorted(candidates, key=_cudart_soname_sort_key):
+            yield str(candidate)
 
 
 def _find_cudart() -> Any:
@@ -209,8 +256,11 @@ def _find_cudart() -> Any:
     Search order: the system loader (``find_library`` then bare sonames), then
     pip-wheel CUDA installs (see :func:`_iter_wheel_cudart_paths`).
     """
-    # System loader: honours LD_LIBRARY_PATH and the ldconfig cache.
-    for name in ("cudart", "cudart64_13", "cudart64_12", "cudart64_11"):
+    # System loader: honours LD_LIBRARY_PATH and the ldconfig cache. Try the
+    # unversioned name first, then generated per-major Windows names (find_library
+    # wants a stem, not a full soname).
+    find_library_names = ["cudart"] + [f"cudart64_{major}" for major in _CUDART_MAJORS]
+    for name in find_library_names:
         path = ctypes.util.find_library(name)
         if path:
             try:
@@ -220,7 +270,7 @@ def _find_cudart() -> Any:
 
     # Bare sonames: covers systems where find_library misses the versioned name
     # but the loader can still resolve it (e.g. an already-loaded copy).
-    for soname in _CUDART_SONAMES:
+    for soname in _cudart_sonames():
         try:
             return ctypes.CDLL(soname)
         except OSError:

--- a/tesseract_core/runtime/cuda_ipc.py
+++ b/tesseract_core/runtime/cuda_ipc.py
@@ -23,7 +23,11 @@ runtime machinery. The public entry points used by :mod:`array_encoding` are:
 """
 
 import ctypes
+import ctypes.util
+import importlib.util
 import weakref
+from collections.abc import Iterable, Iterator
+from pathlib import Path
 from typing import Any, get_args
 
 import numpy as np
@@ -138,44 +142,113 @@ class _CudaIpcMemHandle(ctypes.Structure):
     _fields_ = [("reserved", ctypes.c_byte * _CUDA_IPC_HANDLE_SIZE)]
 
 
+# Library filenames for the CUDA runtime, per platform, newest major first.
+_CUDART_SONAMES = (
+    "libcudart.so",
+    "libcudart.so.13",
+    "libcudart.so.12",
+    "libcudart.so.11",
+    "libcudart.dylib",
+    "cudart64_13.dll",
+    "cudart64_12.dll",
+)
+
+
+def _iter_wheel_cudart_paths() -> Iterator[str]:
+    """Yield candidate absolute paths to libcudart shipped inside pip wheels.
+
+    The pip CUDA wheels (``nvidia-cuda-runtime-cuXX``, pulled in transitively by
+    ``jax[cudaXX]`` / ``cupy-cudaXXx``) install the runtime under a
+    ``site-packages/nvidia/<pkg>/lib/libcudart.so.NN`` directory (``<pkg>`` is
+    typically ``cuda_runtime``). That directory is on neither
+    ``LD_LIBRARY_PATH`` nor the ``ldconfig`` cache, so both
+    :func:`ctypes.util.find_library` and a bare ``ctypes.CDLL(soname)`` can miss
+    it -- observed on GPU CI runners with no system CUDA toolkit installed. When
+    that happens we locate the wheel directory ourselves.
+    """
+
+    def _spec_locations(name: str) -> Iterable[str]:
+        try:
+            spec = importlib.util.find_spec(name)
+        except (ImportError, ValueError):
+            return ()
+        return () if spec is None else (spec.submodule_search_locations or ())
+
+    lib_dirs: list[Path] = []
+    seen: set[str] = set()
+
+    def _add(lib_dir: Path) -> None:
+        key = str(lib_dir)
+        if key not in seen:
+            seen.add(key)
+            lib_dirs.append(lib_dir)
+
+    # Preferred: ask importlib where the runtime wheel's package lives, so we do
+    # not hardcode the site-packages layout.
+    for location in _spec_locations("nvidia.cuda_runtime"):
+        _add(Path(location) / "lib")
+
+    # Fallback: glob every nvidia namespace package on the import path, in case
+    # the runtime is bundled under a differently named package. Anchoring on the
+    # nvidia namespace itself (rather than a fixed depth off __file__) keeps this
+    # correct for editable installs and non-standard layouts.
+    for location in _spec_locations("nvidia"):
+        for lib in Path(location).glob("*/lib"):
+            _add(lib)
+
+    for lib_dir in lib_dirs:
+        for soname in _CUDART_SONAMES:
+            candidate = lib_dir / soname
+            if candidate.exists():
+                yield str(candidate)
+
+
+def _find_cudart() -> Any:
+    """Locate and load libcudart (a ``ctypes.CDLL``), or ``None`` if not found.
+
+    Search order: the system loader (``find_library`` then bare sonames), then
+    pip-wheel CUDA installs (see :func:`_iter_wheel_cudart_paths`).
+    """
+    # System loader: honours LD_LIBRARY_PATH and the ldconfig cache.
+    for name in ("cudart", "cudart64_13", "cudart64_12", "cudart64_11"):
+        path = ctypes.util.find_library(name)
+        if path:
+            try:
+                return ctypes.CDLL(path)
+            except OSError:
+                pass
+
+    # Bare sonames: covers systems where find_library misses the versioned name
+    # but the loader can still resolve it (e.g. an already-loaded copy).
+    for soname in _CUDART_SONAMES:
+        try:
+            return ctypes.CDLL(soname)
+        except OSError:
+            continue
+
+    # pip-wheel CUDA: load by absolute path from the wheel's lib directory.
+    for path in _iter_wheel_cudart_paths():
+        try:
+            return ctypes.CDLL(path)
+        except OSError:
+            continue
+
+    return None
+
+
 def _get_cudart():
     """Lazily load the CUDA runtime shared library and declare signatures."""
     global _CUDART_HANDLE
     if _CUDART_HANDLE is not None:
         return _CUDART_HANDLE
 
-    import ctypes.util
-
-    cudart = None
-    # Try common names for the CUDA runtime library
-    for name in ("cudart", "cudart64_13", "cudart64_12", "cudart64_11"):
-        path = ctypes.util.find_library(name)
-        if path:
-            cudart = ctypes.CDLL(path)
-            break
-
-    if cudart is None:
-        # Fallback: try loading directly (covers systems where find_library
-        # misses the versioned soname).
-        for path in (
-            "libcudart.so",
-            "libcudart.so.13",
-            "libcudart.so.12",
-            "libcudart.so.11",
-            "libcudart.dylib",
-            "cudart64_13.dll",
-            "cudart64_12.dll",
-        ):
-            try:
-                cudart = ctypes.CDLL(path)
-                break
-            except OSError:
-                continue
+    cudart = _find_cudart()
 
     if cudart is None:
         raise RuntimeError(
-            "Could not find CUDA runtime library (libcudart). "
-            "Make sure CUDA is installed and LD_LIBRARY_PATH is set."
+            "Could not find CUDA runtime library (libcudart). Make sure CUDA is "
+            "installed and on the loader path (set LD_LIBRARY_PATH), or install a "
+            "CUDA runtime wheel (e.g. nvidia-cuda-runtime-cu12)."
         )
 
     # Declare argument/return types so ctypes marshals 64-bit pointers and the

--- a/tesseract_core/runtime/cuda_ipc.py
+++ b/tesseract_core/runtime/cuda_ipc.py
@@ -33,6 +33,7 @@ import ctypes.util
 import importlib.util
 import weakref
 from collections.abc import Iterable, Iterator
+from itertools import chain
 from pathlib import Path
 from typing import Any, get_args
 
@@ -185,10 +186,11 @@ _CUDART_GLOBS = ("libcudart.so.*", "libcudart.so", "libcudart.dylib", "cudart64_
 def _cudart_soname_sort_key(path: Path) -> tuple[int, int]:
     """Sort key placing higher CUDA majors first among wheel candidates.
 
-    Returns ``(-major, tiebreak)`` so ``sorted`` yields newest-major-first. The
-    major is parsed from ``libcudart.so.<major>`` / ``cudart64_<major>.dll``;
-    names without a parseable version (e.g. an unversioned ``libcudart.so``
-    symlink) sort after all versioned ones so a concrete version wins.
+    Returns ``(0 if versioned else 1, -major)`` so ``sorted`` yields versioned
+    names first and, among them, newest-major-first. The major is parsed from
+    ``libcudart.so.<major>`` / ``cudart64_<major>.dll``; names without a
+    parseable version (e.g. an unversioned ``libcudart.so`` symlink) sort after
+    all versioned ones so a concrete version wins.
     """
     name = path.name
     major = -1
@@ -212,9 +214,10 @@ def _iter_wheel_cudart_paths() -> Iterator[str]:
     ``site-packages/nvidia/<pkg>/lib/libcudart.so.NN`` directory (``<pkg>`` is
     typically ``cuda_runtime``). That directory is on neither
     ``LD_LIBRARY_PATH`` nor the ``ldconfig`` cache, so both
-    :func:`ctypes.util.find_library` and a bare ``ctypes.CDLL(soname)`` can miss
-    it -- observed on GPU CI runners with no system CUDA toolkit installed. When
-    that happens we locate the wheel directory ourselves.
+    :func:`ctypes.util.find_library` and a bare ``ctypes.CDLL(soname)`` miss it
+    -- observed on GPU CI runners with no system CUDA toolkit installed. We
+    locate the wheel directory ourselves so this venv-local runtime is found
+    (and, per :func:`iter_cudart_candidates`, preferred over a system one).
     """
 
     def _spec_locations(name: str) -> Iterable[str]:
@@ -264,46 +267,44 @@ def iter_cudart_candidates() -> Iterator[str]:
     (e.g. ``"libcudart.so.12"``) or an absolute path to a wheel-shipped runtime.
     The order encodes the search strategy:
 
-    1. ``ctypes.util.find_library`` results (honours ``LD_LIBRARY_PATH`` and the
-       ``ldconfig`` cache), unversioned name first then generated per-major
-       Windows stems;
-    2. bare sonames, for systems where ``find_library`` misses the versioned name
-       but the loader can still resolve it (e.g. an already-loaded copy);
-    3. absolute paths to pip-wheel CUDA installs (see
-       :func:`_iter_wheel_cudart_paths`).
+    1. absolute paths to pip-wheel CUDA installs (see
+       :func:`_iter_wheel_cudart_paths`), so a venv's runtime wins over a system
+       one -- this matches how JAX and PyTorch load libcudart (their loaders
+       ``dlopen`` the wheel copy by absolute path first, falling back to the
+       system library only if no wheel is present). Agreeing with them on which
+       runtime is loaded matters for a codec that hands device memory to them;
+    2. ``ctypes.util.find_library`` results (search the ``ldconfig`` cache, and
+       on non-glibc platforms other loader paths), unversioned name first then
+       generated per-major Windows stems;
+    3. bare sonames, for systems where ``find_library`` misses the versioned name
+       but the loader can still resolve it (e.g. an already-loaded copy, or via
+       ``LD_LIBRARY_PATH``, which ``dlopen`` honours but ``find_library`` does
+       not).
 
     This is the public discovery surface: non-Python consumers (e.g. the
     ``tesseract_jax`` C++ FFI shim, which ``dlopen``s libcudart itself) can use
     it to locate the same runtime this module loads, so both agree on the wheel
-    fallback and stay forward-compatible with new CUDA majors without their own
+    preference and stay forward-compatible with new CUDA majors without their own
     hardcoded soname list. Discovery only -- the caller does the actual load.
 
     Items are de-duplicated preserving order; existence is not guaranteed (a
     candidate may still fail to load), so callers should try each in turn.
     """
-    seen: set[str] = set()
-
-    def _fresh(candidate: str) -> bool:
-        if candidate in seen:
-            return False
-        seen.add(candidate)
-        return True
-
     # find_library wants a stem (not a full soname): the unversioned name first,
     # then generated per-major Windows stems.
-    find_library_names = ["cudart"] + [f"cudart64_{major}" for major in _CUDART_MAJORS]
-    for name in find_library_names:
-        path = ctypes.util.find_library(name)
-        if path and _fresh(path):
-            yield path
+    find_library_stems = ("cudart", *(f"cudart64_{major}" for major in _CUDART_MAJORS))
+    from_find_library = (ctypes.util.find_library(stem) for stem in find_library_stems)
+    candidates = chain(
+        _iter_wheel_cudart_paths(),
+        filter(None, from_find_library),
+        _cudart_sonames(),
+    )
 
-    for soname in _cudart_sonames():
-        if _fresh(soname):
-            yield soname
-
-    for path in _iter_wheel_cudart_paths():
-        if _fresh(path):
-            yield path
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate not in seen:
+            seen.add(candidate)
+            yield candidate
 
 
 def _find_cudart() -> Any:
@@ -332,7 +333,7 @@ def _get_cudart():
         raise RuntimeError(
             "Could not find CUDA runtime library (libcudart). Make sure CUDA is "
             "installed and on the loader path (set LD_LIBRARY_PATH), or install a "
-            "CUDA runtime wheel (e.g. nvidia-cuda-runtime-cu12)."
+            "CUDA runtime wheel (e.g. nvidia-cuda-runtime-cu13)."
         )
 
     # Declare argument/return types so ctypes marshals 64-bit pointers and the

--- a/tests/test_cuda_ipc_cpu.py
+++ b/tests/test_cuda_ipc_cpu.py
@@ -810,8 +810,12 @@ def test_iter_wheel_cudart_paths_prefers_newest_major(tmp_path, monkeypatch):
 # every item is a bare soname or absolute path -- is part of the interface.
 
 
-def test_iter_cudart_candidates_orders_system_then_wheel(monkeypatch):
-    """find_library hits come first, then bare sonames, then wheel paths."""
+def test_iter_cudart_candidates_orders_wheel_then_system(monkeypatch):
+    """Wheel paths come first, then find_library hits, then bare sonames.
+
+    Wheel-first matches how JAX and PyTorch load libcudart (venv copy over a
+    system one), so a codec handing device memory to them agrees on the runtime.
+    """
     monkeypatch.setattr(
         cuda_ipc.ctypes.util,
         "find_library",
@@ -825,13 +829,15 @@ def test_iter_cudart_candidates_orders_system_then_wheel(monkeypatch):
 
     candidates = list(cuda_ipc.iter_cudart_candidates())
 
-    # System loader's resolved path leads.
-    assert candidates[0] == "/usr/lib/libcudart.so.12"
-    # Bare sonames sit in the middle, wheel path last.
+    # Wheel (venv) path leads, ahead of the system loader's resolved path.
+    assert candidates[0] == "/wheel/nvidia/lib/libcudart.so.12"
+    assert candidates.index("/wheel/nvidia/lib/libcudart.so.12") < candidates.index(
+        "/usr/lib/libcudart.so.12"
+    )
+    # Bare sonames trail the find_library hits.
     assert "libcudart.so" in candidates
-    assert candidates[-1] == "/wheel/nvidia/lib/libcudart.so.12"
-    assert candidates.index("libcudart.so") < candidates.index(
-        "/wheel/nvidia/lib/libcudart.so.12"
+    assert candidates.index("/usr/lib/libcudart.so.12") < candidates.index(
+        "libcudart.so"
     )
 
 
@@ -848,7 +854,7 @@ def test_iter_cudart_candidates_dedups_preserving_order(monkeypatch):
     candidates = list(cuda_ipc.iter_cudart_candidates())
 
     assert candidates.count(dup) == 1
-    # The earlier (find_library) occurrence wins its position.
+    # The earlier (wheel) occurrence wins its position.
     assert candidates[0] == dup
 
 

--- a/tests/test_cuda_ipc_cpu.py
+++ b/tests/test_cuda_ipc_cpu.py
@@ -693,3 +693,64 @@ def test_output_to_bytes_cuda_ipc_context(monkeypatch):
 
     file_interactions.output_to_bytes({"y": 1}, "json+cuda_ipc")
     assert captured["context"] == {"array_encoding": "cuda_ipc"}
+
+
+# ── libcudart discovery (wheel-installed CUDA) ──────────────────────────
+#
+# The pip CUDA wheels (nvidia-cuda-runtime-cuXX, pulled in by jax[cudaXX] /
+# cupy-cudaXXx) install libcudart under site-packages/nvidia/cuda_runtime/lib/,
+# which is on neither LD_LIBRARY_PATH nor the ldconfig cache. _find_cudart must
+# still discover it there after the system-loader probes come up empty.
+
+
+def _fake_cudart_wheel(tmp_path, soname="libcudart.so.12"):
+    """Create a fake ``nvidia/cuda_runtime/lib/<soname>`` layout; return its lib dir."""
+    lib_dir = tmp_path / "nvidia" / "cuda_runtime" / "lib"
+    lib_dir.mkdir(parents=True)
+    (lib_dir / soname).write_bytes(b"")
+    return lib_dir
+
+
+def test_iter_wheel_cudart_paths_finds_runtime_wheel(tmp_path, monkeypatch):
+    """The runtime wheel's lib dir is discovered via its importlib spec."""
+    lib_dir = _fake_cudart_wheel(tmp_path)
+
+    real_find_spec = cuda_ipc.importlib.util.find_spec
+
+    def fake_find_spec(name):
+        if name == "nvidia.cuda_runtime":
+            spec = types.SimpleNamespace()
+            spec.submodule_search_locations = [str(lib_dir.parent)]
+            return spec
+        return real_find_spec(name)
+
+    monkeypatch.setattr(cuda_ipc.importlib.util, "find_spec", fake_find_spec)
+
+    found = list(cuda_ipc._iter_wheel_cudart_paths())
+    assert str(lib_dir / "libcudart.so.12") in found
+
+
+def test_find_cudart_falls_back_to_wheel(tmp_path, monkeypatch):
+    """When the system loader misses libcudart, the wheel copy is loaded."""
+    lib_dir = _fake_cudart_wheel(tmp_path)
+    loaded = {}
+
+    # System-loader probes find nothing.
+    monkeypatch.setattr(cuda_ipc.ctypes.util, "find_library", lambda name: None)
+    monkeypatch.setattr(
+        cuda_ipc, "_iter_wheel_cudart_paths", lambda: [str(lib_dir / "libcudart.so.12")]
+    )
+
+    def fake_cdll(path):
+        # Bare sonames (no path separator) are the system-loader attempts; only
+        # the absolute wheel path should succeed.
+        if "/" not in path and "\\" not in path:
+            raise OSError(f"{path}: not found")
+        loaded["path"] = path
+        return object()
+
+    monkeypatch.setattr(cuda_ipc.ctypes, "CDLL", fake_cdll)
+
+    handle = cuda_ipc._find_cudart()
+    assert handle is not None
+    assert loaded["path"] == str(lib_dir / "libcudart.so.12")

--- a/tests/test_cuda_ipc_cpu.py
+++ b/tests/test_cuda_ipc_cpu.py
@@ -730,22 +730,28 @@ def test_iter_wheel_cudart_paths_finds_runtime_wheel(tmp_path, monkeypatch):
     assert str(lib_dir / "libcudart.so.12") in found
 
 
-def test_find_cudart_falls_back_to_wheel(tmp_path, monkeypatch):
-    """When the system loader misses libcudart, the wheel copy is loaded."""
+def test_find_cudart_prefers_wheel_over_system(tmp_path, monkeypatch):
+    """The wheel copy is loaded even when a system soname would also resolve.
+
+    The wheel is tried before the system loader, so on a host with both a venv
+    runtime and a system one the venv copy wins -- matching how JAX/torch load
+    libcudart.
+    """
     lib_dir = _fake_cudart_wheel(tmp_path)
+    wheel_path = str(lib_dir / "libcudart.so.12")
+
+    # A system runtime is also resolvable, so both sources could satisfy the load.
+    monkeypatch.setattr(
+        cuda_ipc.ctypes.util,
+        "find_library",
+        lambda name: "libcudart.so.12" if name == "cudart" else None,
+    )
+    monkeypatch.setattr(cuda_ipc, "_iter_wheel_cudart_paths", lambda: [wheel_path])
+
+    # Everything loads; _find_cudart returns the first candidate it tries.
     loaded = {}
 
-    # System-loader probes find nothing.
-    monkeypatch.setattr(cuda_ipc.ctypes.util, "find_library", lambda name: None)
-    monkeypatch.setattr(
-        cuda_ipc, "_iter_wheel_cudart_paths", lambda: [str(lib_dir / "libcudart.so.12")]
-    )
-
     def fake_cdll(path):
-        # Bare sonames (no path separator) are the system-loader attempts; only
-        # the absolute wheel path should succeed.
-        if "/" not in path and "\\" not in path:
-            raise OSError(f"{path}: not found")
         loaded["path"] = path
         return object()
 
@@ -753,7 +759,8 @@ def test_find_cudart_falls_back_to_wheel(tmp_path, monkeypatch):
 
     handle = cuda_ipc._find_cudart()
     assert handle is not None
-    assert loaded["path"] == str(lib_dir / "libcudart.so.12")
+    # The wheel path is first in the candidate order, so it is what gets loaded.
+    assert loaded["path"] == wheel_path
 
 
 def test_iter_wheel_cudart_paths_finds_unenumerated_future_major(tmp_path, monkeypatch):

--- a/tests/test_cuda_ipc_cpu.py
+++ b/tests/test_cuda_ipc_cpu.py
@@ -801,3 +801,69 @@ def test_iter_wheel_cudart_paths_prefers_newest_major(tmp_path, monkeypatch):
 
     found = list(cuda_ipc._iter_wheel_cudart_paths())
     assert found[0] == str(lib_dir / "libcudart.so.13")
+
+
+# ── iter_cudart_candidates (public discovery surface) ───────────────────
+#
+# Public API: out-of-process consumers (the tesseract_jax C++ shim) dlopen
+# libcudart using these candidates, so its contract -- ordering, dedup, and that
+# every item is a bare soname or absolute path -- is part of the interface.
+
+
+def test_iter_cudart_candidates_orders_system_then_wheel(monkeypatch):
+    """find_library hits come first, then bare sonames, then wheel paths."""
+    monkeypatch.setattr(
+        cuda_ipc.ctypes.util,
+        "find_library",
+        lambda name: "/usr/lib/libcudart.so.12" if name == "cudart" else None,
+    )
+    monkeypatch.setattr(
+        cuda_ipc,
+        "_iter_wheel_cudart_paths",
+        lambda: ["/wheel/nvidia/lib/libcudart.so.12"],
+    )
+
+    candidates = list(cuda_ipc.iter_cudart_candidates())
+
+    # System loader's resolved path leads.
+    assert candidates[0] == "/usr/lib/libcudart.so.12"
+    # Bare sonames sit in the middle, wheel path last.
+    assert "libcudart.so" in candidates
+    assert candidates[-1] == "/wheel/nvidia/lib/libcudart.so.12"
+    assert candidates.index("libcudart.so") < candidates.index(
+        "/wheel/nvidia/lib/libcudart.so.12"
+    )
+
+
+def test_iter_cudart_candidates_dedups_preserving_order(monkeypatch):
+    """A path surfaced by both find_library and the wheel search appears once."""
+    dup = "/wheel/nvidia/lib/libcudart.so.12"
+    monkeypatch.setattr(
+        cuda_ipc.ctypes.util,
+        "find_library",
+        lambda name: dup if name == "cudart" else None,
+    )
+    monkeypatch.setattr(cuda_ipc, "_iter_wheel_cudart_paths", lambda: [dup])
+
+    candidates = list(cuda_ipc.iter_cudart_candidates())
+
+    assert candidates.count(dup) == 1
+    # The earlier (find_library) occurrence wins its position.
+    assert candidates[0] == dup
+
+
+def test_iter_cudart_candidates_are_dlopen_arguments(monkeypatch):
+    """Every candidate is a bare soname or an absolute path (never a stem).
+
+    C++ consumers pass these straight to dlopen/LoadLibrary, which need a real
+    library name or path -- not a find_library stem like ``"cudart"``.
+    """
+    monkeypatch.setattr(cuda_ipc.ctypes.util, "find_library", lambda name: None)
+    monkeypatch.setattr(cuda_ipc, "_iter_wheel_cudart_paths", list)
+
+    for candidate in cuda_ipc.iter_cudart_candidates():
+        # A real soname (lib*.so*/lib*.dylib), a Windows DLL, or an absolute
+        # path -- never a bare find_library stem like "cudart" / "cudart64_12".
+        is_soname = candidate.startswith("lib") or candidate.endswith(".dll")
+        is_path = candidate.startswith("/")
+        assert is_soname or is_path, candidate

--- a/tests/test_cuda_ipc_cpu.py
+++ b/tests/test_cuda_ipc_cpu.py
@@ -754,3 +754,50 @@ def test_find_cudart_falls_back_to_wheel(tmp_path, monkeypatch):
     handle = cuda_ipc._find_cudart()
     assert handle is not None
     assert loaded["path"] == str(lib_dir / "libcudart.so.12")
+
+
+def test_iter_wheel_cudart_paths_finds_unenumerated_future_major(tmp_path, monkeypatch):
+    """A wheel shipping a CUDA major we never hardcoded is still discovered.
+
+    The wheel search globs by filename rather than probing a fixed set, so a
+    runtime released after this code was written (here ``.so.99``) is picked up
+    without any change to the version lists.
+    """
+    future_soname = f"libcudart.so.{cuda_ipc._CUDART_MAJOR_NEWEST + 79}"
+    lib_dir = _fake_cudart_wheel(tmp_path, soname=future_soname)
+
+    real_find_spec = cuda_ipc.importlib.util.find_spec
+
+    def fake_find_spec(name):
+        if name == "nvidia.cuda_runtime":
+            spec = types.SimpleNamespace()
+            spec.submodule_search_locations = [str(lib_dir.parent)]
+            return spec
+        return real_find_spec(name)
+
+    monkeypatch.setattr(cuda_ipc.importlib.util, "find_spec", fake_find_spec)
+
+    found = list(cuda_ipc._iter_wheel_cudart_paths())
+    assert str(lib_dir / future_soname) in found
+
+
+def test_iter_wheel_cudart_paths_prefers_newest_major(tmp_path, monkeypatch):
+    """When a wheel lib dir holds several runtimes, the newest major comes first."""
+    lib_dir = tmp_path / "nvidia" / "cuda_runtime" / "lib"
+    lib_dir.mkdir(parents=True)
+    for soname in ("libcudart.so.11", "libcudart.so.13", "libcudart.so.12"):
+        (lib_dir / soname).write_bytes(b"")
+
+    real_find_spec = cuda_ipc.importlib.util.find_spec
+
+    def fake_find_spec(name):
+        if name == "nvidia.cuda_runtime":
+            spec = types.SimpleNamespace()
+            spec.submodule_search_locations = [str(lib_dir.parent)]
+            return spec
+        return real_find_spec(name)
+
+    monkeypatch.setattr(cuda_ipc.importlib.util, "find_spec", fake_find_spec)
+
+    found = list(cuda_ipc._iter_wheel_cudart_paths())
+    assert found[0] == str(lib_dir / "libcudart.so.13")


### PR DESCRIPTION
#### Relevant issue or PR

Unblocks the GPU-direct `cuda_ipc` work in the sibling repos:
- pasteurlabs/tesseract-jax#239
- pasteurlabs/tesseract-torch#42

Both currently carry a temporary CI `LD_LIBRARY_PATH` workaround that this PR lets them drop (once released + their locks bumped).

#### Description of changes

Three related changes to how the `cuda_ipc` codec locates libcudart.

**1. Find wheel-installed libcudart.** The codec loaded libcudart via `ctypes.util.find_library` and bare sonames, neither of which searches the **pip CUDA wheels** (`nvidia-cuda-runtime*`, under `site-packages/nvidia/*/lib`). On a host with **no system CUDA toolkit** — a GPU CI runner where `jax[cudaNN]` / `cupy` pull the runtime in as wheels — decode failed with *"Could not find CUDA runtime library (libcudart)"*, even though jax/cupy themselves worked (their loaders `dlopen` the wheel copy by absolute path, which doesn't make the bare soname resolvable for a later `ctypes.CDLL`). `_iter_wheel_cudart_paths()` now locates the wheel lib dir via `importlib.util.find_spec("nvidia.cuda_runtime")`, with a glob over the whole `nvidia` namespace as fallback.

**2. Forward-compatibility across CUDA majors.** The old hardcoded soname list (`.so.11/.12/.13`) meant every new CUDA release needed a code edit. Since the codec only calls long-stable runtime symbols, versioned names are now generated over an open-ended major range (`_CUDART_MAJORS`, 20→11), and the wheel search globs `libcudart.so.*` and picks the newest present. A future `libcudart.so.14` is found with no change here.

**3. Public discovery API.** New `iter_cudart_candidates()` yields the ordered names/paths to try — each valid for both `ctypes.CDLL` and a raw `dlopen`. This lets out-of-process consumers (the tesseract-jax C++ FFI shim, which `dlopen`s libcudart itself and has the *same* hardcoded-soname + no-wheel-fallback gap) reuse this discovery instead of duplicating it. `_find_cudart()` is now just a loop over it.

No behavior change where libcudart is already on the loader path.

#### Testing done

- Added CPU tests (`tests/test_cuda_ipc_cpu.py`): both wheel-discovery paths, the newest-major preference, an unenumerated future major (`.so.99`), the `_find_cudart` wheel fallback, and the `iter_cudart_candidates` contract (ordering, dedup, dlopen-able items).
- Reproduced the wheel-only condition locally (system loader blinded, libcudart only under a wheel dir) and confirmed `_get_cudart()` resolves it.
- Full GPU `cuda_ipc` suite passes on an A100 (44 passed) through the refactored loader.
