### PR TITLE
fix: build Tesseracts on base images that set UV_SYSTEM_PYTHON

### DIFF
--- a/tesseract_core/sdk/templates/build_pip_venv.sh
+++ b/tesseract_core/sdk/templates/build_pip_venv.sh
@@ -5,6 +5,26 @@
 
 set -e  # Exit immediately if a command exits with a non-zero status
 
+# Neutralize uv configuration inherited from the base image so that every `uv`
+# command below installs into /python-env, which is the only thing the run stage
+# copies. A base image can redirect installs (e.g. into the system Python) via
+# two independent channels, each needing its own guard:
+#
+#   1. Environment variables that redirect installs or the target interpreter.
+#      NVIDIA NGC images, for instance, set UV_SYSTEM_PYTHON=1 and
+#      UV_BREAK_SYSTEM_PACKAGES=1. Setting these while building a dedicated venv
+#      is always self-defeating, so we unconditionally unset them. (An empty
+#      value is not enough: uv rejects e.g. UV_SYSTEM_PYTHON="" as an invalid
+#      boolean, so the variable must be fully unset.)
+#
+#   2. Config files (/etc/uv/uv.toml, $XDG_CONFIG_DIRS, ~/.config/uv/uv.toml,
+#      ...), which UV_NO_CONFIG ignores. Unlike the vars above, pointing uv at a
+#      config file can be legitimate, so we only default UV_NO_CONFIG on when the
+#      user has not set it themselves via build_config.build_env (which lands in
+#      the environment before this script runs).
+unset UV_SYSTEM_PYTHON UV_BREAK_SYSTEM_PACKAGES UV_PYTHON UV_PROJECT_ENVIRONMENT
+export UV_NO_CONFIG="${UV_NO_CONFIG:-1}"
+
 # python_version and inherit_base_image_packages are mutually exclusive (enforced
 # at config validation time), so at most one of these branches sets venv options.
 if [ -n "${TESSERACT_PYTHON_VERSION:-}" ]; then
@@ -16,12 +36,6 @@ else
     uv venv /python-env
 fi
 source /python-env/bin/activate
-
-# Some base images (e.g. NVIDIA NGC) set UV_SYSTEM_PYTHON=1 and
-# UV_BREAK_SYSTEM_PACKAGES=1 in their environment. These make `uv pip install`
-# ignore the active venv and install into the base image's system site-packages,
-# which the run stage never copies. Unset them so installs land in /python-env.
-unset UV_SYSTEM_PYTHON UV_BREAK_SYSTEM_PACKAGES
 
 # Set up host credentials (netrc + git-credentials) for authenticated indices,
 # direct-reference wheels, and git+https dependencies. No-op if none declared.

--- a/tesseract_core/sdk/templates/build_pip_venv.sh
+++ b/tesseract_core/sdk/templates/build_pip_venv.sh
@@ -17,6 +17,12 @@ else
 fi
 source /python-env/bin/activate
 
+# Some base images (e.g. NVIDIA NGC) set UV_SYSTEM_PYTHON=1 and
+# UV_BREAK_SYSTEM_PACKAGES=1 in their environment. These make `uv pip install`
+# ignore the active venv and install into the base image's system site-packages,
+# which the run stage never copies. Unset them so installs land in /python-env.
+unset UV_SYSTEM_PYTHON UV_BREAK_SYSTEM_PACKAGES
+
 # Set up host credentials (netrc + git-credentials) for authenticated indices,
 # direct-reference wheels, and git+https dependencies. No-op if none declared.
 source setup_host_credentials.sh

--- a/tests/endtoend_tests/test_build.py
+++ b/tests/endtoend_tests/test_build.py
@@ -170,24 +170,27 @@ def test_tarball_install(cli_runner, dummy_tesseract_package, docker_cleanup):
     docker_cleanup["images"].append(img_tag)
 
 
