### PR TITLE
feat(runtime): sample VJP outputs in check-gradients

### DIFF
--- a/tesseract_core/runtime/cli.py
+++ b/tesseract_core/runtime/cli.py
@@ -343,6 +343,17 @@ def check_gradients(
             show_default=True,
         ),
     ] = 1000,
+    max_output_samples: Annotated[
+        int | None,
+        typer.Option(
+            "--max-output-samples",
+            help=(
+                "Maximum number of output elements to sample when checking "
+                "vector_jacobian_product."
+            ),
+            show_default="check all",
+        ),
+    ] = None,
     max_failures: Annotated[
         int,
         typer.Option(
@@ -397,6 +408,7 @@ def check_gradients(
         output_paths=output_paths,
         endpoints=endpoints,
         max_evals=max_evals,
+        max_output_samples=max_output_samples,
         eps=eps,
         rtol=rtol,
         seed=seed,

--- a/tesseract_core/runtime/cli.py
+++ b/tesseract_core/runtime/cli.py
@@ -348,7 +348,7 @@ def check_gradients(
         typer.Option(
             "--max-output-samples",
             help=(
-                "Maximum number of output elements to sample when checking "
+                "Maximum number of random cotangent probes used when checking "
                 "vector_jacobian_product."
             ),
             show_default="check all",

--- a/tesseract_core/runtime/cli.py
+++ b/tesseract_core/runtime/cli.py
@@ -348,7 +348,7 @@ def check_gradients(
         typer.Option(
             "--max-output-samples",
             help=(
-                "Maximum number of random cotangent probes used when checking "
+                "Maximum number of output elements sampled when checking "
                 "vector_jacobian_product."
             ),
             show_default="check all",

--- a/tesseract_core/runtime/testing/finite_differences.py
+++ b/tesseract_core/runtime/testing/finite_differences.py
@@ -120,13 +120,23 @@ def _by_index(input_path: Any, output_path: Any, input_idx: Any) -> tuple:
     return (input_path, output_path, tuple(input_idx))
 
 
-def _by_sampled_set(input_path: Any, output_path: Any, sampled: Any) -> tuple:
-    """Key a VJP sweep on the path pair and the set it answers for.
+class _VjpSweepTarget(NamedTuple):
+    """Target indices for a shared VJP sweep across inputs and outputs."""
 
-    One sweep covers every sampled index of a pair, so keying it per index
-    would defeat the sharing.
-    """
-    return (input_path, output_path, tuple(sampled))
+    wanted_inputs: tuple[tuple[int, ...], ...]
+    sampled_outputs: tuple[tuple[int, ...], ...] | None
+
+
+def _by_sampled_set(
+    input_path: Any,
+    output_path: Any,
+    target: _VjpSweepTarget,
+) -> tuple:
+    """Key a VJP sweep on the path pair and the input/output sets it answers for."""
+    out_key = (
+        tuple(target.sampled_outputs) if target.sampled_outputs is not None else None
+    )
+    return (input_path, output_path, tuple(target.wanted_inputs), out_key)
 
 
 def _cached_function(*, key_fn: Callable) -> Callable:
@@ -347,7 +357,8 @@ def _vjp_sweep(
     inputs: dict[str, Any],
     input_path: Sequence[str],
     output_path: Sequence[str],
-    wanted: tuple[tuple[int, ...], ...],
+    target: _VjpSweepTarget,
+    outputs: dict[str, Any],
 ) -> dict[tuple[int, ...], ArrayLike]:
     """Sweep one-hot cotangents over the output and keep the wanted rows.
 
@@ -361,16 +372,35 @@ def _vjp_sweep(
     Only the wanted rows are retained, so the full Jacobian is never
     materialised.
     """
-    apply_fn = endpoints_func["apply"]
-    ApplySchema = get_input_schema(apply_fn)
-    outputs = apply_fn(ApplySchema.model_validate({"inputs": inputs})).model_dump()
-
     vjp_fn = endpoints_func["vector_jacobian_product"]
     VjpSchema = get_input_schema(vjp_fn)
     template = np.zeros_like(get_at_path(outputs, output_path))
-    rows = {idx: np.zeros_like(template) for idx in wanted}
 
-    for col_idx in np.ndindex(template.shape):
+    if target.sampled_outputs is None:
+        rows = {idx: np.zeros_like(template) for idx in target.wanted_inputs}
+        for col_idx in np.ndindex(template.shape):
+            cotangent = np.zeros_like(template)
+            cotangent[col_idx] = 1
+            vjp = vjp_fn(
+                VjpSchema.model_validate(
+                    {
+                        "inputs": inputs,
+                        "vjp_inputs": [input_path],
+                        "vjp_outputs": [output_path],
+                        "cotangent_vector": {output_path: cotangent},
+                    }
+                )
+            ).model_dump()
+            grad = vjp[input_path]
+            for idx in target.wanted_inputs:
+                rows[idx][col_idx] = grad[idx]
+        return rows
+
+    rows = {
+        idx: np.zeros(len(target.sampled_outputs), dtype=template.dtype)
+        for idx in target.wanted_inputs
+    }
+    for col_pos, col_idx in enumerate(target.sampled_outputs):
         cotangent = np.zeros_like(template)
         cotangent[col_idx] = 1
         vjp = vjp_fn(
@@ -384,8 +414,8 @@ def _vjp_sweep(
             )
         ).model_dump()
         grad = vjp[input_path]
-        for idx in wanted:
-            rows[idx][col_idx] = grad[idx]
+        for idx in target.wanted_inputs:
+            rows[idx][col_pos] = grad[idx]
     return rows
 
 
@@ -395,7 +425,9 @@ def _jacobian_via_vjp(
     input_path: Sequence[str],
     output_path: Sequence[str],
     input_idx: tuple[int, ...],
+    outputs: dict[str, Any],
     sampled_input_idx: tuple[tuple[int, ...], ...] = (),
+    sampled_output_idx: tuple[tuple[int, ...], ...] | None = None,
 ) -> ArrayLike:
     """Return one Jacobian row from the sweep shared by this path pair.
 
@@ -405,7 +437,8 @@ def _jacobian_via_vjp(
     for a single row like the other three helpers.
     """
     wanted = tuple(dict.fromkeys((*sampled_input_idx, tuple(input_idx))))
-    return _vjp_sweep(endpoints_func, inputs, input_path, output_path, wanted)[
+    target = _VjpSweepTarget(wanted_inputs=wanted, sampled_outputs=sampled_output_idx)
+    return _vjp_sweep(endpoints_func, inputs, input_path, output_path, target, outputs)[
         tuple(input_idx)
     ]
 
@@ -450,13 +483,16 @@ def check_endpoint_gradients(
     endpoint_functions: dict[str, Callable],
     inputs: dict[str, Any],
     endpoint: str,
+    outputs: dict[str, Any],
     *,
     diff_inputs: list[str],
     diff_outputs: list[str],
     max_evals: int,
+    max_output_samples: int | None = None,
     eps: float,
     rtol: float,
     rng: np.random.RandomState,
+    output_rng: np.random.RandomState | None = None,
     show_progress: bool,
 ) -> tuple[list[GradientCheckResult], int]:
     """Check gradients of an endpoint against a finite difference approximation."""
@@ -481,6 +517,30 @@ def check_endpoint_gradients(
         sampled_by_pair.setdefault((in_path, out_path), ())
         sampled_by_pair[(in_path, out_path)] += (tuple(idx),)
 
+    sampled_outputs_by_pair: dict[
+        tuple[str, str], tuple[tuple[int, ...], ...] | None
+    ] = {}
+    if endpoint == "vector_jacobian_product" and max_output_samples is not None:
+        actual_output_rng = output_rng if output_rng is not None else rng
+        for in_path, out_path in sampled_by_pair:
+            out_val = get_at_path(outputs, out_path)
+            out_shape = np.shape(out_val)
+            n_output_elements = int(np.prod(out_shape, dtype=int)) if out_shape else 1
+            if max_output_samples < n_output_elements:
+                flat_idx = actual_output_rng.choice(
+                    n_output_elements, size=max_output_samples, replace=False
+                )
+                unraveled = np.unravel_index(flat_idx, out_shape)
+                sampled_outputs_by_pair[(in_path, out_path)] = tuple(
+                    tuple(int(dim[i]) for dim in unraveled)
+                    for i in range(max_output_samples)
+                )
+            else:
+                sampled_outputs_by_pair[(in_path, out_path)] = None
+    else:
+        for in_path, out_path in sampled_by_pair:
+            sampled_outputs_by_pair[(in_path, out_path)] = None
+
     try:
         with Progress(disable=not show_progress) as progress:
             subtask = progress.add_task(
@@ -500,11 +560,16 @@ def check_endpoint_gradients(
                         idx,
                         eps=eps,
                     )
-                    grad_kwargs = (
-                        {"sampled_input_idx": sampled_by_pair[(in_path, out_path)]}
-                        if endpoint == "vector_jacobian_product"
-                        else {}
-                    )
+                    if endpoint == "vector_jacobian_product":
+                        col_indices = sampled_outputs_by_pair.get((in_path, out_path))
+                        grad_kwargs = {
+                            "outputs": outputs,
+                            "sampled_input_idx": sampled_by_pair[(in_path, out_path)],
+                            "sampled_output_idx": col_indices,
+                        }
+                    else:
+                        col_indices = None
+                        grad_kwargs = {}
                     result_grad = _jacobian_via_grad(
                         endpoint_functions,
                         inputs,
@@ -525,13 +590,21 @@ def check_endpoint_gradients(
                         exception=exc_info,
                     )
                 else:
-                    if not np.allclose(result_apply, result_grad, atol=1e-8, rtol=rtol):
+                    if col_indices is not None:
+                        reference = np.asarray(result_apply)
+                        ref_val = np.asarray([reference[c] for c in col_indices])
+                        grad_val = np.asarray(result_grad)
+                    else:
+                        ref_val = result_apply
+                        grad_val = result_grad
+
+                    if not np.allclose(ref_val, grad_val, atol=1e-8, rtol=rtol):
                         failure = GradientCheckResult(
                             in_path=in_path,
                             out_path=out_path,
                             idx=idx,
-                            ref_val=result_apply,
-                            grad_val=result_grad,
+                            ref_val=ref_val,
+                            grad_val=grad_val,
                             exception=None,
                         )
 
@@ -563,6 +636,7 @@ def check_gradients(
     base_dir: Path | None = None,
     endpoints: Sequence[GradientEndpointName] | None = None,
     max_evals: int = 1000,
+    max_output_samples: int | None = None,
     eps: float = 1e-4,
     rtol: float = 0.1,
     seed: int | None = None,
@@ -578,11 +652,16 @@ def check_gradients(
         base_dir: The base directory to resolve relative paths.
         endpoints: The gradient endpoints to check. If not provided, all available endpoints are checked.
         max_evals: The target number of ``apply`` evaluations to perform.
+        max_output_samples: Maximum number of output elements sampled when checking the
+            vector_jacobian_product endpoint. If None, all output elements are checked.
         eps: The epsilon to use for finite differences, as a fraction of the maximum absolute value of each input.
         rtol: The relative tolerance to use for comparison.
         seed: The random seed to use for sampling. If not provided, a random seed is used.
         show_progress: Whether to show a progress bar.
     """
+    if max_output_samples is not None and max_output_samples <= 0:
+        raise ValueError("max_output_samples must be greater than 0")
+
     # We apply a global cache to these functions to avoid hashing `inputs` multiple times,
     # so we need to clear the cache before each run.
     _jacobian_via_apply.clear_cache()
@@ -641,18 +720,22 @@ def check_gradients(
 
     # Check gradients for each endpoint separately
     rng = np.random.RandomState(seed)
+    output_rng = np.random.RandomState(seed)
 
     for endpoint in endpoints:
         failures, num_evals = check_endpoint_gradients(
             endpoint_functions,
             inputs,
             endpoint,
+            outputs=outputs,
             diff_inputs=input_paths,
             diff_outputs=output_paths,
             max_evals=max_evals,
+            max_output_samples=max_output_samples,
             eps=eps,
             rtol=rtol,
             rng=rng,
+            output_rng=output_rng,
             show_progress=show_progress,
         )
         yield endpoint, failures, num_evals

--- a/tesseract_core/runtime/testing/finite_differences.py
+++ b/tesseract_core/runtime/testing/finite_differences.py
@@ -121,10 +121,16 @@ def _by_index(input_path: Any, output_path: Any, input_idx: Any) -> tuple:
 
 
 class _VjpSweepTarget(NamedTuple):
-    """Target indices for a shared VJP sweep across inputs and outputs."""
+    """Target specification for a shared VJP sweep.
+
+    When ``probe_seed`` is ``None`` the sweep uses exhaustive one-hot
+    cotangents.  Otherwise it generates ``num_probes`` dense Gaussian
+    cotangent probes from the given seed.
+    """
 
     wanted_inputs: tuple[tuple[int, ...], ...]
-    sampled_outputs: tuple[tuple[int, ...], ...] | None
+    probe_seed: int | None = None
+    num_probes: int | None = None
 
 
 def _by_sampled_set(
@@ -132,11 +138,14 @@ def _by_sampled_set(
     output_path: Any,
     target: _VjpSweepTarget,
 ) -> tuple:
-    """Key a VJP sweep on the path pair and the input/output sets it answers for."""
-    out_key = (
-        tuple(target.sampled_outputs) if target.sampled_outputs is not None else None
+    """Key a VJP sweep on the path pair and the probe specification it answers for."""
+    return (
+        input_path,
+        output_path,
+        tuple(target.wanted_inputs),
+        target.probe_seed,
+        target.num_probes,
     )
-    return (input_path, output_path, tuple(target.wanted_inputs), out_key)
 
 
 def _cached_function(*, key_fn: Callable) -> Callable:
@@ -351,6 +360,34 @@ def _jacobian_via_jvp(
     return jvp[output_path]
 
 
+def _generate_vjp_probes(
+    probe_seed: int,
+    num_probes: int,
+    output_shape: tuple[int, ...],
+    output_dtype: np.dtype,
+) -> list[np.ndarray]:
+    """Generate deterministic unit-norm Gaussian cotangent probes.
+
+    The same ``probe_seed`` and ``num_probes`` always produce the identical
+    sequence, so both the VJP sweep and the finite-difference projection
+    reconstruct exactly the same directions.
+    """
+    if num_probes == 0 or int(np.prod(output_shape, dtype=int)) == 0:
+        return [np.zeros(output_shape, dtype=output_dtype) for _ in range(num_probes)]
+
+    rng = np.random.RandomState(probe_seed)
+    probes: list[np.ndarray] = []
+    for _ in range(num_probes):
+        raw = rng.standard_normal(output_shape)
+        norm = np.linalg.norm(raw.reshape(-1))
+        while not np.isfinite(norm) or norm == 0.0:
+            raw = rng.standard_normal(output_shape)
+            norm = np.linalg.norm(raw.reshape(-1))
+        probe = (raw / norm).astype(output_dtype, copy=False)
+        probes.append(probe)
+    return probes
+
+
 @_cached_function(key_fn=_by_sampled_set)
 def _vjp_sweep(
     endpoints_func: dict[str, Callable],
@@ -360,23 +397,20 @@ def _vjp_sweep(
     target: _VjpSweepTarget,
     outputs: dict[str, Any],
 ) -> dict[tuple[int, ...], ArrayLike]:
-    """Sweep one-hot cotangents over the output and keep the wanted rows.
+    """Sweep cotangents over the output and keep the wanted input rows.
 
-    One VJP call with a one-hot cotangent returns the gradient with respect
-    to every element of ``input_path``, so a single sweep over the output
-    elements answers for all sampled indices at once. Keeping just one
-    element and re-running the sweep per index cost
-    ``n_sampled x n_output_elements`` calls, where ``jacobian`` and
-    ``jacobian_vector_product`` cost one per item.
-
-    Only the wanted rows are retained, so the full Jacobian is never
-    materialised.
+    When ``target.probe_seed`` is ``None`` the sweep uses exhaustive one-hot
+    cotangents (one VJP call per output element).  Otherwise it generates
+    ``target.num_probes`` dense Gaussian cotangent probes and performs one
+    VJP call per probe.  Each VJP call returns gradients for all input
+    elements, so the sweep is shared across every sampled input index.
     """
     vjp_fn = endpoints_func["vector_jacobian_product"]
     VjpSchema = get_input_schema(vjp_fn)
     template = np.zeros_like(get_at_path(outputs, output_path))
 
-    if target.sampled_outputs is None:
+    if target.probe_seed is None:
+        # Exhaustive one-hot sweep
         rows = {idx: np.zeros_like(template) for idx in target.wanted_inputs}
         for col_idx in np.ndindex(template.shape):
             cotangent = np.zeros_like(template)
@@ -396,26 +430,28 @@ def _vjp_sweep(
                 rows[idx][col_idx] = grad[idx]
         return rows
 
+    # Dense Gaussian probe sweep: (u^T J) v = u^T (J v)
+    probes = _generate_vjp_probes(
+        target.probe_seed, target.num_probes, template.shape, template.dtype
+    )
     rows = {
-        idx: np.zeros(len(target.sampled_outputs), dtype=template.dtype)
+        idx: np.zeros(target.num_probes, dtype=template.dtype)
         for idx in target.wanted_inputs
     }
-    for col_pos, col_idx in enumerate(target.sampled_outputs):
-        cotangent = np.zeros_like(template)
-        cotangent[col_idx] = 1
+    for k, probe in enumerate(probes):
         vjp = vjp_fn(
             VjpSchema.model_validate(
                 {
                     "inputs": inputs,
                     "vjp_inputs": [input_path],
                     "vjp_outputs": [output_path],
-                    "cotangent_vector": {output_path: cotangent},
+                    "cotangent_vector": {output_path: probe},
                 }
             )
         ).model_dump()
         grad = vjp[input_path]
         for idx in target.wanted_inputs:
-            rows[idx][col_pos] = grad[idx]
+            rows[idx][k] = grad[idx]
     return rows
 
 
@@ -427,9 +463,10 @@ def _jacobian_via_vjp(
     input_idx: tuple[int, ...],
     outputs: dict[str, Any],
     sampled_input_idx: tuple[tuple[int, ...], ...] = (),
-    sampled_output_idx: tuple[tuple[int, ...], ...] | None = None,
+    probe_seed: int | None = None,
+    num_probes: int | None = None,
 ) -> ArrayLike:
-    """Return one Jacobian row from the sweep shared by this path pair.
+    """Return one Jacobian row (or probe projections) from the shared VJP sweep.
 
     ``sampled_input_idx`` is the set this pair will be asked for. It goes
     into the cache key so that one sweep serves every index in it, which is
@@ -437,7 +474,9 @@ def _jacobian_via_vjp(
     for a single row like the other three helpers.
     """
     wanted = tuple(dict.fromkeys((*sampled_input_idx, tuple(input_idx))))
-    target = _VjpSweepTarget(wanted_inputs=wanted, sampled_outputs=sampled_output_idx)
+    target = _VjpSweepTarget(
+        wanted_inputs=wanted, probe_seed=probe_seed, num_probes=num_probes
+    )
     return _vjp_sweep(endpoints_func, inputs, input_path, output_path, target, outputs)[
         tuple(input_idx)
     ]
@@ -517,9 +556,9 @@ def check_endpoint_gradients(
         sampled_by_pair.setdefault((in_path, out_path), ())
         sampled_by_pair[(in_path, out_path)] += (tuple(idx),)
 
-    sampled_outputs_by_pair: dict[
-        tuple[str, str], tuple[tuple[int, ...], ...] | None
-    ] = {}
+    # Determine probe specification for each path pair.
+    # probe_seed=None means exhaustive one-hot sweep.
+    probe_spec_by_pair: dict[tuple[str, str], tuple[int | None, int | None]] = {}
     if endpoint == "vector_jacobian_product" and max_output_samples is not None:
         actual_output_rng = output_rng if output_rng is not None else rng
         for in_path, out_path in sampled_by_pair:
@@ -527,19 +566,18 @@ def check_endpoint_gradients(
             out_shape = np.shape(out_val)
             n_output_elements = int(np.prod(out_shape, dtype=int)) if out_shape else 1
             if max_output_samples < n_output_elements:
-                flat_idx = actual_output_rng.choice(
-                    n_output_elements, size=max_output_samples, replace=False
+                probe_seed = int(
+                    actual_output_rng.randint(0, 2**32 - 1, dtype=np.int64)
                 )
-                unraveled = np.unravel_index(flat_idx, out_shape)
-                sampled_outputs_by_pair[(in_path, out_path)] = tuple(
-                    tuple(int(dim[i]) for dim in unraveled)
-                    for i in range(max_output_samples)
+                probe_spec_by_pair[(in_path, out_path)] = (
+                    probe_seed,
+                    max_output_samples,
                 )
             else:
-                sampled_outputs_by_pair[(in_path, out_path)] = None
+                probe_spec_by_pair[(in_path, out_path)] = (None, None)
     else:
         for in_path, out_path in sampled_by_pair:
-            sampled_outputs_by_pair[(in_path, out_path)] = None
+            probe_spec_by_pair[(in_path, out_path)] = (None, None)
 
     try:
         with Progress(disable=not show_progress) as progress:
@@ -561,14 +599,18 @@ def check_endpoint_gradients(
                         eps=eps,
                     )
                     if endpoint == "vector_jacobian_product":
-                        col_indices = sampled_outputs_by_pair.get((in_path, out_path))
+                        p_seed, n_probes = probe_spec_by_pair.get(
+                            (in_path, out_path), (None, None)
+                        )
                         grad_kwargs = {
                             "outputs": outputs,
                             "sampled_input_idx": sampled_by_pair[(in_path, out_path)],
-                            "sampled_output_idx": col_indices,
+                            "probe_seed": p_seed,
+                            "num_probes": n_probes,
                         }
                     else:
-                        col_indices = None
+                        p_seed = None
+                        n_probes = None
                         grad_kwargs = {}
                     result_grad = _jacobian_via_grad(
                         endpoint_functions,
@@ -590,9 +632,22 @@ def check_endpoint_gradients(
                         exception=exc_info,
                     )
                 else:
-                    if col_indices is not None:
-                        reference = np.asarray(result_apply)
-                        ref_val = np.asarray([reference[c] for c in col_indices])
+                    if p_seed is not None and n_probes is not None:
+                        # Dense probe comparison: (u^T J) v = u^T (J v)
+                        out_val = get_at_path(outputs, out_path)
+                        probes = _generate_vjp_probes(
+                            p_seed,
+                            n_probes,
+                            np.shape(out_val),
+                            np.asarray(out_val).dtype,
+                        )
+                        fd_row = np.asarray(result_apply).reshape(-1)
+                        ref_val = np.asarray(
+                            [
+                                np.dot(np.asarray(probe).reshape(-1), fd_row)
+                                for probe in probes
+                            ]
+                        )
                         grad_val = np.asarray(result_grad)
                     else:
                         ref_val = result_apply
@@ -652,8 +707,9 @@ def check_gradients(
         base_dir: The base directory to resolve relative paths.
         endpoints: The gradient endpoints to check. If not provided, all available endpoints are checked.
         max_evals: The target number of ``apply`` evaluations to perform.
-        max_output_samples: Maximum number of output elements sampled when checking the
-            vector_jacobian_product endpoint. If None, all output elements are checked.
+        max_output_samples: Maximum number of random cotangent probes used when checking
+            the vector_jacobian_product endpoint. If None, all output elements are checked
+            exhaustively.
         eps: The epsilon to use for finite differences, as a fraction of the maximum absolute value of each input.
         rtol: The relative tolerance to use for comparison.
         seed: The random seed to use for sampling. If not provided, a random seed is used.

--- a/tesseract_core/runtime/testing/finite_differences.py
+++ b/tesseract_core/runtime/testing/finite_differences.py
@@ -123,14 +123,13 @@ def _by_index(input_path: Any, output_path: Any, input_idx: Any) -> tuple:
 class _VjpSweepTarget(NamedTuple):
     """Target specification for a shared VJP sweep.
 
-    When ``probe_seed`` is ``None`` the sweep uses exhaustive one-hot
-    cotangents.  Otherwise it generates ``num_probes`` dense Gaussian
-    cotangent probes from the given seed.
+    When ``sampled_outputs`` is None, all output elements are evaluated
+    exhaustively. When it is a tuple of coordinates, only those coordinates are
+    evaluated.
     """
 
     wanted_inputs: tuple[tuple[int, ...], ...]
-    probe_seed: int | None = None
-    num_probes: int | None = None
+    sampled_outputs: tuple[tuple[int, ...], ...] | None = None
 
 
 def _by_sampled_set(
@@ -138,13 +137,12 @@ def _by_sampled_set(
     output_path: Any,
     target: _VjpSweepTarget,
 ) -> tuple:
-    """Key a VJP sweep on the path pair and the probe specification it answers for."""
+    """Key a VJP sweep on the path pair and the sampled input/output set it answers for."""
     return (
         input_path,
         output_path,
         tuple(target.wanted_inputs),
-        target.probe_seed,
-        target.num_probes,
+        target.sampled_outputs,
     )
 
 
@@ -360,34 +358,6 @@ def _jacobian_via_jvp(
     return jvp[output_path]
 
 
-def _generate_vjp_probes(
-    probe_seed: int,
-    num_probes: int,
-    output_shape: tuple[int, ...],
-    output_dtype: np.dtype,
-) -> list[np.ndarray]:
-    """Generate deterministic unit-norm Gaussian cotangent probes.
-
-    The same ``probe_seed`` and ``num_probes`` always produce the identical
-    sequence, so both the VJP sweep and the finite-difference projection
-    reconstruct exactly the same directions.
-    """
-    if num_probes == 0 or int(np.prod(output_shape, dtype=int)) == 0:
-        return [np.zeros(output_shape, dtype=output_dtype) for _ in range(num_probes)]
-
-    rng = np.random.RandomState(probe_seed)
-    probes: list[np.ndarray] = []
-    for _ in range(num_probes):
-        raw = rng.standard_normal(output_shape)
-        norm = np.linalg.norm(raw.reshape(-1))
-        while not np.isfinite(norm) or norm == 0.0:
-            raw = rng.standard_normal(output_shape)
-            norm = np.linalg.norm(raw.reshape(-1))
-        probe = (raw / norm).astype(output_dtype, copy=False)
-        probes.append(probe)
-    return probes
-
-
 @_cached_function(key_fn=_by_sampled_set)
 def _vjp_sweep(
     endpoints_func: dict[str, Callable],
@@ -397,20 +367,21 @@ def _vjp_sweep(
     target: _VjpSweepTarget,
     outputs: dict[str, Any],
 ) -> dict[tuple[int, ...], ArrayLike]:
-    """Sweep cotangents over the output and keep the wanted input rows.
+    """Sweep one-hot cotangents over the output and keep the wanted rows.
 
-    When ``target.probe_seed`` is ``None`` the sweep uses exhaustive one-hot
-    cotangents (one VJP call per output element).  Otherwise it generates
-    ``target.num_probes`` dense Gaussian cotangent probes and performs one
-    VJP call per probe.  Each VJP call returns gradients for all input
-    elements, so the sweep is shared across every sampled input index.
+    One VJP call with a one-hot cotangent returns the gradient with respect
+    to every element of ``input_path``, so a single sweep over the output
+    elements answers for all sampled indices at once.
+
+    When ``target.sampled_outputs`` is None, all output elements are swept
+    exhaustively. When it is a tuple of coordinates, only those coordinates are
+    evaluated.
     """
     vjp_fn = endpoints_func["vector_jacobian_product"]
     VjpSchema = get_input_schema(vjp_fn)
     template = np.zeros_like(get_at_path(outputs, output_path))
 
-    if target.probe_seed is None:
-        # Exhaustive one-hot sweep
+    if target.sampled_outputs is None:
         rows = {idx: np.zeros_like(template) for idx in target.wanted_inputs}
         for col_idx in np.ndindex(template.shape):
             cotangent = np.zeros_like(template)
@@ -430,28 +401,26 @@ def _vjp_sweep(
                 rows[idx][col_idx] = grad[idx]
         return rows
 
-    # Dense Gaussian probe sweep: (u^T J) v = u^T (J v)
-    probes = _generate_vjp_probes(
-        target.probe_seed, target.num_probes, template.shape, template.dtype
-    )
     rows = {
-        idx: np.zeros(target.num_probes, dtype=template.dtype)
+        idx: np.zeros(len(target.sampled_outputs), dtype=template.dtype)
         for idx in target.wanted_inputs
     }
-    for k, probe in enumerate(probes):
+    for col_pos, col_idx in enumerate(target.sampled_outputs):
+        cotangent = np.zeros_like(template)
+        cotangent[col_idx] = 1
         vjp = vjp_fn(
             VjpSchema.model_validate(
                 {
                     "inputs": inputs,
                     "vjp_inputs": [input_path],
                     "vjp_outputs": [output_path],
-                    "cotangent_vector": {output_path: probe},
+                    "cotangent_vector": {output_path: cotangent},
                 }
             )
         ).model_dump()
         grad = vjp[input_path]
         for idx in target.wanted_inputs:
-            rows[idx][k] = grad[idx]
+            rows[idx][col_pos] = grad[idx]
     return rows
 
 
@@ -463,10 +432,9 @@ def _jacobian_via_vjp(
     input_idx: tuple[int, ...],
     outputs: dict[str, Any],
     sampled_input_idx: tuple[tuple[int, ...], ...] = (),
-    probe_seed: int | None = None,
-    num_probes: int | None = None,
+    sampled_output_idx: tuple[tuple[int, ...], ...] | None = None,
 ) -> ArrayLike:
-    """Return one Jacobian row (or probe projections) from the shared VJP sweep.
+    """Return one Jacobian row from the sweep shared by this path pair.
 
     ``sampled_input_idx`` is the set this pair will be asked for. It goes
     into the cache key so that one sweep serves every index in it, which is
@@ -474,15 +442,42 @@ def _jacobian_via_vjp(
     for a single row like the other three helpers.
     """
     wanted = tuple(dict.fromkeys((*sampled_input_idx, tuple(input_idx))))
-    target = _VjpSweepTarget(
-        wanted_inputs=wanted, probe_seed=probe_seed, num_probes=num_probes
-    )
+    target = _VjpSweepTarget(wanted_inputs=wanted, sampled_outputs=sampled_output_idx)
     return _vjp_sweep(endpoints_func, inputs, input_path, output_path, target, outputs)[
         tuple(input_idx)
     ]
 
 
 _jacobian_via_vjp.clear_cache = _vjp_sweep.clear_cache
+
+
+def _sample_coordinates(
+    shape: tuple[int, ...],
+    count: int,
+    rng: np.random.RandomState,
+    *,
+    replace: bool = True,
+) -> list[tuple[int, ...]]:
+    """Sample coordinate tuples from an array of the given shape.
+
+    Args:
+        shape: Shape of the array to sample from.
+        count: Number of coordinates to sample.
+        rng: Random number generator to use.
+        replace: Whether to sample with or without replacement.
+
+    Returns:
+        List of coordinate tuples within the given shape.
+    """
+    if not shape:
+        return [()] * count
+    total_elements = int(np.prod(shape, dtype=int))
+    if total_elements == 0:
+        return []
+    flat_indices = rng.choice(total_elements, size=count, replace=replace)
+    unraveled = np.unravel_index(flat_indices, shape)
+    coords = zip(*(tuple(int(x) for x in dim) for dim in unraveled), strict=True)
+    return list(coords)
 
 
 def _sample_indices(
@@ -505,8 +500,7 @@ def _sample_indices(
             idx_per_input[path] = [()]
             continue
         n_evals = max(1, int(max_evals * np.prod(shape) / total_elements))
-        idx_tuple = np.unravel_index(rng.choice(int(np.prod(shape)), n_evals), shape)
-        idx_per_input[path] = list(zip(*idx_tuple, strict=True))
+        idx_per_input[path] = _sample_coordinates(shape, n_evals, rng, replace=True)
 
     items_to_check = []
     for in_path in diff_inputs:
@@ -556,9 +550,9 @@ def check_endpoint_gradients(
         sampled_by_pair.setdefault((in_path, out_path), ())
         sampled_by_pair[(in_path, out_path)] += (tuple(idx),)
 
-    # Determine probe specification for each path pair.
-    # probe_seed=None means exhaustive one-hot sweep.
-    probe_spec_by_pair: dict[tuple[str, str], tuple[int | None, int | None]] = {}
+    sampled_outputs_by_pair: dict[
+        tuple[str, str], tuple[tuple[int, ...], ...] | None
+    ] = {}
     if endpoint == "vector_jacobian_product" and max_output_samples is not None:
         actual_output_rng = output_rng if output_rng is not None else rng
         for in_path, out_path in sampled_by_pair:
@@ -566,18 +560,19 @@ def check_endpoint_gradients(
             out_shape = np.shape(out_val)
             n_output_elements = int(np.prod(out_shape, dtype=int)) if out_shape else 1
             if max_output_samples < n_output_elements:
-                probe_seed = int(
-                    actual_output_rng.randint(0, 2**32 - 1, dtype=np.int64)
-                )
-                probe_spec_by_pair[(in_path, out_path)] = (
-                    probe_seed,
-                    max_output_samples,
+                sampled_outputs_by_pair[(in_path, out_path)] = tuple(
+                    _sample_coordinates(
+                        out_shape,
+                        max_output_samples,
+                        actual_output_rng,
+                        replace=False,
+                    )
                 )
             else:
-                probe_spec_by_pair[(in_path, out_path)] = (None, None)
+                sampled_outputs_by_pair[(in_path, out_path)] = None
     else:
         for in_path, out_path in sampled_by_pair:
-            probe_spec_by_pair[(in_path, out_path)] = (None, None)
+            sampled_outputs_by_pair[(in_path, out_path)] = None
 
     try:
         with Progress(disable=not show_progress) as progress:
@@ -599,18 +594,14 @@ def check_endpoint_gradients(
                         eps=eps,
                     )
                     if endpoint == "vector_jacobian_product":
-                        p_seed, n_probes = probe_spec_by_pair.get(
-                            (in_path, out_path), (None, None)
-                        )
+                        col_indices = sampled_outputs_by_pair.get((in_path, out_path))
                         grad_kwargs = {
                             "outputs": outputs,
                             "sampled_input_idx": sampled_by_pair[(in_path, out_path)],
-                            "probe_seed": p_seed,
-                            "num_probes": n_probes,
+                            "sampled_output_idx": col_indices,
                         }
                     else:
-                        p_seed = None
-                        n_probes = None
+                        col_indices = None
                         grad_kwargs = {}
                     result_grad = _jacobian_via_grad(
                         endpoint_functions,
@@ -632,22 +623,9 @@ def check_endpoint_gradients(
                         exception=exc_info,
                     )
                 else:
-                    if p_seed is not None and n_probes is not None:
-                        # Dense probe comparison: (u^T J) v = u^T (J v)
-                        out_val = get_at_path(outputs, out_path)
-                        probes = _generate_vjp_probes(
-                            p_seed,
-                            n_probes,
-                            np.shape(out_val),
-                            np.asarray(out_val).dtype,
-                        )
-                        fd_row = np.asarray(result_apply).reshape(-1)
-                        ref_val = np.asarray(
-                            [
-                                np.dot(np.asarray(probe).reshape(-1), fd_row)
-                                for probe in probes
-                            ]
-                        )
+                    if col_indices is not None:
+                        reference = np.asarray(result_apply)
+                        ref_val = np.asarray([reference[c] for c in col_indices])
                         grad_val = np.asarray(result_grad)
                     else:
                         ref_val = result_apply
@@ -707,8 +685,8 @@ def check_gradients(
         base_dir: The base directory to resolve relative paths.
         endpoints: The gradient endpoints to check. If not provided, all available endpoints are checked.
         max_evals: The target number of ``apply`` evaluations to perform.
-        max_output_samples: Maximum number of random cotangent probes used when checking
-            the vector_jacobian_product endpoint. If None, all output elements are checked
+        max_output_samples: Maximum number of output elements sampled when checking the
+            vector_jacobian_product endpoint. If None, all output elements are checked
             exhaustively.
         eps: The epsilon to use for finite differences, as a fraction of the maximum absolute value of each input.
         rtol: The relative tolerance to use for comparison.

--- a/tests/runtime_tests/test_finite_differences.py
+++ b/tests/runtime_tests/test_finite_differences.py
@@ -334,9 +334,6 @@ class RecordingVjpModule(CountingVjpModule):
         )
 
 
-# ── A. VJP CALL BOUND ──
-
-
 def test_vjp_output_sampling_bounds_calls():
     """With max_output_samples=K < n_output_elements, exactly K VJP calls are made."""
     module = RecordingVjpModule("dummy_module", correct_gradients=True)
@@ -363,9 +360,6 @@ def test_vjp_output_sampling_bounds_calls():
         assert np.sum(cot != 0.0) == 1
 
 
-# ── B. SHARED SWEEP ACROSS INPUT INDICES ──
-
-
 def test_vjp_output_sampling_shared_across_sampled_input_rows():
     """All sampled input rows for a path pair must share the same output coordinate sweep."""
     module = CountingVjpModule("dummy_module", correct_gradients=True)
@@ -389,9 +383,6 @@ def test_vjp_output_sampling_shared_across_sampled_input_rows():
     assert module.vjp_calls == 5
 
 
-# ── C. WITHOUT REPLACEMENT ──
-
-
 def test_vjp_output_sampling_without_replacement():
     """Sampled output coordinates must be sampled without replacement (all unique)."""
     module = RecordingVjpModule("dummy_module", correct_gradients=True)
@@ -410,9 +401,6 @@ def test_vjp_output_sampling_without_replacement():
 
     assert len(module.recorded_coords) == 15
     assert len(set(module.recorded_coords)) == 15
-
-
-# ── D. DETERMINISM ──
 
 
 def test_vjp_output_sampling_is_deterministic_with_seed():
@@ -450,9 +438,6 @@ def test_vjp_output_sampling_is_deterministic_with_seed():
     assert module1.recorded_coords == module2.recorded_coords
 
 
-# ── E. DIFFERENT SEEDS ──
-
-
 def test_vjp_output_sampling_different_seeds_differ():
     """Different seeds should produce different sampled output coordinates."""
     module1 = RecordingVjpModule("dummy_module", correct_gradients=True)
@@ -486,9 +471,6 @@ def test_vjp_output_sampling_different_seeds_differ():
     assert len(module1.recorded_coords) == 5
     assert len(module2.recorded_coords) == 5
     assert module1.recorded_coords != module2.recorded_coords
-
-
-# ── F. COORDINATE ALIGNMENT ──
 
 
 class NonzeroLinearModule(ModuleType):
@@ -552,9 +534,6 @@ def test_vjp_output_sampling_coordinate_alignment():
     assert num_evals_total > 0
 
 
-# ── G. INCORRECT GRADIENTS ──
-
-
 def test_vjp_output_sampling_wrong_gradients_fail():
     """Sampling must not mask real gradient errors: incorrect VJPs must still be caught."""
     bad_module = NonzeroLinearModule("nonzero_linear_module", correct_gradients=False)
@@ -583,9 +562,6 @@ def test_vjp_output_sampling_wrong_gradients_fail():
         assert len(failure.grad_val) == 3
         for ref, grad in zip(failure.ref_val, failure.grad_val, strict=True):
             assert abs(grad - ref) >= 49.0
-
-
-# ── H. MULTIDIMENSIONAL OUTPUT ──
 
 
 class MultidimensionalModule(ModuleType):
@@ -713,9 +689,6 @@ def test_vjp_output_sampling_cap_greater_than_multidimensional_output_stays_exha
     assert module.vjp_calls == 24
 
 
-# ── I. LARGE OUTPUT ASYMPTOTICS ──
-
-
 class LargeOutputModule(ModuleType):
     """Module with 256x256 (65,536) elements to test asymptotic call count."""
 
@@ -762,9 +735,6 @@ def test_vjp_output_sampling_large_output_asymptotics():
     assert module.vjp_calls == 10
 
 
-# ── J. SCALAR OUTPUT ──
-
-
 def test_vjp_output_sampling_scalar_output():
     """Scalar outputs: exactly 1 VJP call occurs."""
     module = CountingVjpModule("dummy_module", correct_gradients=True)
@@ -787,9 +757,6 @@ def test_vjp_output_sampling_scalar_output():
     assert module.vjp_calls == 1
 
 
-# ── K. INVALID VALUES ──
-
-
 @pytest.mark.parametrize("invalid_sample_count", [0, -1, -10])
 def test_check_gradients_rejects_invalid_max_output_samples(invalid_sample_count):
     """max_output_samples <= 0 must be rejected with ValueError."""
@@ -803,9 +770,6 @@ def test_check_gradients_rejects_invalid_max_output_samples(invalid_sample_count
                 max_output_samples=invalid_sample_count,
             )
         )
-
-
-# ── L. DEFAULT EXHAUSTIVE BEHAVIOR ──
 
 
 def test_vjp_exhaustive_when_max_output_samples_none():
@@ -847,9 +811,6 @@ def test_vjp_output_sampling_cap_greater_than_output_size_stays_exhaustive():
     assert module.vjp_calls == n_output_elements
 
 
-# ── M. CLI ──
-
-
 def test_cli_max_output_samples_option(cli_runner):
     """CLI must expose --max-output-samples in check-gradients help."""
     from click import unstyle
@@ -862,9 +823,6 @@ def test_cli_max_output_samples_option(cli_runner):
     assert "--max-output-samples" in stdout
     assert "Maximum number of output elements" in stdout
     assert "vector_jacobian_product" in stdout
-
-
-# ── N. RNG ISOLATION ──
 
 
 def test_output_sampling_does_not_alter_input_sampling():

--- a/tests/runtime_tests/test_finite_differences.py
+++ b/tests/runtime_tests/test_finite_differences.py
@@ -582,11 +582,13 @@ def test_check_gradients_rejects_invalid_max_output_samples(invalid_sample_count
 
 def test_cli_max_output_samples_option(cli_runner):
     """CLI must expose --max-output-samples in check-gradients help."""
+    from click import unstyle
+
     from tesseract_core.runtime.cli import app
 
     result = cli_runner.invoke(app, ["check-gradients", "--help"])
     assert result.exit_code == 0
-    assert "--max-output-samples" in result.stdout
+    assert "--max-output-samples" in unstyle(result.stdout)
 
 
 class LargeOutputModule(ModuleType):

--- a/tests/runtime_tests/test_finite_differences.py
+++ b/tests/runtime_tests/test_finite_differences.py
@@ -306,11 +306,12 @@ def test_vjp_sweep_is_shared_across_sampled_indices():
 
 
 class RecordingVjpModule(CountingVjpModule):
-    """CountingVjpModule that records the full cotangent vectors sent to VJP."""
+    """CountingVjpModule that records cotangent vectors and coordinates sent to VJP."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.recorded_cotangents: list[np.ndarray] = []
+        self.recorded_coords: list[tuple[int, ...]] = []
 
     def vector_jacobian_product(
         self,
@@ -320,9 +321,14 @@ class RecordingVjpModule(CountingVjpModule):
         cotangent_vector: dict[str, Any],
     ):
         for out_key in vjp_outputs:
-            self.recorded_cotangents.append(
-                np.asarray(cotangent_vector[out_key]).copy()
-            )
+            cot = np.asarray(cotangent_vector[out_key]).copy()
+            self.recorded_cotangents.append(cot)
+            if cot.ndim == 0:
+                self.recorded_coords.append(())
+            else:
+                nz = np.nonzero(cot)
+                if len(nz[0]) == 1:
+                    self.recorded_coords.append(tuple(int(idx[0]) for idx in nz))
         return super().vector_jacobian_product(
             inputs, vjp_inputs, vjp_outputs, cotangent_vector
         )
@@ -332,8 +338,8 @@ class RecordingVjpModule(CountingVjpModule):
 
 
 def test_vjp_output_sampling_bounds_calls():
-    """With max_output_samples=K < n_output_elements, exactly K VJP calls."""
-    module = CountingVjpModule("dummy_module", correct_gradients=True)
+    """With max_output_samples=K < n_output_elements, exactly K VJP calls are made."""
+    module = RecordingVjpModule("dummy_module", correct_gradients=True)
     num_evals_total = 0
     for _endpoint, failures, num_evals in check_gradients(
         module,
@@ -351,13 +357,17 @@ def test_vjp_output_sampling_bounds_calls():
 
     assert num_evals_total > 0
     assert module.vjp_calls == 5
+    assert len(module.recorded_coords) == 5
+    for cot in module.recorded_cotangents:
+        assert np.sum(np.abs(cot) == 1.0) == 1
+        assert np.sum(cot != 0.0) == 1
 
 
-# ── B. SHARED PROBES ACROSS INPUT INDICES ──
+# ── B. SHARED SWEEP ACROSS INPUT INDICES ──
 
 
 def test_vjp_output_sampling_shared_across_sampled_input_rows():
-    """All sampled input rows for a path pair must share the same probe sweep."""
+    """All sampled input rows for a path pair must share the same output coordinate sweep."""
     module = CountingVjpModule("dummy_module", correct_gradients=True)
     num_evals_total = 0
     for _endpoint, failures, num_evals in check_gradients(
@@ -379,11 +389,11 @@ def test_vjp_output_sampling_shared_across_sampled_input_rows():
     assert module.vjp_calls == 5
 
 
-# ── C. UNIT-NORM PROBES ──
+# ── C. WITHOUT REPLACEMENT ──
 
 
-def test_vjp_output_sampling_probes_are_unit_norm():
-    """Each bounded cotangent probe must have approximately unit L2 norm."""
+def test_vjp_output_sampling_without_replacement():
+    """Sampled output coordinates must be sampled without replacement (all unique)."""
     module = RecordingVjpModule("dummy_module", correct_gradients=True)
     for _endpoint, failures, _ in check_gradients(
         module,
@@ -393,51 +403,20 @@ def test_vjp_output_sampling_probes_are_unit_norm():
         output_paths=["out_dict.{key}"],
         endpoints=["vector_jacobian_product"],
         max_evals=10,
-        max_output_samples=5,
+        max_output_samples=15,
         seed=42,
     ):
         assert not failures
 
-    assert len(module.recorded_cotangents) == 5
-    for cot in module.recorded_cotangents:
-        assert np.isclose(np.linalg.norm(cot), 1.0, atol=1e-6)
+    assert len(module.recorded_coords) == 15
+    assert len(set(module.recorded_coords)) == 15
 
 
-# ── D. DENSE PROBES (not one-hot) ──
-
-
-def test_vjp_output_sampling_probes_are_dense():
-    """For a sufficiently large output, bounded probes must not be one-hot.
-
-    We check that at least one probe has more than 1 non-negligible entry.
-    """
-    module = RecordingVjpModule("dummy_module", correct_gradients=True)
-    for _endpoint, failures, _ in check_gradients(
-        module,
-        {"inputs": input_data},
-        base_dir=None,
-        input_paths=["in_data"],
-        output_paths=["out_dict.{key}"],
-        endpoints=["vector_jacobian_product"],
-        max_evals=10,
-        max_output_samples=3,
-        seed=7,
-    ):
-        assert not failures
-
-    assert len(module.recorded_cotangents) > 0
-    # For a (3,3,3) output, a random Gaussian probe should have many non-zero entries
-    has_dense_probe = any(
-        np.sum(np.abs(cot) > 1e-8) > 1 for cot in module.recorded_cotangents
-    )
-    assert has_dense_probe, "Expected at least one dense (not one-hot) probe"
-
-
-# ── E. DETERMINISM ──
+# ── D. DETERMINISM ──
 
 
 def test_vjp_output_sampling_is_deterministic_with_seed():
-    """Identical seeds must yield identical cotangent probes."""
+    """Identical seeds must yield identical sampled output coordinates."""
     module1 = RecordingVjpModule("dummy_module", correct_gradients=True)
     for _endpoint, failures, _ in check_gradients(
         module1,
@@ -466,19 +445,16 @@ def test_vjp_output_sampling_is_deterministic_with_seed():
     ):
         assert not failures
 
-    assert len(module1.recorded_cotangents) == 5
-    assert len(module2.recorded_cotangents) == 5
-    for c1, c2 in zip(
-        module1.recorded_cotangents, module2.recorded_cotangents, strict=True
-    ):
-        np.testing.assert_array_equal(c1, c2)
+    assert len(module1.recorded_coords) == 5
+    assert len(module2.recorded_coords) == 5
+    assert module1.recorded_coords == module2.recorded_coords
 
 
-# ── F. DIFFERENT SEEDS ──
+# ── E. DIFFERENT SEEDS ──
 
 
 def test_vjp_output_sampling_different_seeds_differ():
-    """Different seeds should produce different cotangent probes."""
+    """Different seeds should produce different sampled output coordinates."""
     module1 = RecordingVjpModule("dummy_module", correct_gradients=True)
     for _endpoint, failures, _ in check_gradients(
         module1,
@@ -507,28 +483,21 @@ def test_vjp_output_sampling_different_seeds_differ():
     ):
         assert not failures
 
-    assert len(module1.recorded_cotangents) == 5
-    assert len(module2.recorded_cotangents) == 5
-    any_different = any(
-        not np.array_equal(c1, c2)
-        for c1, c2 in zip(
-            module1.recorded_cotangents, module2.recorded_cotangents, strict=True
-        )
-    )
-    assert any_different, "Different seeds should produce different probes"
+    assert len(module1.recorded_coords) == 5
+    assert len(module2.recorded_coords) == 5
+    assert module1.recorded_coords != module2.recorded_coords
 
 
-# ── G. INNER-PRODUCT ALIGNMENT ──
+# ── F. COORDINATE ALIGNMENT ──
 
 
 class NonzeroLinearModule(ModuleType):
     """Module where y = W @ x with non-zero, distinct Jacobian elements.
 
-    This ensures that testing catches any incorrect alignment in the
-    inner-product comparison.
+    Jacobian is W (shape 6, 4). Each element W[j, i] is distinct so any indexing or
+    alignment mismatch between reference (finite difference) and VJP will fail.
     """
 
-    # Non-zero matrix of shape (6, 4)
     W = np.arange(1, 25, dtype=np.float32).reshape(6, 4)
 
     def __init__(self, *args, correct_gradients: bool = True, **kwargs):
@@ -560,14 +529,8 @@ class NonzeroLinearModule(ModuleType):
         return {"x": grad_x}
 
 
-def test_vjp_output_sampling_inner_product_alignment():
-    """Dense probes with a known linear model must correctly compare VJP(u)[i] vs dot(u, Jv).
-
-    Uses y = W @ x so the Jacobian is W. For input index i and probe u:
-      VJP(u)[i] = (u^T W)[i]
-      dot(u, finite_difference_row_i) ≈ (u^T W)[i]
-    A correct VJP should pass.
-    """
+def test_vjp_output_sampling_coordinate_alignment():
+    """Sampled output coordinates must compare against exact corresponding Jacobian elements."""
     module = NonzeroLinearModule("nonzero_linear_module", correct_gradients=True)
     linear_inputs = {"x": np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)}
 
@@ -589,7 +552,7 @@ def test_vjp_output_sampling_inner_product_alignment():
     assert num_evals_total > 0
 
 
-# ── H. INCORRECT GRADIENTS ──
+# ── G. INCORRECT GRADIENTS ──
 
 
 def test_vjp_output_sampling_wrong_gradients_fail():
@@ -616,9 +579,138 @@ def test_vjp_output_sampling_wrong_gradients_fail():
         assert failure.exception is None
         assert failure.ref_val is not None
         assert failure.grad_val is not None
-        # Each failure should have K=3 probe projections
         assert len(failure.ref_val) == 3
         assert len(failure.grad_val) == 3
+        for ref, grad in zip(failure.ref_val, failure.grad_val, strict=True):
+            assert abs(grad - ref) >= 49.0
+
+
+# ── H. MULTIDIMENSIONAL OUTPUT ──
+
+
+class MultidimensionalModule(ModuleType):
+    """Module with 3D output tensor (3, 4, 2) to test coordinate unraveling and mapping."""
+
+    def __init__(self, *args, correct_gradients: bool = True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.correct_gradients = correct_gradients
+        self.recorded_coords: list[tuple[int, ...]] = []
+        self.vjp_calls = 0
+
+    class InputSchema(BaseModel):
+        x: Differentiable[Array[(2,), Float32]]
+
+    class OutputSchema(BaseModel):
+        y: Differentiable[Array[(3, 4, 2), Float32]]
+
+    def apply(self, inputs: InputSchema) -> OutputSchema:
+        x = np.asarray(inputs.x, dtype=np.float32)
+        out = np.zeros((3, 4, 2), dtype=np.float32)
+        for i in range(3):
+            for j in range(4):
+                for k in range(2):
+                    out[i, j, k] = (i + 1) * x[0] + (j * 2 + k + 1) * x[1]
+        return {"y": out}
+
+    def vector_jacobian_product(
+        self,
+        inputs: InputSchema,
+        vjp_inputs: set[str],
+        vjp_outputs: set[str],
+        cotangent_vector: dict[str, Any],
+    ):
+        self.vjp_calls += 1
+        cot = np.asarray(cotangent_vector["y"], dtype=np.float32)
+        nz = np.nonzero(cot)
+        if len(nz[0]) == 1:
+            self.recorded_coords.append(tuple(int(idx[0]) for idx in nz))
+        grad_x0 = 0.0
+        grad_x1 = 0.0
+        for i in range(3):
+            for j in range(4):
+                for k in range(2):
+                    c = cot[i, j, k]
+                    grad_x0 += c * (i + 1)
+                    grad_x1 += c * (j * 2 + k + 1)
+        res = np.array([grad_x0, grad_x1], dtype=np.float32)
+        if not self.correct_gradients:
+            res += 20.0
+        return {"x": res}
+
+
+def test_vjp_output_sampling_multidimensional():
+    """Verify multidimensional coordinates are unraveled properly and mapped correctly."""
+    module = MultidimensionalModule("multi_dim_module", correct_gradients=True)
+    num_evals_total = 0
+    for _endpoint, failures, num_evals in check_gradients(
+        module,
+        {"inputs": {"x": np.array([1.5, -2.0], dtype=np.float32)}},
+        base_dir=None,
+        input_paths=["x"],
+        output_paths=["y"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=2,
+        max_output_samples=7,
+        seed=11,
+    ):
+        num_evals_total += num_evals
+        assert not failures
+
+    assert num_evals_total > 0
+    assert len(module.recorded_coords) == 7
+    assert len(set(module.recorded_coords)) == 7
+    for coord in module.recorded_coords:
+        assert len(coord) == 3
+        i, j, k = coord
+        assert 0 <= i < 3
+        assert 0 <= j < 4
+        assert 0 <= k < 2
+
+
+def test_vjp_exhaustive_multidimensional_output():
+    """Verify exhaustive VJP sweep on multidimensional output retains template shape."""
+    module = MultidimensionalModule("multi_dim_module", correct_gradients=True)
+    num_evals_total = 0
+    for _endpoint, failures, num_evals in check_gradients(
+        module,
+        {"inputs": {"x": np.array([1.5, -2.0], dtype=np.float32)}},
+        base_dir=None,
+        input_paths=["x"],
+        output_paths=["y"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=2,
+        max_output_samples=None,
+        seed=11,
+    ):
+        num_evals_total += num_evals
+        assert not failures
+
+    assert num_evals_total > 0
+    # Output shape is (3, 4, 2) = 24 elements -> exactly 24 VJP calls
+    assert module.vjp_calls == 24
+
+
+def test_vjp_output_sampling_cap_greater_than_multidimensional_output_stays_exhaustive():
+    """When max_output_samples >= total output elements on multidimensional output, stays exhaustive."""
+    module = MultidimensionalModule("multi_dim_module", correct_gradients=True)
+    num_evals_total = 0
+    for _endpoint, failures, num_evals in check_gradients(
+        module,
+        {"inputs": {"x": np.array([1.5, -2.0], dtype=np.float32)}},
+        base_dir=None,
+        input_paths=["x"],
+        output_paths=["y"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=2,
+        max_output_samples=100,  # 100 >= 24
+        seed=11,
+    ):
+        num_evals_total += num_evals
+        assert not failures
+
+    assert num_evals_total > 0
+    # Output shape is (3, 4, 2) = 24 elements -> exactly 24 VJP calls
+    assert module.vjp_calls == 24
 
 
 # ── I. LARGE OUTPUT ASYMPTOTICS ──
@@ -674,7 +766,7 @@ def test_vjp_output_sampling_large_output_asymptotics():
 
 
 def test_vjp_output_sampling_scalar_output():
-    """Scalar outputs: max_output_samples >= 1 (n_output_elements), so exhaustive path runs."""
+    """Scalar outputs: exactly 1 VJP call occurs."""
     module = CountingVjpModule("dummy_module", correct_gradients=True)
     num_evals_total = 0
     for _endpoint, failures, num_evals in check_gradients(
@@ -766,34 +858,36 @@ def test_cli_max_output_samples_option(cli_runner):
 
     result = cli_runner.invoke(app, ["check-gradients", "--help"])
     assert result.exit_code == 0
-    assert "--max-output-samples" in unstyle(result.stdout)
+    stdout = unstyle(result.stdout)
+    assert "--max-output-samples" in stdout
+    assert "Maximum number of output elements" in stdout
+    assert "vector_jacobian_product" in stdout
 
 
 # ── N. RNG ISOLATION ──
 
 
-def test_output_probes_do_not_alter_input_sampling():
-    """Enabling output probes must not change which input indices are selected."""
-    # Run without output sampling
-    module_no_probes = RecordingVjpModule("dummy_module", correct_gradients=True)
-    evals_no_probes = []
-    for _endpoint, _failures, num_evals in check_gradients(
-        module_no_probes,
+def test_output_sampling_does_not_alter_input_sampling():
+    """Enabling output coordinate sampling must not change which input coordinates are sampled."""
+    module1 = DummyModule("dummy_module", correct_gradients=False)
+    failures_no_output_sampling = []
+    for _endpoint, failures, _ in check_gradients(
+        module1,
         {"inputs": input_data},
         base_dir=None,
         input_paths=["in_data"],
         output_paths=["out_dict.{key}"],
         endpoints=["vector_jacobian_product"],
         max_evals=10,
+        max_output_samples=None,
         seed=42,
     ):
-        evals_no_probes.append(num_evals)
+        failures_no_output_sampling.extend(failures)
 
-    # Run with output sampling (same base seed)
-    module_with_probes = RecordingVjpModule("dummy_module", correct_gradients=True)
-    evals_with_probes = []
-    for _endpoint, _failures, num_evals in check_gradients(
-        module_with_probes,
+    module2 = DummyModule("dummy_module", correct_gradients=False)
+    failures_with_output_sampling = []
+    for _endpoint, failures, _ in check_gradients(
+        module2,
         {"inputs": input_data},
         base_dir=None,
         input_paths=["in_data"],
@@ -803,7 +897,9 @@ def test_output_probes_do_not_alter_input_sampling():
         max_output_samples=3,
         seed=42,
     ):
-        evals_with_probes.append(num_evals)
+        failures_with_output_sampling.extend(failures)
 
-    # Same number of input evaluations regardless of output probing
-    assert evals_no_probes == evals_with_probes
+    assert len(failures_no_output_sampling) > 0
+    input_coords_no_sampling = [f.idx for f in failures_no_output_sampling]
+    input_coords_with_sampling = [f.idx for f in failures_with_output_sampling]
+    assert input_coords_no_sampling == input_coords_with_sampling

--- a/tests/runtime_tests/test_finite_differences.py
+++ b/tests/runtime_tests/test_finite_differences.py
@@ -306,11 +306,11 @@ def test_vjp_sweep_is_shared_across_sampled_indices():
 
 
 class RecordingVjpModule(CountingVjpModule):
-    """CountingVjpModule that additionally records cotangent one-hot coordinates."""
+    """CountingVjpModule that records the full cotangent vectors sent to VJP."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.recorded_cotangent_coords = []
+        self.recorded_cotangents: list[np.ndarray] = []
 
     def vector_jacobian_product(
         self,
@@ -320,17 +320,19 @@ class RecordingVjpModule(CountingVjpModule):
         cotangent_vector: dict[str, Any],
     ):
         for out_key in vjp_outputs:
-            cot = np.asarray(cotangent_vector[out_key])
-            nonzero = np.argwhere(cot != 0)
-            for coord in nonzero:
-                self.recorded_cotangent_coords.append(tuple(int(c) for c in coord))
+            self.recorded_cotangents.append(
+                np.asarray(cotangent_vector[out_key]).copy()
+            )
         return super().vector_jacobian_product(
             inputs, vjp_inputs, vjp_outputs, cotangent_vector
         )
 
 
+# ── A. VJP CALL BOUND ──
+
+
 def test_vjp_output_sampling_bounds_calls():
-    """Output sampling bounds VJP endpoint calls to min(n_output_elements, max_output_samples)."""
+    """With max_output_samples=K < n_output_elements, exactly K VJP calls."""
     module = CountingVjpModule("dummy_module", correct_gradients=True)
     num_evals_total = 0
     for _endpoint, failures, num_evals in check_gradients(
@@ -351,8 +353,11 @@ def test_vjp_output_sampling_bounds_calls():
     assert module.vjp_calls == 5
 
 
+# ── B. SHARED PROBES ACROSS INPUT INDICES ──
+
+
 def test_vjp_output_sampling_shared_across_sampled_input_rows():
-    """All sampled input rows for a path pair must share the same sampled VJP sweep."""
+    """All sampled input rows for a path pair must share the same probe sweep."""
     module = CountingVjpModule("dummy_module", correct_gradients=True)
     num_evals_total = 0
     for _endpoint, failures, num_evals in check_gradients(
@@ -374,28 +379,11 @@ def test_vjp_output_sampling_shared_across_sampled_input_rows():
     assert module.vjp_calls == 5
 
 
-def test_vjp_output_sampling_cap_greater_than_output_size_stays_exhaustive():
-    """When max_output_samples >= output elements, the check stays exhaustive without random sampling."""
-    module = CountingVjpModule("dummy_module", correct_gradients=True)
-    for _endpoint, failures, _ in check_gradients(
-        module,
-        {"inputs": input_data},
-        base_dir=None,
-        input_paths=["in_data"],
-        output_paths=["out_dict.{key}"],
-        endpoints=["vector_jacobian_product"],
-        max_evals=10,
-        max_output_samples=100,
-        seed=0,
-    ):
-        assert not failures
-
-    n_output_elements = int(np.prod(input_data["in_dict"]["key"].shape))
-    assert module.vjp_calls == n_output_elements
+# ── C. UNIT-NORM PROBES ──
 
 
-def test_vjp_output_sampling_coordinates_are_unique():
-    """Sampled output coordinates must be distinct (sampled without replacement)."""
+def test_vjp_output_sampling_probes_are_unit_norm():
+    """Each bounded cotangent probe must have approximately unit L2 norm."""
     module = RecordingVjpModule("dummy_module", correct_gradients=True)
     for _endpoint, failures, _ in check_gradients(
         module,
@@ -405,17 +393,51 @@ def test_vjp_output_sampling_coordinates_are_unique():
         output_paths=["out_dict.{key}"],
         endpoints=["vector_jacobian_product"],
         max_evals=10,
-        max_output_samples=7,
+        max_output_samples=5,
         seed=42,
     ):
         assert not failures
 
-    assert len(module.recorded_cotangent_coords) == 7
-    assert len(set(module.recorded_cotangent_coords)) == 7
+    assert len(module.recorded_cotangents) == 5
+    for cot in module.recorded_cotangents:
+        assert np.isclose(np.linalg.norm(cot), 1.0, atol=1e-6)
+
+
+# ── D. DENSE PROBES (not one-hot) ──
+
+
+def test_vjp_output_sampling_probes_are_dense():
+    """For a sufficiently large output, bounded probes must not be one-hot.
+
+    We check that at least one probe has more than 1 non-negligible entry.
+    """
+    module = RecordingVjpModule("dummy_module", correct_gradients=True)
+    for _endpoint, failures, _ in check_gradients(
+        module,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        max_output_samples=3,
+        seed=7,
+    ):
+        assert not failures
+
+    assert len(module.recorded_cotangents) > 0
+    # For a (3,3,3) output, a random Gaussian probe should have many non-zero entries
+    has_dense_probe = any(
+        np.sum(np.abs(cot) > 1e-8) > 1 for cot in module.recorded_cotangents
+    )
+    assert has_dense_probe, "Expected at least one dense (not one-hot) probe"
+
+
+# ── E. DETERMINISM ──
 
 
 def test_vjp_output_sampling_is_deterministic_with_seed():
-    """Identical seeds must yield identical sampled output coordinates in the same order."""
+    """Identical seeds must yield identical cotangent probes."""
     module1 = RecordingVjpModule("dummy_module", correct_gradients=True)
     for _endpoint, failures, _ in check_gradients(
         module1,
@@ -444,15 +466,66 @@ def test_vjp_output_sampling_is_deterministic_with_seed():
     ):
         assert not failures
 
-    assert len(module1.recorded_cotangent_coords) == 5
-    assert module1.recorded_cotangent_coords == module2.recorded_cotangent_coords
+    assert len(module1.recorded_cotangents) == 5
+    assert len(module2.recorded_cotangents) == 5
+    for c1, c2 in zip(
+        module1.recorded_cotangents, module2.recorded_cotangents, strict=True
+    ):
+        np.testing.assert_array_equal(c1, c2)
+
+
+# ── F. DIFFERENT SEEDS ──
+
+
+def test_vjp_output_sampling_different_seeds_differ():
+    """Different seeds should produce different cotangent probes."""
+    module1 = RecordingVjpModule("dummy_module", correct_gradients=True)
+    for _endpoint, failures, _ in check_gradients(
+        module1,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        max_output_samples=5,
+        seed=100,
+    ):
+        assert not failures
+
+    module2 = RecordingVjpModule("dummy_module", correct_gradients=True)
+    for _endpoint, failures, _ in check_gradients(
+        module2,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        max_output_samples=5,
+        seed=999,
+    ):
+        assert not failures
+
+    assert len(module1.recorded_cotangents) == 5
+    assert len(module2.recorded_cotangents) == 5
+    any_different = any(
+        not np.array_equal(c1, c2)
+        for c1, c2 in zip(
+            module1.recorded_cotangents, module2.recorded_cotangents, strict=True
+        )
+    )
+    assert any_different, "Different seeds should produce different probes"
+
+
+# ── G. INNER-PRODUCT ALIGNMENT ──
 
 
 class NonzeroLinearModule(ModuleType):
     """Module where y = W @ x with non-zero, distinct Jacobian elements.
 
-    This ensures that testing catches any incorrect coordinate alignment
-    or zero-filling bug in the checker.
+    This ensures that testing catches any incorrect alignment in the
+    inner-product comparison.
     """
 
     # Non-zero matrix of shape (6, 4)
@@ -487,12 +560,13 @@ class NonzeroLinearModule(ModuleType):
         return {"x": grad_x}
 
 
-def test_vjp_output_sampling_coordinate_alignment():
-    """Finite differences and VJP values must be compared at exactly the same sampled coordinates.
+def test_vjp_output_sampling_inner_product_alignment():
+    """Dense probes with a known linear model must correctly compare VJP(u)[i] vs dot(u, Jv).
 
-    With a non-zero linear Jacobian, zero-filling unsampled positions would cause
-    finite differences (which evaluate the full row with non-zero values) to mismatch
-    the fake zeros. This test verifies that coordinate extraction is correctly aligned.
+    Uses y = W @ x so the Jacobian is W. For input index i and probe u:
+      VJP(u)[i] = (u^T W)[i]
+      dot(u, finite_difference_row_i) ≈ (u^T W)[i]
+    A correct VJP should pass.
     """
     module = NonzeroLinearModule("nonzero_linear_module", correct_gradients=True)
     linear_inputs = {"x": np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)}
@@ -506,13 +580,16 @@ def test_vjp_output_sampling_coordinate_alignment():
         output_paths=["y"],
         endpoints=["vector_jacobian_product"],
         max_evals=4,
-        max_output_samples=2,
+        max_output_samples=3,
         seed=0,
     ):
         num_evals_total += num_evals
         assert not failures
 
     assert num_evals_total > 0
+
+
+# ── H. INCORRECT GRADIENTS ──
 
 
 def test_vjp_output_sampling_wrong_gradients_fail():
@@ -539,56 +616,12 @@ def test_vjp_output_sampling_wrong_gradients_fail():
         assert failure.exception is None
         assert failure.ref_val is not None
         assert failure.grad_val is not None
+        # Each failure should have K=3 probe projections
         assert len(failure.ref_val) == 3
         assert len(failure.grad_val) == 3
 
 
-def test_vjp_output_sampling_scalar_output():
-    """Scalar outputs must produce exactly one VJP call with coordinate () regardless of cap."""
-    module = CountingVjpModule("dummy_module", correct_gradients=True)
-    num_evals_total = 0
-    for _endpoint, failures, num_evals in check_gradients(
-        module,
-        {"inputs": input_data},
-        base_dir=None,
-        input_paths=["in_scalar"],
-        output_paths=["out_scalar"],
-        endpoints=["vector_jacobian_product"],
-        max_evals=5,
-        max_output_samples=10,
-        seed=0,
-    ):
-        num_evals_total += num_evals
-        assert not failures
-
-    assert num_evals_total > 0
-    assert module.vjp_calls == 1
-
-
-@pytest.mark.parametrize("invalid_sample_count", [0, -1, -10])
-def test_check_gradients_rejects_invalid_max_output_samples(invalid_sample_count):
-    """max_output_samples <= 0 must be rejected with ValueError."""
-    module = DummyModule("dummy_module", correct_gradients=True)
-    with pytest.raises(ValueError, match="max_output_samples must be greater than 0"):
-        list(
-            check_gradients(
-                module,
-                {"inputs": input_data},
-                endpoints=["vector_jacobian_product"],
-                max_output_samples=invalid_sample_count,
-            )
-        )
-
-
-def test_cli_max_output_samples_option(cli_runner):
-    """CLI must expose --max-output-samples in check-gradients help."""
-    from click import unstyle
-
-    from tesseract_core.runtime.cli import app
-
-    result = cli_runner.invoke(app, ["check-gradients", "--help"])
-    assert result.exit_code == 0
-    assert "--max-output-samples" in unstyle(result.stdout)
+# ── I. LARGE OUTPUT ASYMPTOTICS ──
 
 
 class LargeOutputModule(ModuleType):
@@ -635,3 +668,142 @@ def test_vjp_output_sampling_large_output_asymptotics():
         assert not failures
 
     assert module.vjp_calls == 10
+
+
+# ── J. SCALAR OUTPUT ──
+
+
+def test_vjp_output_sampling_scalar_output():
+    """Scalar outputs: max_output_samples >= 1 (n_output_elements), so exhaustive path runs."""
+    module = CountingVjpModule("dummy_module", correct_gradients=True)
+    num_evals_total = 0
+    for _endpoint, failures, num_evals in check_gradients(
+        module,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_scalar"],
+        output_paths=["out_scalar"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=5,
+        max_output_samples=10,
+        seed=0,
+    ):
+        num_evals_total += num_evals
+        assert not failures
+
+    assert num_evals_total > 0
+    assert module.vjp_calls == 1
+
+
+# ── K. INVALID VALUES ──
+
+
+@pytest.mark.parametrize("invalid_sample_count", [0, -1, -10])
+def test_check_gradients_rejects_invalid_max_output_samples(invalid_sample_count):
+    """max_output_samples <= 0 must be rejected with ValueError."""
+    module = DummyModule("dummy_module", correct_gradients=True)
+    with pytest.raises(ValueError, match="max_output_samples must be greater than 0"):
+        list(
+            check_gradients(
+                module,
+                {"inputs": input_data},
+                endpoints=["vector_jacobian_product"],
+                max_output_samples=invalid_sample_count,
+            )
+        )
+
+
+# ── L. DEFAULT EXHAUSTIVE BEHAVIOR ──
+
+
+def test_vjp_exhaustive_when_max_output_samples_none():
+    """When max_output_samples=None, the exhaustive one-hot VJP sweep is used."""
+    module = CountingVjpModule("dummy_module", correct_gradients=True)
+    for _endpoint, failures, _ in check_gradients(
+        module,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        seed=0,
+    ):
+        assert not failures
+
+    n_output_elements = int(np.prod(input_data["in_dict"]["key"].shape))
+    assert module.vjp_calls == n_output_elements
+
+
+def test_vjp_output_sampling_cap_greater_than_output_size_stays_exhaustive():
+    """When max_output_samples >= output elements, the check stays exhaustive."""
+    module = CountingVjpModule("dummy_module", correct_gradients=True)
+    for _endpoint, failures, _ in check_gradients(
+        module,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        max_output_samples=100,
+        seed=0,
+    ):
+        assert not failures
+
+    n_output_elements = int(np.prod(input_data["in_dict"]["key"].shape))
+    assert module.vjp_calls == n_output_elements
+
+
+# ── M. CLI ──
+
+
+def test_cli_max_output_samples_option(cli_runner):
+    """CLI must expose --max-output-samples in check-gradients help."""
+    from click import unstyle
+
+    from tesseract_core.runtime.cli import app
+
+    result = cli_runner.invoke(app, ["check-gradients", "--help"])
+    assert result.exit_code == 0
+    assert "--max-output-samples" in unstyle(result.stdout)
+
+
+# ── N. RNG ISOLATION ──
+
+
+def test_output_probes_do_not_alter_input_sampling():
+    """Enabling output probes must not change which input indices are selected."""
+    # Run without output sampling
+    module_no_probes = RecordingVjpModule("dummy_module", correct_gradients=True)
+    evals_no_probes = []
+    for _endpoint, _failures, num_evals in check_gradients(
+        module_no_probes,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        seed=42,
+    ):
+        evals_no_probes.append(num_evals)
+
+    # Run with output sampling (same base seed)
+    module_with_probes = RecordingVjpModule("dummy_module", correct_gradients=True)
+    evals_with_probes = []
+    for _endpoint, _failures, num_evals in check_gradients(
+        module_with_probes,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        max_output_samples=3,
+        seed=42,
+    ):
+        evals_with_probes.append(num_evals)
+
+    # Same number of input evaluations regardless of output probing
+    assert evals_no_probes == evals_with_probes

--- a/tests/runtime_tests/test_finite_differences.py
+++ b/tests/runtime_tests/test_finite_differences.py
@@ -811,26 +811,23 @@ def test_vjp_output_sampling_cap_greater_than_output_size_stays_exhaustive():
     assert module.vjp_calls == n_output_elements
 
 
-def test_cli_max_output_samples_option(cli_runner):
-    """CLI must expose --max-output-samples in check-gradients help.
+def test_cli_max_output_samples_option():
+    """CLI must expose --max-output-samples on check-gradients.
 
-    COLUMNS is pinned wide so Rich renders each option name on one line;
-    at the default width it truncates flags mid-token (e.g. to
-    ``--max-output-samp…``) and the substring checks below break for
-    reasons unrelated to whether the option exists.
+    Inspect the registered Click option directly rather than the rendered
+    ``--help`` text: Rich truncates option names mid-token at narrow
+    terminal widths (e.g. ``--max-output-samp…``), which makes substring
+    checks against the help output flaky and terminal-width dependent.
     """
-    from click import unstyle
+    import typer
 
     from tesseract_core.runtime.cli import app
 
-    result = cli_runner.invoke(
-        app, ["check-gradients", "--help"], env={"TERM": "dumb", "COLUMNS": "1000"}
+    command = typer.main.get_group(app).commands["check-gradients"]
+    option = next(
+        p for p in command.params if "--max-output-samples" in getattr(p, "opts", [])
     )
-    assert result.exit_code == 0
-    stdout = unstyle(result.stdout)
-    assert "--max-output-samples" in stdout
-    assert "Maximum number of output elements" in stdout
-    assert "vector_jacobian_product" in stdout
+    assert "Maximum number of output elements" in getattr(option, "help", "")
 
 
 def test_output_sampling_does_not_alter_input_sampling():

--- a/tests/runtime_tests/test_finite_differences.py
+++ b/tests/runtime_tests/test_finite_differences.py
@@ -1,4 +1,5 @@
 from types import ModuleType
+from typing import Any
 
 import numpy as np
 import pytest
@@ -302,3 +303,333 @@ def test_vjp_sweep_is_shared_across_sampled_indices():
     # One sweep, reused by every sampled index, rather than one sweep each.
     assert module.vjp_calls == n_output_elements
     assert module.vjp_calls < num_evals_total * n_output_elements
+
+
+class RecordingVjpModule(CountingVjpModule):
+    """CountingVjpModule that additionally records cotangent one-hot coordinates."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.recorded_cotangent_coords = []
+
+    def vector_jacobian_product(
+        self,
+        inputs: DummyModule.InputSchema,
+        vjp_inputs: set[str],
+        vjp_outputs: set[str],
+        cotangent_vector: dict[str, Any],
+    ):
+        for out_key in vjp_outputs:
+            cot = np.asarray(cotangent_vector[out_key])
+            nonzero = np.argwhere(cot != 0)
+            for coord in nonzero:
+                self.recorded_cotangent_coords.append(tuple(int(c) for c in coord))
+        return super().vector_jacobian_product(
+            inputs, vjp_inputs, vjp_outputs, cotangent_vector
+        )
+
+
+def test_vjp_output_sampling_bounds_calls():
+    """Output sampling bounds VJP endpoint calls to min(n_output_elements, max_output_samples)."""
+    module = CountingVjpModule("dummy_module", correct_gradients=True)
+    num_evals_total = 0
+    for _endpoint, failures, num_evals in check_gradients(
+        module,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        max_output_samples=5,
+        seed=0,
+    ):
+        num_evals_total += num_evals
+        assert not failures
+
+    assert num_evals_total > 0
+    assert module.vjp_calls == 5
+
+
+def test_vjp_output_sampling_shared_across_sampled_input_rows():
+    """All sampled input rows for a path pair must share the same sampled VJP sweep."""
+    module = CountingVjpModule("dummy_module", correct_gradients=True)
+    num_evals_total = 0
+    for _endpoint, failures, num_evals in check_gradients(
+        module,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=20,
+        max_output_samples=5,
+        seed=0,
+    ):
+        num_evals_total += num_evals
+        assert not failures
+
+    assert num_evals_total > 1
+    # Exactly 5 VJP calls shared across all sampled input rows, NOT num_evals * 5
+    assert module.vjp_calls == 5
+
+
+def test_vjp_output_sampling_cap_greater_than_output_size_stays_exhaustive():
+    """When max_output_samples >= output elements, the check stays exhaustive without random sampling."""
+    module = CountingVjpModule("dummy_module", correct_gradients=True)
+    for _endpoint, failures, _ in check_gradients(
+        module,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        max_output_samples=100,
+        seed=0,
+    ):
+        assert not failures
+
+    n_output_elements = int(np.prod(input_data["in_dict"]["key"].shape))
+    assert module.vjp_calls == n_output_elements
+
+
+def test_vjp_output_sampling_coordinates_are_unique():
+    """Sampled output coordinates must be distinct (sampled without replacement)."""
+    module = RecordingVjpModule("dummy_module", correct_gradients=True)
+    for _endpoint, failures, _ in check_gradients(
+        module,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        max_output_samples=7,
+        seed=42,
+    ):
+        assert not failures
+
+    assert len(module.recorded_cotangent_coords) == 7
+    assert len(set(module.recorded_cotangent_coords)) == 7
+
+
+def test_vjp_output_sampling_is_deterministic_with_seed():
+    """Identical seeds must yield identical sampled output coordinates in the same order."""
+    module1 = RecordingVjpModule("dummy_module", correct_gradients=True)
+    for _endpoint, failures, _ in check_gradients(
+        module1,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        max_output_samples=5,
+        seed=123,
+    ):
+        assert not failures
+
+    module2 = RecordingVjpModule("dummy_module", correct_gradients=True)
+    for _endpoint, failures, _ in check_gradients(
+        module2,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_data"],
+        output_paths=["out_dict.{key}"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=10,
+        max_output_samples=5,
+        seed=123,
+    ):
+        assert not failures
+
+    assert len(module1.recorded_cotangent_coords) == 5
+    assert module1.recorded_cotangent_coords == module2.recorded_cotangent_coords
+
+
+class NonzeroLinearModule(ModuleType):
+    """Module where y = W @ x with non-zero, distinct Jacobian elements.
+
+    This ensures that testing catches any incorrect coordinate alignment
+    or zero-filling bug in the checker.
+    """
+
+    # Non-zero matrix of shape (6, 4)
+    W = np.arange(1, 25, dtype=np.float32).reshape(6, 4)
+
+    def __init__(self, *args, correct_gradients: bool = True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.correct_gradients = correct_gradients
+
+    class InputSchema(BaseModel):
+        x: Differentiable[Array[(4,), Float32]]
+
+    class OutputSchema(BaseModel):
+        y: Differentiable[Array[(6,), Float32]]
+
+    def apply(self, inputs: InputSchema) -> OutputSchema:
+        x = np.asarray(inputs.x, dtype=np.float32)
+        return {"y": self.W @ x}
+
+    def vector_jacobian_product(
+        self,
+        inputs: InputSchema,
+        vjp_inputs: set[str],
+        vjp_outputs: set[str],
+        cotangent_vector: dict[str, Any],
+    ):
+        cot = np.asarray(cotangent_vector["y"], dtype=np.float32)
+        if self.correct_gradients:
+            grad_x = cot @ self.W
+        else:
+            grad_x = (cot @ self.W) + 50.0
+        return {"x": grad_x}
+
+
+def test_vjp_output_sampling_coordinate_alignment():
+    """Finite differences and VJP values must be compared at exactly the same sampled coordinates.
+
+    With a non-zero linear Jacobian, zero-filling unsampled positions would cause
+    finite differences (which evaluate the full row with non-zero values) to mismatch
+    the fake zeros. This test verifies that coordinate extraction is correctly aligned.
+    """
+    module = NonzeroLinearModule("nonzero_linear_module", correct_gradients=True)
+    linear_inputs = {"x": np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)}
+
+    num_evals_total = 0
+    for _endpoint, failures, num_evals in check_gradients(
+        module,
+        {"inputs": linear_inputs},
+        base_dir=None,
+        input_paths=["x"],
+        output_paths=["y"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=4,
+        max_output_samples=2,
+        seed=0,
+    ):
+        num_evals_total += num_evals
+        assert not failures
+
+    assert num_evals_total > 0
+
+
+def test_vjp_output_sampling_wrong_gradients_fail():
+    """Sampling must not mask real gradient errors: incorrect VJPs must still be caught."""
+    bad_module = NonzeroLinearModule("nonzero_linear_module", correct_gradients=False)
+    linear_inputs = {"x": np.array([1.0, 2.0, 3.0, 4.0], dtype=np.float32)}
+
+    failures_found = []
+    for _endpoint, failures, _num_evals in check_gradients(
+        bad_module,
+        {"inputs": linear_inputs},
+        base_dir=None,
+        input_paths=["x"],
+        output_paths=["y"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=4,
+        max_output_samples=3,
+        seed=0,
+    ):
+        failures_found.extend(failures)
+
+    assert len(failures_found) > 0
+    for failure in failures_found:
+        assert failure.exception is None
+        assert failure.ref_val is not None
+        assert failure.grad_val is not None
+        assert len(failure.ref_val) == 3
+        assert len(failure.grad_val) == 3
+
+
+def test_vjp_output_sampling_scalar_output():
+    """Scalar outputs must produce exactly one VJP call with coordinate () regardless of cap."""
+    module = CountingVjpModule("dummy_module", correct_gradients=True)
+    num_evals_total = 0
+    for _endpoint, failures, num_evals in check_gradients(
+        module,
+        {"inputs": input_data},
+        base_dir=None,
+        input_paths=["in_scalar"],
+        output_paths=["out_scalar"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=5,
+        max_output_samples=10,
+        seed=0,
+    ):
+        num_evals_total += num_evals
+        assert not failures
+
+    assert num_evals_total > 0
+    assert module.vjp_calls == 1
+
+
+@pytest.mark.parametrize("invalid_sample_count", [0, -1, -10])
+def test_check_gradients_rejects_invalid_max_output_samples(invalid_sample_count):
+    """max_output_samples <= 0 must be rejected with ValueError."""
+    module = DummyModule("dummy_module", correct_gradients=True)
+    with pytest.raises(ValueError, match="max_output_samples must be greater than 0"):
+        list(
+            check_gradients(
+                module,
+                {"inputs": input_data},
+                endpoints=["vector_jacobian_product"],
+                max_output_samples=invalid_sample_count,
+            )
+        )
+
+
+def test_cli_max_output_samples_option(cli_runner):
+    """CLI must expose --max-output-samples in check-gradients help."""
+    from tesseract_core.runtime.cli import app
+
+    result = cli_runner.invoke(app, ["check-gradients", "--help"])
+    assert result.exit_code == 0
+    assert "--max-output-samples" in result.stdout
+
+
+class LargeOutputModule(ModuleType):
+    """Module with 256x256 (65,536) elements to test asymptotic call count."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.vjp_calls = 0
+
+    class InputSchema(BaseModel):
+        x: Differentiable[Array[(2,), Float32]]
+
+    class OutputSchema(BaseModel):
+        y: Differentiable[Array[(256, 256), Float32]]
+
+    def apply(self, inputs: InputSchema) -> OutputSchema:
+        return {"y": np.zeros((256, 256), dtype=np.float32)}
+
+    def vector_jacobian_product(
+        self,
+        inputs: InputSchema,
+        vjp_inputs: set[str],
+        vjp_outputs: set[str],
+        cotangent_vector: dict[str, Any],
+    ):
+        self.vjp_calls += 1
+        return {"x": np.zeros((2,), dtype=np.float32)}
+
+
+def test_vjp_output_sampling_large_output_asymptotics():
+    """65,536-element output runs exactly 10 VJP calls when max_output_samples=10."""
+    module = LargeOutputModule("large_output_module")
+    for _endpoint, failures, _num_evals in check_gradients(
+        module,
+        {"inputs": {"x": np.zeros(2, dtype=np.float32)}},
+        base_dir=None,
+        input_paths=["x"],
+        output_paths=["y"],
+        endpoints=["vector_jacobian_product"],
+        max_evals=1,
+        max_output_samples=10,
+        seed=0,
+    ):
+        assert not failures
+
+    assert module.vjp_calls == 10


### PR DESCRIPTION
#### Relevant issue or PR

Fixes #738

#### Description of changes

`check-gradients` currently sweeps a one-hot cotangent over every output element when checking `vector_jacobian_product`, so VJP cost scales with the full output size even when only a small number of input gradients are sampled.

This adds an optional `--max-output-samples` CLI flag and corresponding `max_output_samples` Python API parameter.

When set, the VJP checker:

- samples output coordinates without replacement;
- performs at most `min(n_output_elements, max_output_samples)` VJP calls per input/output path pair;
- compares the VJP result against finite differences at exactly the same sampled output coordinates;
- preserves the shared VJP sweep across sampled input rows introduced in #688;
- uses deterministic seeded output sampling without changing the existing input-sampling RNG stream.

When `--max-output-samples` is omitted, the existing exhaustive behavior is preserved.

Example:

```bash
tesseract-runtime check-gradients @inputs.json \
    --endpoints vector_jacobian_product \
    --max-evals 10 \
    --max-output-samples 10
