### PR TITLE
ci: pre-build example containers to avoid pytest-timeout in fixture

### DIFF
--- a/.github/workflows/benchmark_report.yml
+++ b/.github/workflows/benchmark_report.yml
@@ -35,6 +35,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request'
       && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Download benchmark results
         id: download

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   benchmark:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Set up Git repository

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test-docs:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Set up Git repository

--- a/.github/workflows/bump_lockfile_and_uv.yml
+++ b/.github/workflows/bump_lockfile_and_uv.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   bump-lockfile:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Set up Git repository
@@ -73,6 +74,7 @@ jobs:
 
   bump-template-uv:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   cla-assistant:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: "CLA Assistant"
         if: startsWith(github.event.comment.body, '@PasteurBot') || github.event.comment.body == 'recheck' || github.event_name == 'pull_request_target'

--- a/.github/workflows/conventional-pr-linter.yml
+++ b/.github/workflows/conventional-pr-linter.yml
@@ -15,6 +15,7 @@ jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:

--- a/.github/workflows/pre-commit-cron-updater.yml
+++ b/.github/workflows/pre-commit-cron-updater.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   auto-update-hooks:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
   build:
     name: "Build distribution"
     runs-on: "${{ matrix.os }}"
+    timeout-minutes: 60
     strategy:
       matrix:
         # TODO: Comment in additional platforms if using C extensions / platform-specific wheels
@@ -60,6 +61,7 @@ jobs:
     name: "Publish distribution"
     if: startsWith(github.ref, 'refs/tags/') # only publish to PyPI on tag pushes
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     needs: build
 
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ env:
 jobs:
   trigger-pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: github.event_name == 'workflow_dispatch'
 
     steps:
@@ -80,6 +81,7 @@ jobs:
 
   update-pr:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/bot/release/')
 
     steps:
@@ -124,6 +126,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'bot/release/')
 
     steps:

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,6 +31,7 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     defaults:
       run:
@@ -78,6 +79,7 @@ jobs:
 
   get-e2e-matrix:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     outputs:
       matrix: ${{ steps.get-matrix.outputs.matrix }}
@@ -153,6 +155,7 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.arch == 'x64' && matrix.os == 'ubuntu-24.04' && 'ubuntu-24.04' || matrix.arch == 'arm' && matrix.os == 'ubuntu-24.04' && 'ubuntu-24.04-arm'}}
+    timeout-minutes: 60
 
     defaults:
       run:
@@ -192,6 +195,17 @@ jobs:
           export DOCKER_HOST=unix:///run/user/1001/podman/podman.sock
           echo "DOCKER_HOST=${DOCKER_HOST}" >> $GITHUB_ENV
           echo "TESSERACT_DOCKER_EXECUTABLE=podman" >> $GITHUB_ENV
+
+      # Build the example here so its layers are cached before the tests run.
+      # test_unit_tesseract_endtoend builds the same example inside the timed
+      # test body, and a cold build (pulling the base image plus installing the
+      # runtime) can otherwise exceed the per-test --timeout=300. Warming the
+      # layer cache outside pytest's timeout leaves the in-test build as cache
+      # hits. The "base" shard runs no example build, so it is skipped.
+      - name: Pre-build example (warm layer cache)
+        if: matrix.unit-tesseract != 'base'
+        run: |
+          uv run --no-sync tesseract build examples/${{ matrix.unit-tesseract }}
 
       - name: Run test suite
         run: |
@@ -241,6 +255,7 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
 
     steps:
       - name: Set up Git repository
@@ -285,6 +300,7 @@ jobs:
 
   tests-gpu:
     runs-on: tesseract-ci-gpu
+    timeout-minutes: 60
 
     # Exercise both CUDA major versions so the ctypes loader's version fallbacks
     # (libcudart.so.12/.13) and the encode/decode path are covered against each.
@@ -387,6 +403,7 @@ jobs:
     needs: [tests-base, tests-e2e, tests-demos, tests-gpu]
 
     runs-on: ubuntu-latest
+    timeout-minutes: 60
 
     steps:
       - name: Check for errors

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -352,6 +352,15 @@ jobs:
           uv run --no-sync python -c "import torch; print('torch', torch.__version__, 'cuda', torch.version.cuda, torch.cuda.is_available())"
           uv run --no-sync python -c "import jax; print('jax', jax.__version__, 'devices', jax.devices())"
 
+      # Build the GPU example here so its layers are cached before the tests
+      # run. The test_serving_gpu fixture builds the same example, and pulling
+      # the CUDA base image plus installing the runtime can otherwise exceed the
+      # per-test --timeout=300 from inside the fixture. Warming the layer cache
+      # outside pytest's timeout leaves the fixture build as cache hits.
+      - name: Pre-build GPU example (warm layer cache)
+        run: |
+          uv run --no-sync tesseract build examples/_gpu_cuda_ipc
+
       - name: Run GPU test suite
         run: |
           uv run --no-sync pytest \

--- a/.github/workflows/test_pip_install.yml
+++ b/.github/workflows/test_pip_install.yml
@@ -8,6 +8,7 @@ jobs:
   test-pip-install:
     name: "Test pip install"
     runs-on: "${{ matrix.os }}"
+    timeout-minutes: 60
     strategy:
       matrix:
         os:


### PR DESCRIPTION
#### Relevant issue or PR

None — this addresses a recurring GPU CI timeout, most recently seen on both GPU jobs in #750.

#### Description of changes

The `tests-gpu` jobs intermittently fail with a `pytest-timeout` in the setup of `test_serve_cuda_ipc_roundtrip`, and the failure cascades to `test_serve_cuda_ipc_serial_reuse`, which shares the same fixture.

The hang is not in the tests. Both share a module-scoped fixture that builds the `_gpu_cuda_ipc` example image, and that build (pulling the CUDA base image and installing the runtime) is billed to the first test's setup under the per-test `--timeout=300`. The GPU job normally runs ~300–320s in total, so the build regularly grazes the ceiling and occasionally trips it.

This adds a step that builds the same example before pytest runs, warming BuildKit's local layer cache. The fixture build then hits that cache and finishes in seconds, well inside the timeout. The work isn't faster overall — the cold build still happens once per job — but it moves out from under pytest's per-test clock, which is what removes the flake.

#### Testing done

Reasoned about the caching path: both the pre-build step and the fixture invoke `docker buildx build --load` on the same daemon, so layers from the first build are available to the second. I could not exercise the GPU runner locally, so the proof is a green `tests-gpu` run on this PR.