-def test_build_inherit_base_image_packages_with_uv_system_python(
+def test_build_inherit_base_image_packages_with_uv_config(
     cli_runner, docker_client, dummy_tesseract_package, docker_cleanup, tmp_path
 ):
-    """inherit_base_image_packages must work when the base image sets UV_SYSTEM_PYTHON.
+    """inherit_base_image_packages must work despite base-image uv configuration.
 
-    Regression test for #747: NVIDIA NGC base images set UV_SYSTEM_PYTHON=1 and
-    UV_BREAK_SYSTEM_PACKAGES=1, which make ``uv pip install`` ignore the active
-    /python-env venv and install into the base image's system site-packages. The
-    run stage only copies /python-env, so the runtime (and everything else) ends
-    up missing and the build fails at the ``tesseract-runtime check`` step.
+    Regression test for #747: base images can redirect ``uv pip install`` away
+    from the active /python-env venv (into the system Python) through two
+    independent channels, and the build copies only /python-env into the run
+    stage, so a redirected install drops the runtime and the build fails at the
+    ``tesseract-runtime check`` step. The mock base image below exercises both:
 
-    We build a small mock base image that mimics NGC: it sets those two env vars
-    and pre-installs a distinctive package (``cowsay``) into the system Python.
-    Building a Tesseract on top with ``inherit_base_image_packages: true`` must
-    succeed, and both the inherited package and the runtime must be importable
-    from /python-env in the final image.
+    * environment variables — NVIDIA NGC images set UV_SYSTEM_PYTHON=1 and
+      UV_BREAK_SYSTEM_PACKAGES=1;
+    * a system-wide config file — /etc/uv/uv.toml with ``[pip] system = true``.
+
+    It also pre-installs a distinctive package (``cowsay``) into the system
+    Python. Building a Tesseract on top with ``inherit_base_image_packages:
+    true`` must succeed, and both the inherited package and the runtime must be
+    importable from /python-env in the final image.
     """
-    base_image_tag = "tesseract-test-uv-system-python-base:latest"
+    base_image_tag = "tesseract-test-uv-config-base:latest"
     dockerfile = tmp_path / "Dockerfile.base"
     dockerfile.write_text(
         dedent(
@@ -195,6 +198,7 @@ def test_build_inherit_base_image_packages_with_uv_system_python(
             FROM python:3.12-slim
             ENV UV_SYSTEM_PYTHON=1
             ENV UV_BREAK_SYSTEM_PACKAGES=1
+            RUN mkdir -p /etc/uv && printf '[pip]\\nsystem = true\\n' > /etc/uv/uv.toml
             RUN pip install --no-cache-dir cowsay==6.1
             """
         )

--- a/tests/endtoend_tests/test_build.py
+++ b/tests/endtoend_tests/test_build.py
@@ -170,6 +170,96 @@ def test_tarball_install(cli_runner, dummy_tesseract_package, docker_cleanup):
     docker_cleanup["images"].append(img_tag)
 
 
