### PR TITLE
feat(runtime): add experimental Ref for sidecar model outputs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -336,6 +336,12 @@ linkcheck_ignore = [
     # in a browser. The docs.pasteurlabs.ai subdomain is hosted elsewhere (Read
     # the Docs) and is left checked.
     r"https://pasteurlabs\.ai(/.*)?$",
+    # TEMPORARY -- remove when this PR merges. Example pages link to
+    # tree/main/examples/<name>, which 404s for an example that only exists on
+    # the PR branch. linkcheck was added after the last example was added, so
+    # this is the first new example to hit it; a general fix (checking the
+    # current ref, or dropping these links) is worth considering separately.
+    r"https://github\.com/pasteurlabs/tesseract-core/tree/main/examples/ref_output",
 ]
 
 # Pages whose in-page anchors are generated client-side (or are browser text

--- a/docs/content/examples/building-blocks/ref_output.md
+++ b/docs/content/examples/building-blocks/ref_output.md
@@ -51,7 +51,7 @@ tesseract-runtime \
 
 Each entry is self-describing, in the same way an encoded array carries
 `"object_type": "array"`. That is what lets a client resolve refs without
-knowing the Tesseract's schema (see [Reading refs back](#reading-refs-back)).
+knowing the Tesseract's schema (see [Reading refs back](reading-refs-back)).
 
 ```
 output/
@@ -66,7 +66,7 @@ the shared buffer:
 
 ```json
 {
-  "name": "frame_001",
+  "name": "step_1",
   "displacement": {
     "object_type": "array",
     "shape": [4, 3],
@@ -99,7 +99,31 @@ tesseract-runtime apply '{"inputs": {"scale": 2.0, "n_nodes": 2, "n_frames": 1}}
 ```
 
 ```json
-{"frames": [{"name": "frame_000", "displacement": {...}, "pressure": {...}}]}
+{
+  "frames": [
+    {
+      "name": "step_0",
+      "displacement": {
+        "object_type": "array",
+        "shape": [2, 3],
+        "dtype": "float32",
+        "data": {
+          "buffer": [
+            [0.0, 0.0, 0.0],
+            [2.0, 2.0, 2.0]
+          ],
+          "encoding": "json"
+        }
+      },
+      "pressure": {
+        "object_type": "array",
+        "shape": [2],
+        "dtype": "float64",
+        "data": { "buffer": [0.0, 2.0], "encoding": "json" }
+      }
+    }
+  ]
+}
 ```
 
 Validation accepts both forms, so a payload produced either way can be read
@@ -107,6 +131,8 @@ back. A ref is resolved against `base_dir`, the file is read, and the wrapped
 model's own validators run on its contents — array shapes and dtypes inside a
 sidecar are checked exactly as they would be inline. A bare path string is
 accepted too, so hand-written payloads that just name the file keep working.
+
+(reading-refs-back)=
 
 ## Reading refs back
 
@@ -128,14 +154,33 @@ sidecar, and decodes the arrays inside it (including nested refs). Without an
 
 ## Naming sidecar files
 
-By default sidecars get UUID names, matching how `json+binref` names `.bin`
-files. Give the wrapped model a `__ref_name__()` method to derive readable
-names from the data instead. The stem must be unique across the payload;
-duplicates and unsafe names are rejected rather than silently clobbered.
+Sidecars are named `<prefix>_<index>.json`, where the prefix comes from the
+first of these that is usable:
 
-```{literalinclude} ../../../../examples/ref_output/tesseract_api.py
-:pyobject: Frame.__ref_name__
-:language: python
+1. the prefix passed as `Ref[Frame, "frame"]` → `frame_000.json`;
+2. the model's own `name` field → `step_0_000.json`;
+3. the model's class name → `Frame_000.json`.
+
+Failing all three, files are named with a UUID, matching how `json+binref`
+names its `.bin` files. Because every name carries a running index, sidecars in
+one payload can never collide — a `name` field need not be unique. A `name`
+that is missing or not filename-safe (a path separator, say) quietly falls
+through to the next option rather than sinking the whole response; a prefix
+passed to `Ref` is developer-supplied, so an unusable one raises.
+
+Counters restart on each dump, so two dumps into the _same_ directory overwrite
+each other. A served Tesseract avoids this by writing into a per-request
+`run_<id>/` directory.
+
+```{note}
+Linters read a bare string in a subscript as a forward reference, so
+`Ref[Frame, "frame"]` may need a `# noqa: F821`. The same applies to Tesseract's
+existing `Array[(2, 3), "float32"]` form.
+```
+
+```python
+class OutputSchema(BaseModel):
+    frames: list[Ref[Frame, "frame"]]
 ```
 
 ## Refs and differentiation

--- a/docs/content/examples/building-blocks/ref_output.md
+++ b/docs/content/examples/building-blocks/ref_output.md
@@ -40,8 +40,18 @@ tesseract-runtime \
 ```
 
 ```json
-{ "frames": ["frame_000.json", "frame_001.json", "frame_002.json"] }
+{
+  "frames": [
+    { "object_type": "ref", "path": "frame_000.json" },
+    { "object_type": "ref", "path": "frame_001.json" },
+    { "object_type": "ref", "path": "frame_002.json" }
+  ]
+}
 ```
+
+Each entry is self-describing, in the same way an encoded array carries
+`"object_type": "array"`. That is what lets a client resolve refs without
+knowing the Tesseract's schema (see [Reading refs back](#reading-refs-back)).
 
 ```
 output/
@@ -74,10 +84,15 @@ the shared buffer:
 
 ## When refs are written
 
-`Ref` writes a sidecar only when the serialization context carries a
-`base_dir`, which is what `json+binref` sets. With the `json` and
-`json+base64` formats there is nowhere to write, so refs are serialized
-**inline** and the same Tesseract keeps working over plain HTTP:
+Whether refs become files depends on the **output format**, not on the
+transport: `Ref` writes a sidecar when the serialization context carries a
+`base_dir`, which is what `json+binref` sets. That applies over HTTP too — a
+served Tesseract writes sidecars into its per-request `run_<id>/` directory
+under `--output-path`, next to the `.bin` buffer they point into.
+
+With the `json` and `json+base64` formats there is no output directory to
+write to, so refs are serialized **inline** and the same Tesseract still
+returns a self-contained response:
 
 ```bash
 tesseract-runtime apply '{"inputs": {"scale": 2.0, "n_nodes": 2, "n_frames": 1}}'
@@ -88,9 +103,28 @@ tesseract-runtime apply '{"inputs": {"scale": 2.0, "n_nodes": 2, "n_frames": 1}}
 ```
 
 Validation accepts both forms, so a payload produced either way can be read
-back. A path is resolved against `base_dir`, the file is read, and the wrapped
+back. A ref is resolved against `base_dir`, the file is read, and the wrapped
 model's own validators run on its contents — array shapes and dtypes inside a
-sidecar are checked exactly as they would be inline.
+sidecar are checked exactly as they would be inline. A bare path string is
+accepted too, so hand-written payloads that just name the file keep working.
+
+## Reading refs back
+
+The Python SDK resolves refs for you, provided it knows where the output
+directory is:
+
+```python
+tess = Tesseract.from_image("ref_output", output_path="./output",
+                            output_format="json+binref")
+out = tess.apply({"scale": 2.0, "n_nodes": 2, "n_frames": 2})
+
+out["frames"][1]["displacement"]   # -> np.ndarray, loaded from the sidecar
+```
+
+The client has no access to your `OutputSchema`, so it recognises a ref by its
+`object_type` marker — exactly how it recognises encoded arrays — loads the
+sidecar, and decodes the arrays inside it (including nested refs). Without an
+`output_path` it raises rather than handing back an unresolvable path.
 
 ## Naming sidecar files
 

--- a/docs/content/examples/building-blocks/ref_output.md
+++ b/docs/content/examples/building-blocks/ref_output.md
@@ -1,0 +1,124 @@
+# Sidecar model outputs with `Ref`
+
+[View on GitHub](https://github.com/pasteurlabs/tesseract-core/tree/main/examples/ref_output)
+
+## Context
+
+The `json+binref` output format already keeps array _buffers_ out of the
+response payload by writing them to `.bin` files. `Ref` applies the same idea
+one level up the tree: it takes a nested Pydantic model — typically your own
+domain object holding several arrays — and writes the whole model to its own
+`.json` file, leaving only a relative path in the main payload.
+
+This is useful when a Tesseract returns many structured objects (time steps,
+cases, samples) and callers want to fetch them selectively rather than parse
+one large response.
+
+## Example Tesseract (`examples/ref_output`)
+
+`Frame` is an ordinary user-defined model with two differentiable array leaves
+and a plain string leaf. Wrapping it in `Ref[Frame]` is the only change needed:
+
+```{literalinclude} ../../../../examples/ref_output/tesseract_api.py
+:pyobject: Frame
+:language: python
+```
+
+```{literalinclude} ../../../../examples/ref_output/tesseract_api.py
+:pyobject: OutputSchema
+:language: python
+```
+
+Run with an output path and the `json+binref` format, the response carries only
+the sidecar paths:
+
+```bash
+tesseract-runtime \
+    --output-path ./output \
+    --output-format json+binref \
+    apply '{"inputs": {"scale": 2.0, "n_nodes": 4, "n_frames": 3}}'
+```
+
+```json
+{ "frames": ["frame_000.json", "frame_001.json", "frame_002.json"] }
+```
+
+```
+output/
+├── 49aa7689-….bin        # array buffers, shared across all frames
+├── frame_000.json
+├── frame_001.json
+└── frame_002.json
+```
+
+Each sidecar is a normal encoded payload, whose arrays are in turn binrefs into
+the shared buffer:
+
+```json
+{
+  "name": "frame_001",
+  "displacement": {
+    "object_type": "array",
+    "shape": [4, 3],
+    "dtype": "float32",
+    "data": { "buffer": "49aa7689-….bin:80", "encoding": "binref" }
+  },
+  "pressure": {
+    "object_type": "array",
+    "shape": [4],
+    "dtype": "float64",
+    "data": { "buffer": "49aa7689-….bin:128", "encoding": "binref" }
+  }
+}
+```
+
+## When refs are written
+
+`Ref` writes a sidecar only when the serialization context carries a
+`base_dir`, which is what `json+binref` sets. With the `json` and
+`json+base64` formats there is nowhere to write, so refs are serialized
+**inline** and the same Tesseract keeps working over plain HTTP:
+
+```bash
+tesseract-runtime apply '{"inputs": {"scale": 2.0, "n_nodes": 2, "n_frames": 1}}'
+```
+
+```json
+{"frames": [{"name": "frame_000", "displacement": {...}, "pressure": {...}}]}
+```
+
+Validation accepts both forms, so a payload produced either way can be read
+back. A path is resolved against `base_dir`, the file is read, and the wrapped
+model's own validators run on its contents — array shapes and dtypes inside a
+sidecar are checked exactly as they would be inline.
+
+## Naming sidecar files
+
+By default sidecars get UUID names, matching how `json+binref` names `.bin`
+files. Give the wrapped model a `__ref_name__()` method to derive readable
+names from the data instead. The stem must be unique across the payload;
+duplicates and unsafe names are rejected rather than silently clobbered.
+
+```{literalinclude} ../../../../examples/ref_output/tesseract_api.py
+:pyobject: Frame.__ref_name__
+:language: python
+```
+
+## Refs and differentiation
+
+`Ref` is a thin `Annotated` wrapper, which keeps it transparent to schema
+generation. The arrays inside a wrapped model stay visible at their natural
+paths, so nothing has to be re-declared:
+
+- `abstract_eval` replaces the arrays inside `Frame` with `ShapeDType` on its own.
+- `jac_outputs` / `jvp_outputs` / `vjp_outputs` accept `frames.[0].displacement`
+  and `frames.[1].pressure` as usual.
+
+Gradient payloads are flat `{path: array}` mappings keyed by paths into the
+output tree, so they never traverse a ref — no ref-specific handling is needed
+in your gradient endpoints, and none of the array data is written to sidecars
+there.
+
+```{note}
+`Ref` is part of `tesseract_core.runtime.experimental` and its API may change.
+```

--- a/docs/content/examples/example_gallery.md
+++ b/docs/content/examples/example_gallery.md
@@ -17,6 +17,7 @@ building-blocks/arm64.md
 building-blocks/localpackage.md
 building-blocks/dataloader.md
 building-blocks/file_io.md
+building-blocks/ref_output.md
 building-blocks/finitediff.md
 building-blocks/gradient-fallbacks.md
 ```
@@ -101,6 +102,15 @@ Tesseract that passes files and directories through the input/output mounts
 instead of serializing their contents into the request payload.
 Useful when inputs or outputs are large on disk, or consist of
 many (or a variable number of) files.
+:::
+
+:::{grid-item-card} Sidecar Model Outputs
+:link: building-blocks/ref_output
+:link-type: doc
+
+Tesseract that writes each nested output model to its own JSON file and returns
+only the paths, the way `json+binref` does for array buffers. Stays transparent
+to differentiation. _(Experimental)_
 :::
 
 :::{grid-item-card} Finite Difference Gradients

--- a/examples/ref_output/tesseract_api.py
+++ b/examples/ref_output/tesseract_api.py
@@ -5,7 +5,7 @@
 
 ``apply`` returns one ``Frame`` per requested time step. Each ``Frame`` is a
 user-defined Pydantic model holding two differentiable arrays and a plain
-string. Wrapping it in ``Ref[Frame, "name"]`` means that, when the Tesseract is
+string. Wrapping it in ``Ref[Frame, "frame"]`` means that, when the Tesseract is
 run with an output path and the ``json+binref`` format, the main payload is
 just::
 
@@ -34,19 +34,13 @@ from tesseract_core.runtime.experimental import Ref
 class Frame(BaseModel):
     """A single time step. Two differentiable array leaves plus a string leaf."""
 
-    name: str = Field(
-        description="Frame identifier, also used as the sidecar filename."
-    )
+    name: str = Field(description="Frame identifier.")
     displacement: Differentiable[Array[(None, 3), Float32]] = Field(
         description="Per-node displacement vectors."
     )
     pressure: Differentiable[Array[(None,), Float64]] = Field(
         description="Per-node scalar pressure."
     )
-
-    def __ref_name__(self) -> str:
-        """Name this frame's sidecar file after the frame itself."""
-        return self.name
 
 
 class InputSchema(BaseModel):
@@ -58,7 +52,10 @@ class InputSchema(BaseModel):
 
 
 class OutputSchema(BaseModel):
-    frames: list[Ref[Frame]] = Field(
+    # The "frame" prefix names the sidecar files (frame_000.json, ...).
+    # Linters read a bare string in a subscript as a forward reference, hence
+    # the suppression below; the same applies to Array[(2, 3), "float32"].
+    frames: list[Ref[Frame, "frame"]] = Field(  # noqa: F821
         description="One frame per time step, each serialized to its own JSON file."
     )
 
@@ -82,7 +79,7 @@ def _frames(inputs: InputSchema, scale: float) -> list[Frame]:
         displacement, pressure = _base_fields(inputs.n_nodes, i)
         frames.append(
             Frame(
-                name=f"frame_{i:03d}",
+                name=f"step_{i}",
                 displacement=(scale * displacement).astype("float32"),
                 pressure=scale * pressure,
             )

--- a/examples/ref_output/tesseract_api.py
+++ b/examples/ref_output/tesseract_api.py
@@ -1,0 +1,147 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Example Tesseract demonstrating ``Ref``: nested models as sidecar JSON files.
+
+``apply`` returns one ``Frame`` per requested time step. Each ``Frame`` is a
+user-defined Pydantic model holding two differentiable arrays and a plain
+string. Wrapping it in ``Ref[Frame, "name"]`` means that, when the Tesseract is
+run with an output path and the ``json+binref`` format, the main payload is
+just::
+
+    {"frames": ["frame_000.json", "frame_001.json", "frame_002.json"]}
+
+with each frame written to its own JSON file (whose arrays are in turn binrefs
+into the shared ``.bin`` buffer). Run with plain ``json`` output and the frames
+are inlined instead, so the same Tesseract still serves over plain HTTP.
+
+Crucially, ``Ref`` is transparent to schema generation: the differentiable
+arrays inside ``Frame`` remain visible as ``frames.[0].displacement`` etc., so
+``abstract_eval`` and all three gradient endpoints work unchanged.
+"""
+
+import numpy as np
+from pydantic import BaseModel, Field
+
+from tesseract_core.runtime import Array, Differentiable, Float32, Float64
+from tesseract_core.runtime.experimental import Ref
+
+#
+# Schemas
+#
+
+
+class Frame(BaseModel):
+    """A single time step. Two differentiable array leaves plus a string leaf."""
+
+    name: str = Field(
+        description="Frame identifier, also used as the sidecar filename."
+    )
+    displacement: Differentiable[Array[(None, 3), Float32]] = Field(
+        description="Per-node displacement vectors."
+    )
+    pressure: Differentiable[Array[(None,), Float64]] = Field(
+        description="Per-node scalar pressure."
+    )
+
+    def __ref_name__(self) -> str:
+        """Name this frame's sidecar file after the frame itself."""
+        return self.name
+
+
+class InputSchema(BaseModel):
+    scale: Differentiable[Float32] = Field(
+        description="Scalar multiplier applied to every frame.", default=1.0
+    )
+    n_nodes: int = Field(description="Number of nodes per frame.", default=4, gt=0)
+    n_frames: int = Field(description="Number of frames to produce.", default=3, gt=0)
+
+
+class OutputSchema(BaseModel):
+    frames: list[Ref[Frame]] = Field(
+        description="One frame per time step, each serialized to its own JSON file."
+    )
+
+
+#
+# Helpers
+#
+
+
+def _base_fields(n_nodes: int, frame_idx: int) -> tuple[np.ndarray, np.ndarray]:
+    """Deterministic, differentiable-in-`scale` frame contents (before scaling)."""
+    node = np.arange(n_nodes, dtype="float64")
+    displacement = np.stack([node, node + frame_idx, node - frame_idx], axis=-1)
+    pressure = node**2 + frame_idx
+    return displacement.astype("float32"), pressure
+
+
+def _frames(inputs: InputSchema, scale: float) -> list[Frame]:
+    frames = []
+    for i in range(inputs.n_frames):
+        displacement, pressure = _base_fields(inputs.n_nodes, i)
+        frames.append(
+            Frame(
+                name=f"frame_{i:03d}",
+                displacement=(scale * displacement).astype("float32"),
+                pressure=scale * pressure,
+            )
+        )
+    return frames
+
+
+#
+# Required endpoints
+#
+
+
+def apply(inputs: InputSchema) -> OutputSchema:
+    """Produce one frame per time step, scaled by `scale`."""
+    return OutputSchema(frames=_frames(inputs, float(inputs.scale)))
+
+
+#
+# Optional endpoints
+#
+# Gradient payloads are flat {path: array} mappings keyed by paths *into* the
+# output tree (e.g. "frames.[1].pressure"), so they never traverse a Ref and
+# need no ref-specific handling. Every output here is linear in `scale`, so the
+# derivative w.r.t. `scale` is just the unscaled field.
+
+
+def _unit_frames(inputs: InputSchema) -> dict[str, np.ndarray]:
+    """d(output)/d(scale) for every differentiable output path."""
+    derivatives = {}
+    for i, frame in enumerate(_frames(inputs, 1.0)):
+        derivatives[f"frames.[{i}].displacement"] = frame.displacement
+        derivatives[f"frames.[{i}].pressure"] = frame.pressure
+    return derivatives
+
+
+def jacobian(
+    inputs: InputSchema, jac_inputs: set[str], jac_outputs: set[str]
+) -> dict[str, dict[str, np.ndarray]]:
+    derivatives = _unit_frames(inputs)
+    return {out: {inp: derivatives[out] for inp in jac_inputs} for out in jac_outputs}
+
+
+def jacobian_vector_product(
+    inputs: InputSchema,
+    jvp_inputs: set[str],
+    jvp_outputs: set[str],
+    tangent_vector: dict[str, np.ndarray],
+) -> dict[str, np.ndarray]:
+    derivatives = _unit_frames(inputs)
+    tangent = float(tangent_vector["scale"])
+    return {out: derivatives[out] * tangent for out in jvp_outputs}
+
+
+def vector_jacobian_product(
+    inputs: InputSchema,
+    vjp_inputs: set[str],
+    vjp_outputs: set[str],
+    cotangent_vector: dict[str, np.ndarray],
+) -> dict[str, np.ndarray]:
+    derivatives = _unit_frames(inputs)
+    total = sum(np.sum(derivatives[out] * cotangent_vector[out]) for out in vjp_outputs)
+    return {"scale": np.float32(total)}

--- a/examples/ref_output/tesseract_config.yaml
+++ b/examples/ref_output/tesseract_config.yaml
@@ -1,0 +1,10 @@
+name: ref_output
+version: "1.0.0"
+description: |
+  Tesseract that returns a list of nested models, each serialized to its own
+  JSON file via Ref. Demonstrates sidecar-file outputs that stay transparent
+  to differentiation and abstract evaluation.
+
+build_config:
+  package_data: []
+  custom_build_steps: []

--- a/examples/ref_output/test_cases/test_apply.json
+++ b/examples/ref_output/test_cases/test_apply.json
@@ -1,0 +1,88 @@
+{
+  "endpoint": "apply",
+  "payload": {
+    "inputs": {
+      "scale": 2.0,
+      "n_nodes": 2,
+      "n_frames": 3
+    }
+  },
+  "expected_outputs": {
+    "frames": [
+      {
+        "name": "frame_000",
+        "displacement": {
+          "object_type": "array",
+          "shape": [2, 3],
+          "dtype": "float32",
+          "data": {
+            "buffer": [
+              [0.0, 0.0, 0.0],
+              [2.0, 2.0, 2.0]
+            ],
+            "encoding": "json"
+          }
+        },
+        "pressure": {
+          "object_type": "array",
+          "shape": [2],
+          "dtype": "float64",
+          "data": {
+            "buffer": [0.0, 2.0],
+            "encoding": "json"
+          }
+        }
+      },
+      {
+        "name": "frame_001",
+        "displacement": {
+          "object_type": "array",
+          "shape": [2, 3],
+          "dtype": "float32",
+          "data": {
+            "buffer": [
+              [0.0, 2.0, -2.0],
+              [2.0, 4.0, 0.0]
+            ],
+            "encoding": "json"
+          }
+        },
+        "pressure": {
+          "object_type": "array",
+          "shape": [2],
+          "dtype": "float64",
+          "data": {
+            "buffer": [2.0, 4.0],
+            "encoding": "json"
+          }
+        }
+      },
+      {
+        "name": "frame_002",
+        "displacement": {
+          "object_type": "array",
+          "shape": [2, 3],
+          "dtype": "float32",
+          "data": {
+            "buffer": [
+              [0.0, 4.0, -4.0],
+              [2.0, 6.0, -2.0]
+            ],
+            "encoding": "json"
+          }
+        },
+        "pressure": {
+          "object_type": "array",
+          "shape": [2],
+          "dtype": "float64",
+          "data": {
+            "buffer": [4.0, 6.0],
+            "encoding": "json"
+          }
+        }
+      }
+    ]
+  },
+  "atol": 1e-8,
+  "rtol": 1e-5
+}

--- a/examples/ref_output/test_cases/test_apply.json
+++ b/examples/ref_output/test_cases/test_apply.json
@@ -10,7 +10,7 @@
   "expected_outputs": {
     "frames": [
       {
-        "name": "frame_000",
+        "name": "step_0",
         "displacement": {
           "object_type": "array",
           "shape": [2, 3],
@@ -34,7 +34,7 @@
         }
       },
       {
-        "name": "frame_001",
+        "name": "step_1",
         "displacement": {
           "object_type": "array",
           "shape": [2, 3],
@@ -58,7 +58,7 @@
         }
       },
       {
-        "name": "frame_002",
+        "name": "step_2",
         "displacement": {
           "object_type": "array",
           "shape": [2, 3],

--- a/examples/ref_output/test_cases_inputs/example_checkgradients_input.json
+++ b/examples/ref_output/test_cases_inputs/example_checkgradients_input.json
@@ -1,0 +1,7 @@
+{
+  "inputs": {
+    "scale": 2.0,
+    "n_nodes": 2,
+    "n_frames": 2
+  }
+}

--- a/tesseract_core/runtime/array_encoding.py
+++ b/tesseract_core/runtime/array_encoding.py
@@ -28,6 +28,7 @@ from tesseract_core.runtime.file_interactions import (
     is_absolute_path,
     is_url,
     join_paths,
+    posix_join,
     read_from_path,
     write_to_path,
 )
@@ -282,9 +283,10 @@ def _dump_binref_arraydict(
     compression: str | None = None,
 ) -> tuple[ArrayDict, str]:
     """Dump array to json+binref encoded array dict."""
-    target_name = f"{current_binref_uuid}.bin"
-    if subdir is not None:
-        target_name = join_paths(subdir, target_name)
+    # target_name goes into the emitted buffer spec, so it must be POSIX even
+    # when the runtime runs natively on Windows; join_paths handles the
+    # forward slashes fine when resolving it against base_dir.
+    target_name = posix_join(subdir, f"{current_binref_uuid}.bin")
     target_path = join_paths(base_dir, target_name)
 
     current_size = get_filesize(target_path)
@@ -293,9 +295,7 @@ def _dump_binref_arraydict(
     if current_size > max_file_size:
         current_size = 0
         current_binref_uuid = str(uuid4())
-        target_name = f"{current_binref_uuid}.bin"
-        if subdir is not None:
-            target_name = join_paths(subdir, target_name)
+        target_name = posix_join(subdir, f"{current_binref_uuid}.bin")
         target_path = join_paths(base_dir, target_name)
 
     blob = _compress(_fast_tobytes(arr), compression)

--- a/tesseract_core/runtime/experimental/__init__.py
+++ b/tesseract_core/runtime/experimental/__init__.py
@@ -27,6 +27,9 @@ from .paths import (
     OutputPath,
     require_file,
 )
+from .refs import (
+    Ref,
+)
 from .tesseract_reference import TesseractReference
 from .vjp_cache import set_jax_vjp_cache_size
 
@@ -44,6 +47,7 @@ for _obj in (
     LazySequence,
     InputPath,
     OutputPath,
+    Ref,
     TesseractReference,
     require_file,
     set_jax_vjp_cache_size,
@@ -67,6 +71,7 @@ __all__ = [
     "LazySequence",
     "OutputFileReference",
     "OutputPath",
+    "Ref",
     "TesseractReference",
     "finite_difference_jacobian",
     "finite_difference_jvp",

--- a/tesseract_core/runtime/experimental/refs.py
+++ b/tesseract_core/runtime/experimental/refs.py
@@ -19,7 +19,6 @@ duplicated shape / dtype declarations.
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Annotated, Any, TypeVar
 from uuid import uuid4
 
@@ -29,8 +28,8 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import core_schema
 
 from tesseract_core.runtime.file_interactions import (
-    PathLike,
     join_paths,
+    posix_join,
     read_from_path,
     write_to_path,
 )
@@ -63,19 +62,6 @@ def _as_ref_path(value: Any) -> str | None:
             raise ValueError(f"Ref marker must carry a string 'path', got {path!r}.")
         return path
     return None
-
-
-def _posix_join(subdir: PathLike | None, filename: str) -> str:
-    """Join a sidecar path for the wire, always with forward slashes.
-
-    The emitted path travels in the response and is resolved by whoever reads
-    it, which may not be on the same OS as the Tesseract. ``join_paths`` uses
-    :class:`pathlib.Path`, so it would produce backslashes when the runtime
-    happens to run natively on Windows.
-    """
-    if not subdir:
-        return filename
-    return "/".join((*Path(subdir).parts, filename))
 
 
 def _ref_prefix(value: Any, prefix: str | None) -> str | None:
@@ -184,7 +170,7 @@ class PydanticRefAnnotation:
             # inside them resolve against the same base_dir.
             subdir = context.get("binref_dir")
             filename = _ref_filename(value, prefix, context)
-            relpath = _posix_join(subdir, filename)
+            relpath = posix_join(subdir, filename)
             write_to_path(orjson.dumps(payload), join_paths(base_dir, relpath))
             return {"object_type": REF_OBJECT_TYPE, "path": relpath}
 

--- a/tesseract_core/runtime/experimental/refs.py
+++ b/tesseract_core/runtime/experimental/refs.py
@@ -1,0 +1,202 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sidecar references: serialize a nested model to its own JSON file.
+
+``Ref[T]`` wraps an arbitrary type ``T`` (typically a Pydantic model holding
+arrays) so that, when the enclosing Tesseract output is dumped to a directory,
+each ``T`` is written to its own ``.json`` file and the main payload carries
+only the relative path to it -- the same idea ``json+binref`` applies to array
+buffers, one level up the tree.
+
+``Ref`` is deliberately a thin ``Annotated`` wrapper. That keeps it transparent
+to :func:`~tesseract_core.runtime.schema_generation.apply_function_to_model_tree`,
+so differentiable-path discovery, ``abstract_eval`` schema derivation and the
+gradient endpoints keep seeing the wrapped model's arrays and need no
+duplicated shape / dtype declarations.
+"""
+
+import re
+from typing import Annotated, Any, TypeVar
+from uuid import uuid4
+
+import orjson
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler, TypeAdapter
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import core_schema
+
+from tesseract_core.runtime.file_interactions import (
+    join_paths,
+    read_from_path,
+    write_to_path,
+)
+
+T = TypeVar("T")
+
+# Filenames derived from user data are restricted to a conservative charset so
+# a stem can never escape the output directory or collide with a .bin file.
+_SAFE_STEM = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _ref_filename(value: Any, context: dict) -> str:
+    """Pick the sidecar filename for ``value``, rejecting unsafe or duplicate stems."""
+    namer = getattr(value, "__ref_name__", None)
+    if namer is None:
+        return f"{uuid4()}.json"
+
+    stem = namer()
+    if not isinstance(stem, str) or not _SAFE_STEM.match(stem):
+        raise ValueError(
+            f"{type(value).__name__}.__ref_name__() must return a string matching "
+            f"{_SAFE_STEM.pattern} to be used as a Ref filename, got {stem!r}."
+        )
+
+    filename = f"{stem}.json"
+    # Track names for the duration of one dump, so two refs cannot silently
+    # clobber each other's file. Mirrors how '__binref_uuid' is threaded
+    # through the serialization context by array_encoding.encode_array.
+    written = context.setdefault("__ref_names", set())
+    if filename in written:
+        raise ValueError(
+            f"Duplicate Ref filename {filename!r}: __ref_name__() must be unique "
+            "across all refs in a single output payload."
+        )
+    written.add(filename)
+    return filename
+
+
+class PydanticRefAnnotation:
+    """Pydantic annotation implementing the sidecar-file encoding for ``Ref``."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise RuntimeError(f"{self.__class__.__name__} cannot be instantiated")
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        _handler: GetCoreSchemaHandler,
+    ) -> core_schema.CoreSchema:
+        # Build a standalone, fully resolved schema for the wrapped type. Going
+        # through TypeAdapter (rather than the handler) is what LazySequence
+        # does too: the handler may hand back unresolved definition references,
+        # which cannot be turned into a validator on their own.
+        adapter = TypeAdapter(source_type)
+
+        def load(value: Any, info: Any) -> Any:
+            context = info.context or {}
+            if not isinstance(value, str):
+                # Inline object -- validate it directly.
+                return adapter.validator.validate_python(value, context=context)
+
+            base_dir = context.get("base_dir")
+            if base_dir is None:
+                raise ValueError(
+                    f"Ref {value!r} is a relative path but no base_dir is set. "
+                    "Invoke the Tesseract with an input / output path set."
+                )
+            payload = orjson.loads(read_from_path(join_paths(base_dir, value)))
+            # Keep base_dir unchanged so binrefs *inside* the sidecar, which are
+            # written relative to the same base_dir, still resolve.
+            return adapter.validator.validate_python(payload, context=context)
+
+        def dump(value: Any, info: Any) -> Any:
+            # Serialize the wrapped model with the caller's settings, so nested
+            # arrays honour array_encoding / compression / exclude_unset.
+            payload = adapter.serializer.to_python(value, **info.__dict__)
+
+            context = info.context or {}
+            base_dir = context.get("base_dir")
+            if not info.mode_is_json() or base_dir is None:
+                # Python mode, or no directory to write to (plain json /
+                # json+base64 responses) -- keep the model inline.
+                return payload
+
+            # Sidecars live next to the .bin files so that relative binrefs
+            # inside them resolve against the same base_dir.
+            subdir = context.get("binref_dir")
+            filename = _ref_filename(value, context)
+            relpath = join_paths(subdir, filename) if subdir else filename
+            write_to_path(orjson.dumps(payload), join_paths(base_dir, relpath))
+            return relpath
+
+        schema = core_schema.with_info_plain_validator_function(
+            load,
+            serialization=core_schema.plain_serializer_function_ser_schema(
+                dump, info_arg=True
+            ),
+        )
+        # Stash the inner schema so __get_pydantic_json_schema__ can describe
+        # the inline alternative without rebuilding it.
+        schema["metadata"] = {"ref_inner_schema": adapter.core_schema}
+        return schema
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, _core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        inline = handler(_core_schema["metadata"]["ref_inner_schema"])
+        return {
+            "oneOf": [
+                {
+                    "type": "string",
+                    "format": "path",
+                    "description": "Relative path to a JSON file holding this object.",
+                },
+                inline,
+            ]
+        }
+
+
+class Ref:
+    """Type annotation for an object serialized to its own JSON file.
+
+    When the enclosing payload is dumped with a ``base_dir`` in the
+    serialization context (which is what the ``json+binref`` output format
+    sets, see :func:`tesseract_core.runtime.file_interactions.output_to_bytes`),
+    each ``Ref`` writes its value to ``<base_dir>/<name>.json`` and serializes
+    as the relative path to that file. Without a ``base_dir`` -- plain ``json``
+    and ``json+base64`` responses, or Python-mode dumps -- the object is
+    serialized inline, so a Tesseract using ``Ref`` still works over plain HTTP.
+
+    Validation accepts both forms: a path string is read and validated against
+    the wrapped type, an inline object is validated directly. Either way the
+    wrapped type's own validators run, so array shapes and dtypes inside the
+    sidecar are checked exactly as they would be inline.
+
+    Sidecars are named with a UUID by default, matching how ``json+binref``
+    names its ``.bin`` files. To get readable filenames, give the wrapped model
+    a ``__ref_name__()`` method returning the filename stem; it must be unique
+    across the payload.
+
+    Example:
+        >>> class Frame(BaseModel):
+        ...     name: str
+        ...     u: Differentiable[Array[(None, 3), Float32]]
+        ...
+        ...     def __ref_name__(self) -> str:
+        ...         return self.name
+
+        >>> class OutputSchema(BaseModel):
+        ...     result: list[Ref[Frame]]
+
+        Dumped with ``json+binref``, this produces
+        ``{"result": ["frame_0.json", "frame_1.json"]}`` plus one JSON file per
+        frame, each holding binref pointers into the shared ``.bin`` buffer.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        clsname = self.__class__.__name__
+        raise RuntimeError(
+            f"{clsname} cannot be instantiated directly, "
+            f"perhaps you meant to use `{clsname}[MyModel]`?"
+        )
+
+    def __class_getitem__(cls, key: Any) -> Any:
+        """Wrap the given type so it is serialized to a sidecar JSON file."""
+        if isinstance(key, tuple):
+            raise ValueError(
+                "Ref takes a single parameter: Ref[MyModel]. To control sidecar "
+                "filenames, give MyModel a __ref_name__() method."
+            )
+        return Annotated[key, PydanticRefAnnotation]

--- a/tesseract_core/runtime/experimental/refs.py
+++ b/tesseract_core/runtime/experimental/refs.py
@@ -18,6 +18,8 @@ duplicated shape / dtype declarations.
 
 import re
 from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
 from typing import Annotated, Any, TypeVar
 from uuid import uuid4
 
@@ -27,6 +29,7 @@ from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import core_schema
 
 from tesseract_core.runtime.file_interactions import (
+    PathLike,
     join_paths,
     read_from_path,
     write_to_path,
@@ -62,42 +65,81 @@ def _as_ref_path(value: Any) -> str | None:
     return None
 
 
-def _ref_filename(value: Any, context: dict) -> str:
-    """Pick the sidecar filename for ``value``, rejecting unsafe or duplicate stems."""
-    namer = getattr(value, "__ref_name__", None)
-    if namer is None:
+def _posix_join(subdir: PathLike | None, filename: str) -> str:
+    """Join a sidecar path for the wire, always with forward slashes.
+
+    The emitted path travels in the response and is resolved by whoever reads
+    it, which may not be on the same OS as the Tesseract. ``join_paths`` uses
+    :class:`pathlib.Path`, so it would produce backslashes when the runtime
+    happens to run natively on Windows.
+    """
+    if not subdir:
+        return filename
+    return "/".join((*Path(subdir).parts, filename))
+
+
+def _ref_prefix(value: Any, prefix: str | None) -> str | None:
+    """Pick the filename prefix for ``value``, or None to fall back to a UUID.
+
+    In order of preference:
+
+    1. the prefix passed to ``Ref[T, "..."]``;
+    2. the model's own ``name`` field, when it holds a usable string;
+    3. the model's class name.
+
+    A ``name`` that is missing, not a string, or not filename-safe falls
+    through to the next option rather than raising: names usually come from
+    runtime data, and a bad one should not sink a whole response. A prefix
+    passed to ``Ref`` is developer-supplied, so an unusable one is an error.
+    """
+    if prefix is not None:
+        if not _SAFE_STEM.match(prefix):
+            raise ValueError(
+                f"Invalid Ref prefix {prefix!r}: must match {_SAFE_STEM.pattern}."
+            )
+        return prefix
+
+    name = getattr(value, "name", None)
+    if isinstance(name, str) and _SAFE_STEM.match(name):
+        return name
+
+    class_name = type(value).__name__
+    if _SAFE_STEM.match(class_name):
+        return class_name
+
+    return None
+
+
+def _ref_filename(value: Any, prefix: str | None, context: dict) -> str:
+    """Build the sidecar filename for ``value``.
+
+    Every prefixed name carries a running index (``frame_000``, ``frame_001``,
+    ...), so sidecars in one payload can never collide no matter how the prefix
+    was derived. Counters live in the serialization context, so they restart on
+    each dump -- the same way ``__binref_uuid`` is threaded through by
+    ``array_encoding.encode_array``. Two dumps into the *same* directory
+    therefore overwrite each other; served Tesseracts avoid this by writing
+    into a per-request ``run_<id>/`` directory.
+    """
+    stem = _ref_prefix(value, prefix)
+    if stem is None:
+        # Nothing usable to name it after; fall back to how binref names .bin files.
         return f"{uuid4()}.json"
 
-    stem = namer()
-    if not isinstance(stem, str) or not _SAFE_STEM.match(stem):
-        raise ValueError(
-            f"{type(value).__name__}.__ref_name__() must return a string matching "
-            f"{_SAFE_STEM.pattern} to be used as a Ref filename, got {stem!r}."
-        )
-
-    filename = f"{stem}.json"
-    # Track names for the duration of one dump, so two refs cannot silently
-    # clobber each other's file. Mirrors how '__binref_uuid' is threaded
-    # through the serialization context by array_encoding.encode_array.
-    written = context.setdefault("__ref_names", set())
-    if filename in written:
-        raise ValueError(
-            f"Duplicate Ref filename {filename!r}: __ref_name__() must be unique "
-            "across all refs in a single output payload."
-        )
-    written.add(filename)
-    return filename
+    counters = context.setdefault("__ref_counters", {})
+    index = counters.get(stem, 0)
+    counters[stem] = index + 1
+    return f"{stem}_{index:03d}.json"
 
 
+@dataclass(frozen=True)
 class PydanticRefAnnotation:
     """Pydantic annotation implementing the sidecar-file encoding for ``Ref``."""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        raise RuntimeError(f"{self.__class__.__name__} cannot be instantiated")
+    prefix: str | None = None
 
-    @classmethod
     def __get_pydantic_core_schema__(
-        cls,
+        self,
         source_type: Any,
         _handler: GetCoreSchemaHandler,
     ) -> core_schema.CoreSchema:
@@ -106,6 +148,7 @@ class PydanticRefAnnotation:
         # does too: the handler may hand back unresolved definition references,
         # which cannot be turned into a validator on their own.
         adapter = TypeAdapter(source_type)
+        prefix = self.prefix
 
         def load(value: Any, info: Any) -> Any:
             context = info.context or {}
@@ -140,8 +183,8 @@ class PydanticRefAnnotation:
             # Sidecars live next to the .bin files so that relative binrefs
             # inside them resolve against the same base_dir.
             subdir = context.get("binref_dir")
-            filename = _ref_filename(value, context)
-            relpath = join_paths(subdir, filename) if subdir else filename
+            filename = _ref_filename(value, prefix, context)
+            relpath = _posix_join(subdir, filename)
             write_to_path(orjson.dumps(payload), join_paths(base_dir, relpath))
             return {"object_type": REF_OBJECT_TYPE, "path": relpath}
 
@@ -156,9 +199,8 @@ class PydanticRefAnnotation:
         schema["metadata"] = {"ref_inner_schema": adapter.core_schema}
         return schema
 
-    @classmethod
     def __get_pydantic_json_schema__(
-        cls, _core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
+        self, _core_schema: core_schema.CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
         inline = handler(_core_schema["metadata"]["ref_inner_schema"])
         return {
@@ -188,34 +230,38 @@ class Ref:
     serialization context (which is what the ``json+binref`` output format
     sets, see :func:`tesseract_core.runtime.file_interactions.output_to_bytes`),
     each ``Ref`` writes its value to ``<base_dir>/<name>.json`` and serializes
-    as the relative path to that file. Without a ``base_dir`` -- plain ``json``
-    and ``json+base64`` responses, or Python-mode dumps -- the object is
-    serialized inline, so a Tesseract using ``Ref`` still works over plain HTTP.
+    as ``{"object_type": "ref", "path": ...}``. Without a ``base_dir`` -- plain
+    ``json`` and ``json+base64`` responses, or Python-mode dumps -- the object
+    is serialized inline, so the response stays self-contained.
 
-    Validation accepts both forms: a path string is read and validated against
-    the wrapped type, an inline object is validated directly. Either way the
-    wrapped type's own validators run, so array shapes and dtypes inside the
-    sidecar are checked exactly as they would be inline.
+    Validation accepts an encoded ref, a bare path string, or an inline
+    object. In every case the wrapped type's own validators run, so array
+    shapes and dtypes inside a sidecar are checked exactly as they would be
+    inline.
 
-    Sidecars are named with a UUID by default, matching how ``json+binref``
-    names its ``.bin`` files. To get readable filenames, give the wrapped model
-    a ``__ref_name__()`` method returning the filename stem; it must be unique
-    across the payload.
+    Sidecar filenames are ``<prefix>_<index>.json``, where the prefix is taken
+    from the first of these that is usable:
+
+    1. the prefix passed as ``Ref[T, "frame"]``;
+    2. the model's own ``name`` field;
+    3. the model's class name.
+
+    Failing all three (a model with no usable class name), files are named with
+    a UUID, matching how ``json+binref`` names its ``.bin`` files. The index
+    makes collisions impossible within a payload, so ``name`` need not be
+    unique.
 
     Example:
         >>> class Frame(BaseModel):
-        ...     name: str
         ...     u: Differentiable[Array[(None, 3), Float32]]
-        ...
-        ...     def __ref_name__(self) -> str:
-        ...         return self.name
 
         >>> class OutputSchema(BaseModel):
-        ...     result: list[Ref[Frame]]
+        ...     frames: list[Ref[Frame, "frame"]]
 
-        Dumped with ``json+binref``, this produces
-        ``{"result": ["frame_0.json", "frame_1.json"]}`` plus one JSON file per
-        frame, each holding binref pointers into the shared ``.bin`` buffer.
+        Dumped with ``json+binref``, this writes ``frame_000.json``,
+        ``frame_001.json``, ... each holding binref pointers into the shared
+        ``.bin`` buffer. Without the prefix the files would be named after the
+        model's ``name`` field, or ``Frame_000.json`` and so on.
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -226,10 +272,20 @@ class Ref:
         )
 
     def __class_getitem__(cls, key: Any) -> Any:
-        """Wrap the given type so it is serialized to a sidecar JSON file."""
+        """Wrap a type so it is serialized to a sidecar file, with an optional prefix."""
         if isinstance(key, tuple):
-            raise ValueError(
-                "Ref takes a single parameter: Ref[MyModel]. To control sidecar "
-                "filenames, give MyModel a __ref_name__() method."
-            )
-        return Annotated[key, PydanticRefAnnotation]
+            if len(key) != 2:
+                raise ValueError(
+                    "Ref takes at most two parameters: "
+                    'Ref[MyModel] or Ref[MyModel, "filename_prefix"]'
+                )
+            base_type, prefix = key
+            if not isinstance(prefix, str):
+                raise ValueError(
+                    "Second parameter of Ref[...] must be a filename prefix "
+                    f"(a string), got {prefix!r}"
+                )
+        else:
+            base_type, prefix = key, None
+
+        return Annotated[base_type, PydanticRefAnnotation(prefix)]

--- a/tesseract_core/runtime/experimental/refs.py
+++ b/tesseract_core/runtime/experimental/refs.py
@@ -17,6 +17,7 @@ duplicated shape / dtype declarations.
 """
 
 import re
+from collections.abc import Mapping
 from typing import Annotated, Any, TypeVar
 from uuid import uuid4
 
@@ -33,9 +34,32 @@ from tesseract_core.runtime.file_interactions import (
 
 T = TypeVar("T")
 
+#: Discriminator marking an encoded ref, mirroring ``object_type: "array"`` on
+#: encoded arrays. Clients that decode responses without access to the
+#: Tesseract's schema (e.g. the SDK's HTTPClient) rely on it to tell a ref
+#: apart from an ordinary string or object field.
+REF_OBJECT_TYPE = "ref"
+
 # Filenames derived from user data are restricted to a conservative charset so
 # a stem can never escape the output directory or collide with a .bin file.
 _SAFE_STEM = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+def _as_ref_path(value: Any) -> str | None:
+    """Return the referenced path if ``value`` encodes a ref, else None.
+
+    Accepts the encoded form ``{"object_type": "ref", "path": ...}`` as well as
+    a bare path string, so payloads hand-written against the output directory
+    keep working.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping) and value.get("object_type") == REF_OBJECT_TYPE:
+        path = value.get("path")
+        if not isinstance(path, str):
+            raise ValueError(f"Ref marker must carry a string 'path', got {path!r}.")
+        return path
+    return None
 
 
 def _ref_filename(value: Any, context: dict) -> str:
@@ -85,17 +109,18 @@ class PydanticRefAnnotation:
 
         def load(value: Any, info: Any) -> Any:
             context = info.context or {}
-            if not isinstance(value, str):
+            relpath = _as_ref_path(value)
+            if relpath is None:
                 # Inline object -- validate it directly.
                 return adapter.validator.validate_python(value, context=context)
 
             base_dir = context.get("base_dir")
             if base_dir is None:
                 raise ValueError(
-                    f"Ref {value!r} is a relative path but no base_dir is set. "
+                    f"Ref {relpath!r} is a relative path but no base_dir is set. "
                     "Invoke the Tesseract with an input / output path set."
                 )
-            payload = orjson.loads(read_from_path(join_paths(base_dir, value)))
+            payload = orjson.loads(read_from_path(join_paths(base_dir, relpath)))
             # Keep base_dir unchanged so binrefs *inside* the sidecar, which are
             # written relative to the same base_dir, still resolve.
             return adapter.validator.validate_python(payload, context=context)
@@ -118,7 +143,7 @@ class PydanticRefAnnotation:
             filename = _ref_filename(value, context)
             relpath = join_paths(subdir, filename) if subdir else filename
             write_to_path(orjson.dumps(payload), join_paths(base_dir, relpath))
-            return relpath
+            return {"object_type": REF_OBJECT_TYPE, "path": relpath}
 
         schema = core_schema.with_info_plain_validator_function(
             load,
@@ -139,9 +164,17 @@ class PydanticRefAnnotation:
         return {
             "oneOf": [
                 {
-                    "type": "string",
-                    "format": "path",
-                    "description": "Relative path to a JSON file holding this object.",
+                    "type": "object",
+                    "description": (
+                        "Reference to a JSON file holding this object, relative to the "
+                        "Tesseract's output path."
+                    ),
+                    "properties": {
+                        "object_type": {"const": REF_OBJECT_TYPE},
+                        "path": {"type": "string", "format": "path"},
+                    },
+                    "required": ["object_type", "path"],
+                    "additionalProperties": False,
                 },
                 inline,
             ]

--- a/tesseract_core/runtime/file_interactions.py
+++ b/tesseract_core/runtime/file_interactions.py
@@ -79,6 +79,20 @@ def output_to_bytes(
     return orjson.dumps(python_dict)
 
 
+def posix_join(subdir: PathLike | None, name: str) -> str:
+    """Join a relative path for the wire, always with forward slashes.
+
+    Paths that travel inside a payload (binref buffers, Ref sidecars) are
+    resolved by whoever reads them, which may not be on the same OS as the
+    Tesseract that wrote them. :func:`join_paths` goes through
+    :class:`pathlib.Path` and so yields backslashes when the runtime runs
+    natively on Windows. Readers accept forward slashes on every platform.
+    """
+    if not subdir:
+        return name
+    return "/".join((*Path(subdir).parts, name))
+
+
 def read_from_path(path: PathLike, offset: int = 0, length: int = -1) -> bytes:
     """Read the contents of the given path as bytes.
 

--- a/tesseract_core/sdk/binref.py
+++ b/tesseract_core/sdk/binref.py
@@ -39,6 +39,12 @@ def _fast_tobytes(arr: np.ndarray) -> memoryview:
     return np.ascontiguousarray(arr).data
 
 
+# Discriminator for an encoded Ref: {"object_type": "ref", "path": ...}. Kept in
+# sync with tesseract_core.runtime.experimental.refs.REF_OBJECT_TYPE by hand --
+# runtime and SDK share no code (they run in different environments).
+REF_OBJECT_TYPE = "ref"
+
+
 def encode_array_binref(arr: Any, input_dir: Path, written_files: list[Path]) -> dict:
     """Encode an array as a binref reference, writing its buffer to ``input_dir``.
 

--- a/tesseract_core/sdk/tesseract.py
+++ b/tesseract_core/sdk/tesseract.py
@@ -26,6 +26,7 @@ from pydantic_core import InitErrorDetails, PydanticCustomError, from_json
 
 from . import engine
 from .binref import (
+    REF_OBJECT_TYPE,
     SUPPORTS_BINREF_POOL,
     BinrefSlot,
     BinrefWritePool,
@@ -1104,19 +1105,44 @@ class HTTPClient:
             # where several arrays share one file at different offsets.
             mapped_paths: list[Path] = []
 
-            def decode_with_path(arr: dict) -> np.ndarray | IpcDeviceArray:
+            def decode_leaf(leaf: dict) -> Any:
+                if leaf.get("object_type") == REF_OBJECT_TYPE:
+                    return decode_ref(leaf)
                 return _decode_array(
-                    arr,
+                    leaf,
                     output_path=self._output_path,
                     lazy=lazy,
                     mapped_paths=mapped_paths,
                 )
 
-            data = _tree_map(
-                decode_with_path,
-                data,
-                is_leaf=lambda x: type(x) is dict and "shape" in x,
-            )
+            def decode_ref(ref: dict) -> Any:
+                """Load a sidecar JSON file and decode the arrays inside it.
+
+                Sidecar paths are relative to the output path, same as binref
+                buffers. Refs may nest, so the loaded contents go back through
+                the same tree walk.
+                """
+                if self._output_path is None:
+                    raise ValueError(
+                        f"Cannot resolve reference {ref['path']!r}: no output_path is set. "
+                        "Pass output_path when creating the Tesseract."
+                    )
+                full_path = Path(self._output_path) / ref["path"]
+                if not full_path.exists():
+                    raise ValueError(
+                        f"Referenced file not found: {full_path}. "
+                        "Make sure output_path points at the Tesseract's output directory."
+                    )
+                with open(full_path, "rb") as f:
+                    contents = orjson.loads(f.read())
+                return _tree_map(decode_leaf, contents, is_leaf=is_encoded_leaf)
+
+            def is_encoded_leaf(x: Any) -> bool:
+                return type(x) is dict and (
+                    "shape" in x or x.get("object_type") == REF_OBJECT_TYPE
+                )
+
+            data = _tree_map(decode_leaf, data, is_leaf=is_encoded_leaf)
 
             for path in set(mapped_paths):
                 path.unlink(missing_ok=True)

--- a/tests/endtoend_tests/test_examples.py
+++ b/tests/endtoend_tests/test_examples.py
@@ -109,6 +109,7 @@ TEST_CASES = {
     ),
     "metrics": Config(test_with_random_inputs=True),
     "qp_solve": Config(),
+    "ref_output": Config(check_gradients=True, output_path="__tmp_path__"),
     "inherit_base_image_packages": Config(),
     "tesseractreference": Config(),  # Can't test requests standalone; needs target Tesseract. Covered in separate test.
     "userhandling": Config(),

--- a/tests/runtime_tests/test_file_interactions.py
+++ b/tests/runtime_tests/test_file_interactions.py
@@ -114,3 +114,33 @@ def test_output_to_bytes_scalar_only():
     assert isinstance(result, bytes)
     decoded = json.loads(result.decode())
     assert decoded == 42.0
+
+
+def test_binref_buffers_are_posix_regardless_of_host(tmp_path):
+    """Buffer specs travel in the response, so they must not pick up backslashes.
+
+    A Tesseract may serve from a different OS than the client resolving the
+    path, and join_paths() goes through pathlib.
+    """
+    import json
+
+    import numpy as np
+    from pydantic import BaseModel
+
+    from tesseract_core.runtime import Array, Float32
+    from tesseract_core.runtime.file_interactions import output_to_bytes
+
+    class Model(BaseModel):
+        arr: Array[(2,), Float32]
+
+    payload = json.loads(
+        output_to_bytes(
+            Model(arr=np.ones(2, "float32")),
+            "json+binref",
+            base_dir=tmp_path,
+            binref_dir="run_1/inner",
+        )
+    )
+    buffer = payload["arr"]["data"]["buffer"]
+    assert buffer.startswith("run_1/inner/")
+    assert "\\" not in buffer

--- a/tests/runtime_tests/test_refs.py
+++ b/tests/runtime_tests/test_refs.py
@@ -359,7 +359,7 @@ def test_ref_paths_are_posix_regardless_of_host(tmp_path):
     A Tesseract may serve from a different OS than the client that resolves
     the path, and join_paths() goes through pathlib.
     """
-    from tesseract_core.runtime.experimental.refs import _posix_join
+    from tesseract_core.runtime.file_interactions import posix_join
 
     payload = json.loads(
         output_to_bytes(
@@ -371,4 +371,4 @@ def test_ref_paths_are_posix_regardless_of_host(tmp_path):
     assert not any("\\" in path for path in paths)
 
     # a subdir that already arrived with native separators is normalised too
-    assert _posix_join(Path("run_1") / "inner", "f.json") == "run_1/inner/f.json"
+    assert posix_join(Path("run_1") / "inner", "f.json") == "run_1/inner/f.json"

--- a/tests/runtime_tests/test_refs.py
+++ b/tests/runtime_tests/test_refs.py
@@ -31,7 +31,7 @@ class Frame(BaseModel):
 
 
 class InputSchema(BaseModel):
-    scale: Differentiable[Array[(), Float32]]
+    scale: Differentiable[Array[(), Float32]] = 1.0
 
 
 class OutputSchema(BaseModel):
@@ -240,3 +240,57 @@ def test_composes_with_lazy_sequence():
         }
     )
     assert restored.result[0].name == "a"
+
+
+# ---------------------------------------------------------------------------
+# Refs over HTTP
+# ---------------------------------------------------------------------------
+
+
+def test_refs_are_written_over_http(tmp_path, monkeypatch):
+    """A served Tesseract must write sidecars into the output path, not inline them.
+
+    serve.create_response always passes base_dir=config.output_path and
+    binref_dir=run_<id>, so refs land in the per-request run directory next to
+    the .bin buffer they point into.
+    """
+    import sys
+    import types
+
+    from fastapi.testclient import TestClient
+
+    from tesseract_core.runtime.config import update_config
+    from tesseract_core.runtime.serve import create_rest_api
+
+    module = types.ModuleType("ref_api")
+    module.InputSchema = InputSchema
+    module.OutputSchema = OutputSchema
+    module.apply = lambda inputs: OutputSchema(result=[make_frame(i) for i in range(2)])
+    monkeypatch.setitem(sys.modules, "ref_api", module)
+
+    update_config(output_path=str(tmp_path))
+    try:
+        client = TestClient(create_rest_api(module))
+        response = client.post(
+            "/apply",
+            json={"inputs": {"scale": 1.0}},
+            headers={"Accept": "application/json+binref"},
+            params={"run_id": "test_refs"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json() == {
+            "result": ["run_test_refs/frame_0.json", "run_test_refs/frame_1.json"]
+        }
+
+        rundir = tmp_path / "run_test_refs"
+        assert (rundir / "frame_0.json").exists()
+        # one shared buffer for the arrays of both sidecars
+        assert len(list(rundir.glob("*.bin"))) == 1
+
+        # the response round-trips against the output path
+        restored = OutputSchema.model_validate(
+            response.json(), context={"base_dir": str(tmp_path)}
+        )
+        np.testing.assert_allclose(restored.result[1].displacement, np.ones((2, 3)))
+    finally:
+        update_config()

--- a/tests/runtime_tests/test_refs.py
+++ b/tests/runtime_tests/test_refs.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel
 
 from tesseract_core.runtime import Array, Differentiable, Float32, Float64
 from tesseract_core.runtime.experimental import LazySequence, Ref
+from tesseract_core.runtime.experimental.refs import REF_OBJECT_TYPE
 from tesseract_core.runtime.file_interactions import output_to_bytes
 from tesseract_core.runtime.schema_generation import (
     create_abstract_eval_schema,
@@ -54,7 +55,12 @@ def test_binref_writes_sidecars_and_emits_paths(tmp_path):
     payload = json.loads(
         output_to_bytes(make_output(), "json+binref", base_dir=tmp_path)
     )
-    assert payload == {"result": ["frame_0.json", "frame_1.json", "frame_2.json"]}
+    assert payload == {
+        "result": [
+            {"object_type": REF_OBJECT_TYPE, "path": f"frame_{i}.json"}
+            for i in range(3)
+        ]
+    }
 
     sidecar = json.loads((tmp_path / "frame_1.json").read_text())
     assert sidecar["name"] == "frame_1"
@@ -75,7 +81,9 @@ def test_binref_dir_keeps_sidecars_next_to_buffers(tmp_path):
             make_output(1), "json+binref", base_dir=tmp_path, binref_dir="sub"
         )
     )
-    assert payload == {"result": ["sub/frame_0.json"]}
+    assert payload == {
+        "result": [{"object_type": REF_OBJECT_TYPE, "path": "sub/frame_0.json"}]
+    }
     assert (tmp_path / "sub" / "frame_0.json").exists()
 
     sidecar = json.loads((tmp_path / "sub" / "frame_0.json").read_text())
@@ -103,6 +111,15 @@ def test_roundtrip_through_sidecars(tmp_path):
     for got, want in zip(restored.result, original.result, strict=True):
         np.testing.assert_allclose(got.displacement, want.displacement)
         np.testing.assert_allclose(got.pressure, want.pressure)
+
+
+def test_validate_accepts_bare_path_strings(tmp_path):
+    """Hand-written payloads that just name the file keep working."""
+    output_to_bytes(make_output(1), "json+binref", base_dir=tmp_path)
+    restored = OutputSchema.model_validate(
+        {"result": ["frame_0.json"]}, context={"base_dir": str(tmp_path)}
+    )
+    assert restored.result[0].name == "frame_0"
 
 
 def test_validate_accepts_inline_objects():
@@ -165,8 +182,9 @@ def test_uuid_names_by_default(tmp_path):
     payload = json.loads(
         output_to_bytes(AnonOutput(result=[anon]), "json+binref", base_dir=tmp_path)
     )
-    (name,) = payload["result"]
-    assert name.endswith(".json") and name != "frame_0.json"
+    (ref,) = payload["result"]
+    assert ref["object_type"] == REF_OBJECT_TYPE
+    assert ref["path"].endswith(".json") and ref["path"] != "frame_0.json"
 
 
 # ---------------------------------------------------------------------------
@@ -279,7 +297,13 @@ def test_refs_are_written_over_http(tmp_path, monkeypatch):
         )
         assert response.status_code == 200, response.text
         assert response.json() == {
-            "result": ["run_test_refs/frame_0.json", "run_test_refs/frame_1.json"]
+            "result": [
+                {
+                    "object_type": REF_OBJECT_TYPE,
+                    "path": f"run_test_refs/frame_{i}.json",
+                }
+                for i in range(2)
+            ]
         }
 
         rundir = tmp_path / "run_test_refs"

--- a/tests/runtime_tests/test_refs.py
+++ b/tests/runtime_tests/test_refs.py
@@ -4,6 +4,7 @@
 """Tests for Ref, the sidecar-JSON encoding for nested models."""
 
 import json
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -27,16 +28,13 @@ class Frame(BaseModel):
     displacement: Differentiable[Array[(None, 3), Float32]]
     pressure: Differentiable[Array[(None,), Float64]]
 
-    def __ref_name__(self) -> str:
-        return self.name
-
 
 class InputSchema(BaseModel):
     scale: Differentiable[Array[(), Float32]] = 1.0
 
 
 class OutputSchema(BaseModel):
-    result: list[Ref[Frame]]
+    result: list[Ref[Frame, "frame"]]  # noqa: F821
 
 
 def make_frame(idx: int, n: int = 2) -> Frame:
@@ -57,12 +55,12 @@ def test_binref_writes_sidecars_and_emits_paths(tmp_path):
     )
     assert payload == {
         "result": [
-            {"object_type": REF_OBJECT_TYPE, "path": f"frame_{i}.json"}
+            {"object_type": REF_OBJECT_TYPE, "path": f"frame_{i:03d}.json"}
             for i in range(3)
         ]
     }
 
-    sidecar = json.loads((tmp_path / "frame_1.json").read_text())
+    sidecar = json.loads((tmp_path / "frame_001.json").read_text())
     assert sidecar["name"] == "frame_1"
     assert sidecar["displacement"]["data"]["encoding"] == "binref"
     assert sidecar["displacement"]["shape"] == [2, 3]
@@ -82,11 +80,11 @@ def test_binref_dir_keeps_sidecars_next_to_buffers(tmp_path):
         )
     )
     assert payload == {
-        "result": [{"object_type": REF_OBJECT_TYPE, "path": "sub/frame_0.json"}]
+        "result": [{"object_type": REF_OBJECT_TYPE, "path": "sub/frame_000.json"}]
     }
-    assert (tmp_path / "sub" / "frame_0.json").exists()
+    assert (tmp_path / "sub" / "frame_000.json").exists()
 
-    sidecar = json.loads((tmp_path / "sub" / "frame_0.json").read_text())
+    sidecar = json.loads((tmp_path / "sub" / "frame_000.json").read_text())
     # binrefs inside the sidecar stay relative to base_dir, not to the sidecar
     assert sidecar["displacement"]["data"]["buffer"].startswith("sub/")
 
@@ -117,7 +115,7 @@ def test_validate_accepts_bare_path_strings(tmp_path):
     """Hand-written payloads that just name the file keep working."""
     output_to_bytes(make_output(1), "json+binref", base_dir=tmp_path)
     restored = OutputSchema.model_validate(
-        {"result": ["frame_0.json"]}, context={"base_dir": str(tmp_path)}
+        {"result": ["frame_000.json"]}, context={"base_dir": str(tmp_path)}
     )
     assert restored.result[0].name == "frame_0"
 
@@ -146,45 +144,80 @@ def test_sidecar_arrays_are_shape_validated(tmp_path):
 
 def test_path_without_base_dir_is_rejected():
     with pytest.raises(ValueError, match="no base_dir is set"):
-        OutputSchema.model_validate({"result": ["frame_0.json"]})
+        OutputSchema.model_validate({"result": ["frame_000.json"]})
 
 
-def test_duplicate_filenames_are_rejected(tmp_path):
+def test_repeated_names_get_distinct_files(tmp_path):
+    """The running index means a non-unique `name` cannot clobber anything."""
     duplicated = OutputSchema(result=[make_frame(0), make_frame(0)])
-    with pytest.raises(Exception, match="Duplicate Ref filename"):
-        output_to_bytes(duplicated, "json+binref", base_dir=tmp_path)
+    payload = json.loads(output_to_bytes(duplicated, "json+binref", base_dir=tmp_path))
+    assert [ref["path"] for ref in payload["result"]] == [
+        "frame_000.json",
+        "frame_001.json",
+    ]
 
 
-def test_ref_rejects_extra_type_parameters():
-    with pytest.raises(ValueError, match="single parameter"):
-        Ref[Frame, "name"]
+def test_invalid_prefix_is_rejected(tmp_path):
+    class Escaping(BaseModel):
+        result: list[Ref[Frame, "../escape"]]  # noqa: F722
+
+    with pytest.raises(Exception, match="Invalid Ref prefix"):
+        output_to_bytes(
+            Escaping(result=[make_frame(0)]), "json+binref", base_dir=tmp_path
+        )
 
 
-def test_unsafe_filename_is_rejected(tmp_path):
+@pytest.mark.parametrize(
+    "field_name,expected",
+    [
+        # no prefix: fall back to the model's own `name` field ...
+        ("name", "frame_0_000.json"),
+        # ... then to the class name
+        ("label", "Unprefixed_000.json"),
+    ],
+)
+def test_name_falls_back_to_field_then_class(tmp_path, field_name, expected):
+    Unprefixed = type(
+        "Unprefixed",
+        (BaseModel,),
+        {
+            "__annotations__": {
+                field_name: str,
+                "displacement": Differentiable[Array[(None, 3), Float32]],
+                "pressure": Differentiable[Array[(None,), Float64]],
+            }
+        },
+    )
+
+    class Out(BaseModel):
+        result: list[Ref[Unprefixed]]
+
+    frame = make_frame(0)
+    item = Unprefixed(
+        **{field_name: "frame_0"},
+        displacement=frame.displacement,
+        pressure=frame.pressure,
+    )
+    payload = json.loads(
+        output_to_bytes(Out(result=[item]), "json+binref", base_dir=tmp_path)
+    )
+    assert payload["result"][0]["path"] == expected
+
+
+def test_unusable_name_falls_through_to_class_name(tmp_path):
+    """A name that is not filename-safe must not sink the whole response."""
     escaping = OutputSchema(result=[make_frame(0)])
     escaping.result[0].name = "../escape"
-    with pytest.raises(Exception, match="as a Ref filename"):
-        output_to_bytes(escaping, "json+binref", base_dir=tmp_path)
 
+    class Unprefixed(BaseModel):
+        result: list[Ref[Frame]]
 
-def test_uuid_names_by_default(tmp_path):
-    class Anon(BaseModel):
-        """Same fields as Frame but no __ref_name__, so sidecars get UUID names."""
-
-        name: str
-        displacement: Differentiable[Array[(None, 3), Float32]]
-        pressure: Differentiable[Array[(None,), Float64]]
-
-    class AnonOutput(BaseModel):
-        result: list[Ref[Anon]]
-
-    anon = Anon(**make_frame(0).model_dump())
     payload = json.loads(
-        output_to_bytes(AnonOutput(result=[anon]), "json+binref", base_dir=tmp_path)
+        output_to_bytes(
+            Unprefixed(result=escaping.result), "json+binref", base_dir=tmp_path
+        )
     )
-    (ref,) = payload["result"]
-    assert ref["object_type"] == REF_OBJECT_TYPE
-    assert ref["path"].endswith(".json") and ref["path"] != "frame_0.json"
+    assert payload["result"][0]["path"] == "Frame_000.json"
 
 
 # ---------------------------------------------------------------------------
@@ -300,14 +333,14 @@ def test_refs_are_written_over_http(tmp_path, monkeypatch):
             "result": [
                 {
                     "object_type": REF_OBJECT_TYPE,
-                    "path": f"run_test_refs/frame_{i}.json",
+                    "path": f"run_test_refs/frame_{i:03d}.json",
                 }
                 for i in range(2)
             ]
         }
 
         rundir = tmp_path / "run_test_refs"
-        assert (rundir / "frame_0.json").exists()
+        assert (rundir / "frame_000.json").exists()
         # one shared buffer for the arrays of both sidecars
         assert len(list(rundir.glob("*.bin"))) == 1
 
@@ -318,3 +351,24 @@ def test_refs_are_written_over_http(tmp_path, monkeypatch):
         np.testing.assert_allclose(restored.result[1].displacement, np.ones((2, 3)))
     finally:
         update_config()
+
+
+def test_ref_paths_are_posix_regardless_of_host(tmp_path):
+    """Ref paths travel in the response, so they must not pick up backslashes.
+
+    A Tesseract may serve from a different OS than the client that resolves
+    the path, and join_paths() goes through pathlib.
+    """
+    from tesseract_core.runtime.experimental.refs import _posix_join
+
+    payload = json.loads(
+        output_to_bytes(
+            make_output(2), "json+binref", base_dir=tmp_path, binref_dir="run_1/inner"
+        )
+    )
+    paths = [ref["path"] for ref in payload["result"]]
+    assert paths == ["run_1/inner/frame_000.json", "run_1/inner/frame_001.json"]
+    assert not any("\\" in path for path in paths)
+
+    # a subdir that already arrived with native separators is normalised too
+    assert _posix_join(Path("run_1") / "inner", "f.json") == "run_1/inner/f.json"

--- a/tests/runtime_tests/test_refs.py
+++ b/tests/runtime_tests/test_refs.py
@@ -1,0 +1,242 @@
+# Copyright 2025 Pasteur Labs. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Ref, the sidecar-JSON encoding for nested models."""
+
+import json
+
+import numpy as np
+import pytest
+from pydantic import BaseModel
+
+from tesseract_core.runtime import Array, Differentiable, Float32, Float64
+from tesseract_core.runtime.experimental import LazySequence, Ref
+from tesseract_core.runtime.file_interactions import output_to_bytes
+from tesseract_core.runtime.schema_generation import (
+    create_abstract_eval_schema,
+    create_apply_schema,
+    create_gradient_schema,
+    get_all_model_path_patterns,
+)
+from tesseract_core.runtime.schema_types import is_differentiable
+
+
+class Frame(BaseModel):
+    name: str
+    displacement: Differentiable[Array[(None, 3), Float32]]
+    pressure: Differentiable[Array[(None,), Float64]]
+
+    def __ref_name__(self) -> str:
+        return self.name
+
+
+class InputSchema(BaseModel):
+    scale: Differentiable[Array[(), Float32]]
+
+
+class OutputSchema(BaseModel):
+    result: list[Ref[Frame]]
+
+
+def make_frame(idx: int, n: int = 2) -> Frame:
+    return Frame(
+        name=f"frame_{idx}",
+        displacement=np.full((n, 3), float(idx), dtype="float32"),
+        pressure=np.arange(n, dtype="float64") + idx,
+    )
+
+
+def make_output(count: int = 3) -> OutputSchema:
+    return OutputSchema(result=[make_frame(i) for i in range(count)])
+
+
+def test_binref_writes_sidecars_and_emits_paths(tmp_path):
+    payload = json.loads(
+        output_to_bytes(make_output(), "json+binref", base_dir=tmp_path)
+    )
+    assert payload == {"result": ["frame_0.json", "frame_1.json", "frame_2.json"]}
+
+    sidecar = json.loads((tmp_path / "frame_1.json").read_text())
+    assert sidecar["name"] == "frame_1"
+    assert sidecar["displacement"]["data"]["encoding"] == "binref"
+    assert sidecar["displacement"]["shape"] == [2, 3]
+    assert sidecar["pressure"]["dtype"] == "float64"
+
+
+def test_binref_arrays_share_one_buffer_across_sidecars(tmp_path):
+    """The binref uuid accumulator must be threaded through refs, not reset per file."""
+    output_to_bytes(make_output(), "json+binref", base_dir=tmp_path)
+    assert len(list(tmp_path.glob("*.bin"))) == 1
+
+
+def test_binref_dir_keeps_sidecars_next_to_buffers(tmp_path):
+    payload = json.loads(
+        output_to_bytes(
+            make_output(1), "json+binref", base_dir=tmp_path, binref_dir="sub"
+        )
+    )
+    assert payload == {"result": ["sub/frame_0.json"]}
+    assert (tmp_path / "sub" / "frame_0.json").exists()
+
+    sidecar = json.loads((tmp_path / "sub" / "frame_0.json").read_text())
+    # binrefs inside the sidecar stay relative to base_dir, not to the sidecar
+    assert sidecar["displacement"]["data"]["buffer"].startswith("sub/")
+
+
+@pytest.mark.parametrize("fmt", ["json", "json+base64"])
+def test_inline_when_no_base_dir(fmt):
+    """Formats without an output directory must keep refs inline, not fail."""
+    payload = json.loads(output_to_bytes(make_output(1), fmt))
+    (frame,) = payload["result"]
+    assert frame["name"] == "frame_0"
+    expected_encoding = "base64" if fmt == "json+base64" else "json"
+    assert frame["displacement"]["data"]["encoding"] == expected_encoding
+
+
+def test_roundtrip_through_sidecars(tmp_path):
+    original = make_output()
+    payload = json.loads(output_to_bytes(original, "json+binref", base_dir=tmp_path))
+    context = {"base_dir": str(tmp_path)}
+    restored = OutputSchema.model_validate(payload, context=context)
+
+    assert [f.name for f in restored.result] == ["frame_0", "frame_1", "frame_2"]
+    for got, want in zip(restored.result, original.result, strict=True):
+        np.testing.assert_allclose(got.displacement, want.displacement)
+        np.testing.assert_allclose(got.pressure, want.pressure)
+
+
+def test_validate_accepts_inline_objects():
+    restored = OutputSchema.model_validate(
+        {
+            "result": [
+                {"name": "a", "displacement": [[1.0, 2.0, 3.0]], "pressure": [1.0]}
+            ]
+        }
+    )
+    assert restored.result[0].displacement.shape == (1, 3)
+
+
+def test_sidecar_arrays_are_shape_validated(tmp_path):
+    """Arrays behind a ref go through the same validation as inline arrays."""
+    (tmp_path / "bad.json").write_text(
+        json.dumps({"name": "bad", "displacement": [[1.0, 2.0]], "pressure": [1.0]})
+    )
+    with pytest.raises(ValueError, match="shape"):
+        OutputSchema.model_validate(
+            {"result": ["bad.json"]}, context={"base_dir": str(tmp_path)}
+        )
+
+
+def test_path_without_base_dir_is_rejected():
+    with pytest.raises(ValueError, match="no base_dir is set"):
+        OutputSchema.model_validate({"result": ["frame_0.json"]})
+
+
+def test_duplicate_filenames_are_rejected(tmp_path):
+    duplicated = OutputSchema(result=[make_frame(0), make_frame(0)])
+    with pytest.raises(Exception, match="Duplicate Ref filename"):
+        output_to_bytes(duplicated, "json+binref", base_dir=tmp_path)
+
+
+def test_ref_rejects_extra_type_parameters():
+    with pytest.raises(ValueError, match="single parameter"):
+        Ref[Frame, "name"]
+
+
+def test_unsafe_filename_is_rejected(tmp_path):
+    escaping = OutputSchema(result=[make_frame(0)])
+    escaping.result[0].name = "../escape"
+    with pytest.raises(Exception, match="as a Ref filename"):
+        output_to_bytes(escaping, "json+binref", base_dir=tmp_path)
+
+
+def test_uuid_names_by_default(tmp_path):
+    class Anon(BaseModel):
+        """Same fields as Frame but no __ref_name__, so sidecars get UUID names."""
+
+        name: str
+        displacement: Differentiable[Array[(None, 3), Float32]]
+        pressure: Differentiable[Array[(None,), Float64]]
+
+    class AnonOutput(BaseModel):
+        result: list[Ref[Anon]]
+
+    anon = Anon(**make_frame(0).model_dump())
+    payload = json.loads(
+        output_to_bytes(AnonOutput(result=[anon]), "json+binref", base_dir=tmp_path)
+    )
+    (name,) = payload["result"]
+    assert name.endswith(".json") and name != "frame_0.json"
+
+
+# ---------------------------------------------------------------------------
+# Ref must stay transparent to schema generation
+# ---------------------------------------------------------------------------
+
+
+def test_diffable_paths_match_unwrapped_model():
+    class Unwrapped(BaseModel):
+        result: list[Frame]
+
+    assert get_all_model_path_patterns(
+        OutputSchema, is_differentiable
+    ) == get_all_model_path_patterns(Unwrapped, is_differentiable)
+
+
+def test_abstract_eval_replaces_arrays_inside_refs():
+    _, AbstractOutput = create_abstract_eval_schema(InputSchema, OutputSchema)
+    schema = AbstractOutput.model_json_schema()
+    frame = schema["$defs"]["AbstractEval_Frame"]["properties"]
+    assert frame["displacement"] == {"$ref": "#/$defs/ShapeDType"}
+    assert frame["pressure"] == {"$ref": "#/$defs/ShapeDType"}
+    assert frame["name"]["type"] == "string"
+
+
+def test_apply_schema_rebuild_propagates_model_config():
+    """The inner model must be rebuilt (Apply_Frame, extra=forbid), not captured stale."""
+    _, ApplyOutput = create_apply_schema(InputSchema, OutputSchema)
+    valid = {
+        "result": [{"name": "a", "displacement": [[1.0, 2.0, 3.0]], "pressure": [1.0]}]
+    }
+    assert (
+        type(ApplyOutput.model_validate(valid).root.result[0]).__name__ == "Apply_Frame"
+    )
+
+    with pytest.raises(ValueError, match=r"[Ee]xtra"):
+        ApplyOutput.model_validate(
+            {"result": [{**valid["result"][0], "unexpected": 1}]}
+        )
+
+
+@pytest.mark.parametrize("gradient_type", ["jacobian", "jvp", "vjp"])
+def test_gradient_endpoints_see_through_refs(gradient_type):
+    """Gradient payloads are flat path->array dicts, so Ref is inherently a no-op there."""
+    GradInput, GradOutput = create_gradient_schema(
+        InputSchema, OutputSchema, gradient_type
+    )
+    out_schema = GradOutput.model_json_schema()
+    # Flat mapping of path -> encoded array (or path -> path -> array for jacobian).
+    # Ref's string/path alternative appears nowhere in it, so gradients never
+    # traverse a ref and need no special handling.
+    assert '"format": "path"' not in json.dumps(out_schema)
+
+    if gradient_type == "jacobian":
+        patterns = GradInput.model_json_schema()["properties"]["jac_outputs"]["items"]
+        assert {p["pattern"] for p in patterns["anyOf"]} == {
+            r"result\.\[\d+\]\.displacement",
+            r"result\.\[\d+\]\.pressure",
+        }
+
+
+def test_composes_with_lazy_sequence():
+    class Composed(BaseModel):
+        result: LazySequence[Ref[Frame]]
+
+    restored = Composed.model_validate(
+        {
+            "result": [
+                {"name": "a", "displacement": [[1.0, 2.0, 3.0]], "pressure": [1.0]}
+            ]
+        }
+    )
+    assert restored.result[0].name == "a"

--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -1029,3 +1029,67 @@ def test_HTTPClient_timeout_fires(free_port):
         shutdown.set()
         httpd.shutdown()
         server_thread.join(timeout=5)
+
+
+def test_HTTPClient_follows_refs(mocker, tmp_path):
+    """Encoded refs are resolved client-side, so callers get decoded models back.
+
+    The client has no access to the Tesseract's schema, so it recognises a ref
+    by its ``object_type`` marker, exactly as it recognises encoded arrays.
+    The response payload here is produced by the real runtime serializer.
+    """
+    import numpy as np
+    from pydantic import BaseModel
+
+    from tesseract_core.runtime import Array, Differentiable, Float32, Float64
+    from tesseract_core.runtime.experimental import Ref
+    from tesseract_core.runtime.file_interactions import output_to_bytes
+
+    class Frame(BaseModel):
+        name: str
+        displacement: Differentiable[Array[(None, 3), Float32]]
+        pressure: Differentiable[Array[(None,), Float64]]
+
+        def __ref_name__(self) -> str:
+            return self.name
+
+    class OutputSchema(BaseModel):
+        frames: list[Ref[Frame]]
+
+    outputs = OutputSchema(
+        frames=[
+            Frame(
+                name=f"frame_{i}",
+                displacement=np.full((2, 3), float(i), dtype="float32"),
+                pressure=np.arange(2, dtype="float64") + i,
+            )
+            for i in range(2)
+        ]
+    )
+    content = output_to_bytes(outputs, "json+binref", base_dir=tmp_path)
+    assert b'"object_type":"ref"' in content
+
+    mock_response = mocker.Mock()
+    mock_response.content = content
+    mock_response.ok = True
+    mock_response.status_code = 200
+    mocker.patch("requests.Session.request", return_value=mock_response)
+
+    client = HTTPClient("somehost", output_path=tmp_path, output_format="json+binref")
+    out = client.run_tesseract("apply", {"inputs": {}})
+
+    assert [frame["name"] for frame in out["frames"]] == ["frame_0", "frame_1"]
+    np.testing.assert_allclose(out["frames"][1]["displacement"], np.ones((2, 3)))
+    np.testing.assert_allclose(out["frames"][1]["pressure"], [1.0, 2.0])
+
+
+def test_HTTPClient_ref_without_output_path_is_rejected(mocker):
+    mock_response = mocker.Mock()
+    mock_response.content = b'{"frames": [{"object_type": "ref", "path": "a.json"}]}'
+    mock_response.ok = True
+    mock_response.status_code = 200
+    mocker.patch("requests.Session.request", return_value=mock_response)
+
+    client = HTTPClient("somehost")
+    with pytest.raises(ValueError, match="no output_path is set"):
+        client.run_tesseract("apply", {"inputs": {}})

--- a/tests/sdk_tests/test_tesseract.py
+++ b/tests/sdk_tests/test_tesseract.py
@@ -1050,11 +1050,8 @@ def test_HTTPClient_follows_refs(mocker, tmp_path):
         displacement: Differentiable[Array[(None, 3), Float32]]
         pressure: Differentiable[Array[(None,), Float64]]
 
-        def __ref_name__(self) -> str:
-            return self.name
-
     class OutputSchema(BaseModel):
-        frames: list[Ref[Frame]]
+        frames: list[Ref[Frame, "frame"]]  # noqa: F821
 
     outputs = OutputSchema(
         frames=[


### PR DESCRIPTION
#### Relevant issue or PR

Drafted in response to a user asking how to return a list of their own Pydantic models (containing differentiable arrays) as separate JSON files, with the main output pointing at them the way `json+binref` points at `.bin` files.

#### Description of changes

Adds `Ref[T]` to `tesseract_core.runtime.experimental`. Users write:

```python
class Frame(BaseModel):
    name: str
    displacement: Differentiable[Array[(None, 3), Float32]]
    pressure: Differentiable[Array[(None,), Float64]]

class OutputSchema(BaseModel):
    frames: list[Ref[Frame, "frame"]]
```

and get, with `json+binref`:

```json
{
  "frames": [
    { "object_type": "ref", "path": "frame_000.json" },
    { "object_type": "ref", "path": "frame_001.json" },
    { "object_type": "ref", "path": "frame_002.json" }
  ]
}
```

plus one JSON file per frame, whose arrays are binrefs into a single shared `.bin` buffer.

**`Ref` is a thin `Annotated` wrapper, and that is the whole point.** `apply_function_to_model_tree` recurses through `Annotated` and re-attaches the metadata, so the wrapped model stays fully visible to schema generation. Nothing has to be re-declared:

- differentiable paths are identical to the unwrapped `list[Frame]`;
- `create_abstract_eval_schema` rewrites the arrays inside `Frame` to `ShapeDType` on its own;
- the inner model is correctly rebuilt as `Apply_Frame` with `extra="forbid"` — the captured `TypeAdapter` is not stale.

This is what the alternatives (a hand-written manifest model, or annotating each path with an abstract declaration) were trying to buy, at the cost of duplicating the schema.

**Gradient endpoints need no work.** `create_gradient_schema` produces flat `{path: array}` mappings keyed by paths *into* the output tree (`frames.[1].pressure`), not the nested `OutputSchema`. Gradient payloads therefore never traverse a ref, and `Ref` is inherently a no-op for all three endpoints.

**Works over HTTP.** `serve.create_response` always passes `base_dir=config.output_path` and `binref_dir=run_<id>`, so a served Tesseract writes sidecars into the per-request run directory next to the `.bin` they point into. Whether refs become files depends on the output *format*, not the transport.

**Graceful degradation.** A sidecar is written only when the serialization context carries a `base_dir`, which is what `json+binref` sets. With `json` / `json+base64` there is nowhere to write, so refs serialize inline and the response stays self-contained. Validation accepts an encoded ref, a bare path string, or an inline object, and runs the wrapped model's own validators in every case, so arrays inside a sidecar are shape- and dtype-checked exactly as inline.

**Why refs are self-describing.** The runtime validator does not need a discriminator — it knows from the schema that a ref is expected and just loads the file. The SDK client does: it never sees the Tesseract's `OutputSchema` and identifies encoded values by type-sniffing the raw JSON (`is_leaf=lambda x: type(x) is dict and "shape" in x`), so a bare string is indistinguishable from an ordinary string field like `name`. Marking refs the way encoded arrays are marked (`object_type: "array"`) lets the same tree walk resolve them. `HTTPClient` now loads the sidecar relative to `output_path` and feeds its contents back through the same walk, so arrays inside sidecars — and nested refs — decode too; a missing `output_path` raises rather than returning an unresolvable path.

`REF_OBJECT_TYPE` is declared separately in `sdk/binref.py`, since runtime and SDK share no code (per AGENTS.md), as binref itself already does.

**Filenames** are `<prefix>_<index>.json`, where the prefix is the first usable of:

1. the prefix passed as `Ref[T, "frame"]` → `frame_000.json`;
2. the model's own `name` field → `step_0_000.json`;
3. the model's class name → `Frame_000.json`;
4. failing all three, a UUID, matching how binref names `.bin` files.

The running index makes collisions impossible within a payload, so a `name` need not be unique. A `name` that is missing or not filename-safe falls through to the next option rather than raising — names come from runtime data and a bad one should not sink a whole response — while an unusable prefix passed to `Ref` is developer-supplied and raises. Counters restart per dump, so two dumps into the same directory overwrite each other; served Tesseracts avoid this via their per-request `run_<id>/` directory.

Note that a bare string in a subscript is read as a forward reference by linters, so `Ref[Frame, "frame"]` may need a `# noqa: F821` (`F722` if the string is not identifier-like). This is not specific to `Ref` — Tesseract's existing `Array[(2, 3), "float32"]` form has the same issue, which is presumably why the exported `Float32` constants are used everywhere in practice.

#### Verification

- 24 fast tests in `tests/runtime_tests/test_refs.py` plus 2 client tests in `tests/sdk_tests/test_tesseract.py`; full fast suite passes (769 passed).
- Verified against a live server (`tesseract-runtime serve` + `HTTPClient`): sidecars land in `run_<id>/`, and the client returns decoded frames — `step_1 displacement [[0,2,-2],[2,4,0]] pressure [2,4]` — where before the marker it returned raw path strings.
- `examples/ref_output` is a real, runnable Tesseract with two differentiable array leaves and a string leaf. All three gradient endpoints implemented and numerically verified: `tesseract-runtime check-gradients` reports 0 failures / 4 checks for each of jacobian, JVP and VJP.
- Docs built locally with `SPHINXOPTS=-W`, clean. Every bash block and JSON payload on the docs page was copied from actual command output.

#### Open questions for review

1. **Coupling to `json+binref`.** Refs are written when the context carries a `base_dir`, which only `json+binref` sets. Keying off "an output path exists" instead is a one-line change in `output_to_bytes`, but `RuntimeConfig.output_path` defaults to `"."` with no unset sentinel, so a Tesseract would spray sidecars into the server's CWD on every request. `json+binref` is the only explicit signal, and it is already guarded client-side (`engine.py:975` refuses it without an `output_path`).
2. **Relationship to `LazySequence`.** `LazySequence` is the read half of this idea and today has no working write half (its serializer materializes everything inline, and it cannot validate a list of path strings — only a single `@glob`). `Ref` is the missing primitive and the two compose: `LazySequence[Ref[T]]` works and is covered by a test. Giving `LazySequence` a serializer that emits refs would make it round-trip, but that is a behaviour change to an existing type and is left out of scope.
3. **Sidecar placement.** Sidecars are written next to the `.bin` files (honouring `binref_dir`) so relative binrefs inside them resolve against the same `base_dir`. Note this differs from `LazySequence`, which rebases `base_dir` to each file's parent on load.

#### Pre-existing issues noticed, not fixed here

- **binref buffer paths are not POSIX-normalised.** `Ref` emits its wire path with forward slashes explicitly, because `join_paths` goes through `pathlib` and produced backslashes when the runtime ran natively on Windows (this broke Windows CI on the first push). `_dump_binref_arraydict` builds `"<subdir>/<uuid>.bin:<offset>"` the same way and has the same latent problem — it is self-consistent when writer and reader share an OS, so it does not fail today, but a Windows-hosted runtime would emit backslashes into the response.
- `docs/content/examples/building-blocks/file_io.md` shows `tesseract-runtime apply --input-path ... --output-path ...`, but those are global options and must precede the subcommand; as written the command fails with `No such option: --output-path`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)