### PR TITLE
chore: tombstone existing Tesseract(url) and *FileReference deprecations

### DIFF
--- a/tesseract_core/_deprecations.py
+++ b/tesseract_core/_deprecations.py
@@ -65,6 +65,27 @@ TOMBSTONES: tuple[Tombstone, ...] = (
             "PipRequirements. Update the tests, too."
         ),
     ),
+    Tombstone(
+        remove_at="1.13.0",
+        what="Tesseract(url) constructor",
+        hint=(
+            "Remove the deprecated Tesseract.__init__ shim in "
+            "tesseract_core/sdk/tesseract.py (callers use Tesseract.from_url / "
+            "from_image / from_tesseract_api); make __init__ raise instead. "
+            "Update the tests, too."
+        ),
+    ),
+    Tombstone(
+        remove_at="1.13.0",
+        what="InputFileReference / OutputFileReference aliases",
+        hint=(
+            "Remove InputFileReference, OutputFileReference and their validators "
+            "(_resolve_input_file, _strip_output_file) from "
+            "tesseract_core/runtime/experimental/paths.py, and drop them from the "
+            "experimental __init__ exports; use InputPath / OutputPath instead. "
+            "Update the tests, too."
+        ),
+    ),
 )
 
 


### PR DESCRIPTION
#### Relevant issue or PR

Builds on the deprecation tombstone registry (`tesseract_core/_deprecations.py`).

#### Description of changes

The tombstone registry pins each deprecation to the version it must be gone by, and a release-PR test fails if a removal comes due — but it only tracked the two `api_parse.py` shims. Two long-standing deprecations had no scheduled removal and would silently linger:

- the `Tesseract(url)` constructor (deprecated Feb 2026, superseded by `Tesseract.from_url` / `from_image` / `from_tesseract_api`), and
- the `InputFileReference` / `OutputFileReference` aliases (deprecated Jun 2026, superseded by `InputPath` / `OutputPath`).

This adds a `Tombstone` for each, both targeting `1.13.0` (the next minor, consistent with the existing entries). No behaviour changes and no code is deleted here — the tombstone is a scheduling record. When `1.13.0` is cut, the release-PR test starts failing and points to the exact code to delete, at which point the shim and its tombstone are removed together.

Nothing else in the package emits an unscheduled deprecation (audited `warnings.warn` / `DeprecationWarning` across `tesseract_core/`; the remaining sites are the already-tombstoned `api_parse.py` aliases and a non-deprecation `ImportWarning`).

#### Testing done

- `tests/sdk_tests/test_deprecations.py` passes: nothing is overdue at the current `1.12` line, and all four tombstones come due at `1.13.0`.
- CI.