+def test_build_inherit_base_image_packages_with_uv_system_python(
+    cli_runner, docker_client, dummy_tesseract_package, docker_cleanup, tmp_path
+):
+    """inherit_base_image_packages must work when the base image sets UV_SYSTEM_PYTHON.
+
+    Regression test for #747: NVIDIA NGC base images set UV_SYSTEM_PYTHON=1 and
+    UV_BREAK_SYSTEM_PACKAGES=1, which make ``uv pip install`` ignore the active
+    /python-env venv and install into the base image's system site-packages. The
+    run stage only copies /python-env, so the runtime (and everything else) ends
+    up missing and the build fails at the ``tesseract-runtime check`` step.
+
+    We build a small mock base image that mimics NGC: it sets those two env vars
+    and pre-installs a distinctive package (``cowsay``) into the system Python.
+    Building a Tesseract on top with ``inherit_base_image_packages: true`` must
+    succeed, and both the inherited package and the runtime must be importable
+    from /python-env in the final image.
+    """
+    base_image_tag = "tesseract-test-uv-system-python-base:latest"
+    dockerfile = tmp_path / "Dockerfile.base"
+    dockerfile.write_text(
+        dedent(
+            """
+            FROM python:3.12-slim
+            ENV UV_SYSTEM_PYTHON=1
+            ENV UV_BREAK_SYSTEM_PACKAGES=1
+            RUN pip install --no-cache-dir cowsay==6.1
+            """
+        )
+    )
+    subprocess.run(
+        ["docker", "build", "-f", str(dockerfile), "-t", base_image_tag, str(tmp_path)],
+        check=True,
+    )
+
+    try:
+        # The Tesseract imports cowsay, which is only present via the inherited
+        # base image packages (it is deliberately absent from
+        # tesseract_requirements.txt).
+        (dummy_tesseract_package / "tesseract_api.py").write_text(
+            dedent(
+                """
+                import cowsay
+                from pydantic import BaseModel
+
+                class InputSchema(BaseModel):
+                    message: str = "Hello, Tesseractor!"
+
+                class OutputSchema(BaseModel):
+                    out: str
+
+                def apply(inputs: InputSchema) -> OutputSchema:
+                    return OutputSchema(out=cowsay.get_output_string("cow", inputs.message))
+                """
+            )
+        )
+        (dummy_tesseract_package / "tesseract_requirements.txt").write_text("")
+
+        image_name = build_tesseract(
+            docker_client,
+            dummy_tesseract_package,
+            "inherit_uv_system_python",
+            config_override={
+                "build_config.base_image": base_image_tag,
+                "build_config.inherit_base_image_packages": "true",
+            },
+        )
+        docker_cleanup["images"].append(image_name)
+        assert image_exists(docker_client, image_name)
+
+        # A successful build already proves the runtime landed in /python-env (the
+        # build fails at tesseract-runtime check otherwise). Running apply proves
+        # the inherited cowsay package is importable from the final image too.
+        result = cli_runner.invoke(
+            app,
+            ["run", image_name, "apply", '{"inputs": {"message": "moo"}}'],
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0, result.stderr
+        assert "moo" in result.stdout
+    finally:
+        # The base is not a Tesseract image, so docker_cleanup cannot remove it.
+        # Force-untag it here; shared layers are reclaimed once docker_cleanup
+        # removes the descendant Tesseract image during teardown.
+        subprocess.run(
+            ["docker", "rmi", "-f", base_image_tag],
+            check=False,
+            capture_output=True,
+        )
+
+
 def test_build_extra_index_url_with_local_dep(
     cli_runner, dummy_tesseract_package, docker_cleanup
 ):


### PR DESCRIPTION
#### Relevant issue or PR

Fixes #747

#### Description of changes

Building a Tesseract with `inherit_base_image_packages: true` on top of a base image that sets `UV_SYSTEM_PYTHON=1` (as NVIDIA NGC images do, e.g. `nvcr.io/nvidia/physicsnemo/physicsnemo:26.06`) failed at the final `tesseract-runtime check` step with `exec: tesseract-runtime: not found`.

The cause: the build script creates and activates `/python-env`, but the base image's uv configuration makes `uv pip install` ignore the active venv and install into the base's system site-packages instead. The run stage only copies `/python-env`, so the runtime and all requirements were silently dropped from the final image. These NGC images are exactly the kind of base you'd want to inherit packages from (PhysicsNeMo, PyTorch, etc.), so this unblocks a common use case.

A base image can redirect installs through two channels, both of which we now reset to inert defaults in the Dockerfile before the venv is built: environment variables (`UV_SYSTEM_PYTHON`, `UV_BREAK_SYSTEM_PACKAGES`, `UV_PYTHON`, `UV_PROJECT_ENVIRONMENT`) and config files (`/etc/uv/uv.toml`, `~/.config/uv/uv.toml`, …, ignored via `UV_NO_CONFIG=1`).

The reset is emitted *before* the `build_env` block, so it neutralizes the base image without overriding user intent: because Docker gives the later `ENV` precedence, any of these variables that the user sets explicitly in `build_config.build_env` still wins. This is the reason the reset lives in the Dockerfile rather than in the build script — at that point base-image and user values are indistinguishable process environment, whereas the Dockerfile can order them.

#### Testing done

- Reproduced both channels directly with `uv`: with an inherited `UV_SYSTEM_PYTHON=1` left in place, a `uv pip install` into an active venv is redirected ("system interpreter required"); with the reset to `0` it correctly targets the venv.
- Added an end-to-end regression test (`test_build_inherit_base_image_packages_with_uv_config`) that builds a lightweight mock base image exercising both channels (env vars **and** a system `uv.toml`) with a package pre-installed into the system Python, then builds a Tesseract on top with `inherit_base_image_packages: true` and runs `apply`. Passes with the reset in place.
- `pre-commit run --all-files` passes.
