### PR TITLE
feat: Let both packages be run as modules

### DIFF
--- a/docs/content/introduction/installation.md
+++ b/docs/content/introduction/installation.md
@@ -104,6 +104,14 @@ We recommend always using a dedicated Python virtual environment. If you use `zs
 $ hash -r
 ```
 
+You can also bypass the name entirely and invoke Tesseract through the
+interpreter you installed it into, which is unambiguous:
+
+```bash
+$ python -m tesseract_core build examples/vectoradd/ vectoradd
+$ python -m tesseract_core.runtime --help   # the runtime, likewise
+```
+
 To confirm which executable `tesseract` resolves to:
 
 ```bash

--- a/tesseract_core/__main__.py
+++ b/tesseract_core/__main__.py
@@ -1,0 +1,13 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Entrypoint for ``python -m tesseract_core``.
+
+Equivalent to the ``tesseract`` console script, but reachable via an interpreter
+path alone. Useful when its scripts directory is not on ``PATH``, and when
+``tesseract`` on this machine is the OCR engine of the same name.
+"""
+
+from tesseract_core.sdk.cli import entrypoint
+
+if __name__ == "__main__":
+    entrypoint()

--- a/tesseract_core/runtime/__init__.py
+++ b/tesseract_core/runtime/__init__.py
@@ -14,6 +14,10 @@ try:
         if path.stem.startswith("app_"):
             # Instantiated versions of apps for testing and CLI that have side effects at import time.
             continue
+        if path.stem == "__main__":
+            # Importing this as a side effect of importing the package makes
+            # `python -m tesseract_core.runtime` warn about a double import.
+            continue
         if path.stem in ("jax_recipes",):
             # Recipes typically have optional dependencies that we don't want to require
             # for the core runtime.

--- a/tesseract_core/runtime/__main__.py
+++ b/tesseract_core/runtime/__main__.py
@@ -1,0 +1,12 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Entrypoint for ``python -m tesseract_core.runtime``.
+
+Equivalent to the ``tesseract-runtime`` console script, but reachable via an
+interpreter path alone, without knowing where its scripts directory is.
+"""
+
+from tesseract_core.runtime.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/tests/sdk_tests/test_cli.py
+++ b/tests/sdk_tests/test_cli.py
@@ -8,6 +8,7 @@
 
 import os
 import subprocess
+import sys
 
 import pytest
 
@@ -149,3 +150,39 @@ def test_config_override(
         result = _run_with_override(arg_to_override, value)
         assert result.exit_code == 0, result.stderr
         assert mocked_build.call_args[1]["config_override"] == expected
+
+
+@pytest.mark.parametrize("module", ["tesseract_core", "tesseract_core.runtime"])
+def test_runnable_as_a_module(module, dummy_tesseract_package):
+    """Both packages must be reachable by interpreter path alone.
+
+    The console scripts need their directory on PATH, and `tesseract` collides
+    with the OCR engine of the same name; `python -m` sidesteps both. The runtime
+    also relies on this to serve a Tesseract from another environment, where only
+    the interpreter is known.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", module, "--help"],
+        capture_output=True,
+        text=True,
+        # The runtime builds its commands from a Tesseract, so it needs one to
+        # have something to describe.
+        env={
+            **os.environ,
+            # The runtime builds its commands from a Tesseract, so it needs one
+            # to have something to describe.
+            "TESSERACT_API_PATH": str(dummy_tesseract_package / "tesseract_api.py"),
+            # As elsewhere in the suite: no colour codes chopping up the text we
+            # match on, and wide enough that rich does not wrap it either.
+            "TERM": "dumb",
+            "COLUMNS": "1000",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    # The two CLIs print help to different streams, and which one is not the point
+    # here -- that the module was found and ran under its own name is.
+    assert f"python -m {module}" in result.stdout + result.stderr
+    # Importing a package should not drag in its own __main__; runpy warns if it
+    # has, and a warning on every invocation would land in captured logs.
+    assert "RuntimeWarning" not in result.stderr


### PR DESCRIPTION
#### Relevant issue or PR

Suggested by @dionhaefner on #669.

#### Description of changes

Both packages are now runnable as modules, so an interpreter path is enough to say exactly which Tesseract you mean:

```bash
$ python -m tesseract_core build examples/vectoradd/ vectoradd
$ python -m tesseract_core.runtime --help
```

#### Testing done

Small import tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)